### PR TITLE
Fixed HTML in logout-iframe template

### DIFF
--- a/modules/core/templates/logout-iframe.php
+++ b/modules/core/templates/logout-iframe.php
@@ -207,6 +207,8 @@ if ($type === 'js') {
 ?>
   </div>
   <!-- #content -->
+</div>
+<!-- #wrap -->
 <?php
 if ($type === 'embed') {
 	$this->includeAtTemplateBase('includes/footer-embed.php');
@@ -214,5 +216,3 @@ if ($type === 'embed') {
 	$this->includeAtTemplateBase('includes/footer.php');
 }
 ?>
-</div>
-<!-- #wrap -->


### PR DESCRIPTION
The wrap &lt;/div&gt; was placed after the footer, which placed it after &lt;/body&gt;.
