### PR TITLE
Use an environment variable to set the location of the configuration directory

### DIFF
--- a/bin/memcacheSync.php
+++ b/bin/memcacheSync.php
@@ -23,8 +23,50 @@ $baseDir = dirname(dirname(__FILE__));
 /* Add library autoloader. */
 require_once($baseDir . '/lib/_autoload.php');
 
-/* Initialize the configuration. */
-$configdir = $baseDir . '/config';
+$configdir = '';
+
+$progName = array_shift($argv);
+foreach($argv as $a) {
+	if(strlen($a) === 0) continue;
+
+	if(strpos($a, '=') !== FALSE) {
+		$p = strpos($a, '=');
+		$v = substr($a, $p + 1);
+		$a = substr($a, 0, $p);
+	} else {
+		$v = NULL;
+	}
+
+	switch ($a) {
+		case '--help':
+			echo printHelp();
+			exit(0);
+		case '--configdir':
+			/* If the path is not empty and the file exists, then set the configuration directory. */
+			if (!empty($v) && file_exists($v)) {
+				$configdir = $v;
+			} else {
+				/* Directory does not exist. */
+				echo "Alternate config directory argument: $configdir was not found. Using default config directory location.\n";
+				$configdir = '';
+			}
+			break;
+		default:
+			echo('Unknown option: ' . $a . "\n");
+			echo('Please run `' . $progName . ' --help` for usage information.' . "\n");
+			exit(1);
+	}
+}
+
+if (empty($configdir)) {
+	if (empty(getenv("SIMPLESAMLPHP_CONFIG_DIR"))) {
+		/* Initialize the default configuration. */
+		$configdir = $baseDir . '/config';
+	} else {
+		$configdir = getenv("SIMPLESAMLPHP_CONFIG_DIR");
+	}
+}
+
 SimpleSAML_Configuration::setConfigDir($configdir);
 
 /* Things we should warn the user about. */
@@ -162,4 +204,17 @@ function getServerKeys($server) {
 	return $keys;
 }
 
+/**
+ * Print a help for the command lin options.
+ */
+function printHelp() {
+	return 'Usage: [options]
+
+This program parses and aggregates SimpleSAMLphp log files.
+
+Options:
+	--configdir		Specify the absolute path of the config directory.
+	--help			Prints help text.
+';
+}
 ?>

--- a/docs/simplesamlphp-features.txt
+++ b/docs/simplesamlphp-features.txt
@@ -73,5 +73,7 @@ An example of a usability problem, is when you are editing a wiki, and are about
 
 SimpleSAMLphp has experimental support for dynamically downloading the metadata of an Service Provider or Identity Provider when receiving a new incomming message where the entityId is unknown. Dynamic SAML requires the EntityID to be a URL pointing to the metadata of the entity.
 
+## Configurable config directory location
 
+An environment variable can be used to specify the location of the configuration directory.  Use the environment variable SIMPLESAMLPHP_CONFIG_DIR to specifiy an absolute path to the SimpleSAMLphp configuration directory.  It is possible to now have a single instance of the SimpleSAMLphp library to serve multiple client configuration setups, by using combining Apache Alias and SetEnv directives.
 

--- a/modules/statistics/bin/loganalyzer.php
+++ b/modules/statistics/bin/loganalyzer.php
@@ -8,10 +8,7 @@ $baseDir = dirname(dirname(dirname(dirname(__FILE__))));
 /* Add library autoloader. */
 require_once($baseDir . '/lib/_autoload.php');
 
-/* Initialize the configuration. */
-SimpleSAML_Configuration::setConfigDir($baseDir . '/config');
-
-SimpleSAML_Utilities::initTimezone();
+$configdir = '';
 
 $progName = array_shift($argv);
 $debug = FALSE;
@@ -44,12 +41,36 @@ foreach($argv as $a) {
 		case '--dry-run':
 			$dryrun = TRUE;
 			break;
+		case '--configdir':
+			/* If the path is not empty and the file exists, then set the configuration directory. */
+			if (!empty($v) && file_exists($v)) {
+				$configdir = $v;
+			} else {
+				/* Directory does not exist. */
+				echo "Alternate config directory argument: $configdir was not found. Using default config directory location.\n";
+				$configdir = '';
+			}
+			break;
 		default:
 			echo('Unknown option: ' . $a . "\n");
 			echo('Please run `' . $progName . ' --help` for usage information.' . "\n");
 			exit(1);
 		}
 }
+
+if (empty($configdir)) {
+	if (empty(getenv("SIMPLESAMLPHP_CONFIG_DIR"))) {
+		/* Initialize the default configuration. */
+		$configdir = $baseDir . '/config';
+	} else {
+		$configdir = getenv("SIMPLESAMLPHP_CONFIG_DIR");
+	}
+}
+
+/* Initialize the configuration. */
+SimpleSAML_Configuration::setConfigDir($configdir);
+
+SimpleSAML_Utilities::initTimezone();
 
 $aggregator = new sspmod_statistics_Aggregator(TRUE);
 $aggregator->dumpConfig();
@@ -86,7 +107,7 @@ This program parses and aggregates SimpleSAMLphp log files.
 Options:
 	-d, --debug			Used when configuring the log file syntax. See doc.
 	--dry-run			Aggregate but do not store the results.
+	--configdir			Specify the absolute path of the config directory.
 
 ');
 }
-

--- a/modules/statistics/bin/logcleaner.php
+++ b/modules/statistics/bin/logcleaner.php
@@ -8,10 +8,7 @@ $baseDir = dirname(dirname(dirname(dirname(__FILE__))));
 /* Add library autoloader. */
 require_once($baseDir . '/lib/_autoload.php');
 
-/* Initialize the configuration. */
-SimpleSAML_Configuration::setConfigDir($baseDir . '/config');
-
-
+$configdir = '';
 
 $progName = array_shift($argv);
 $debug = FALSE;
@@ -52,12 +49,34 @@ foreach($argv as $a) {
 		case '--outfile':
 			$output = $v;
 			break;
+		case '--configdir':
+			/* If the path is not empty and the file exists, then set the configuration directory. */
+			if (!empty($v) && file_exists($v)) {
+				$configdir = $v;
+			} else {
+				/* Directory does not exist. */
+				echo 'Alternate config directory argument: '.$configdir.' was not found. Using default config directory location.';
+				$configdir = '';
+			}
+			break;
 		default:
 			echo('Unknown option: ' . $a . "\n");
 			echo('Please run `' . $progName . ' --help` for usage information.' . "\n");
 			exit(1);
 		}
 }
+
+if (empty($configdir)) {
+	if (empty(getenv("SIMPLESAMLPHP_CONFIG_DIR"))) {
+		/* Initialize the default configuration. */
+		$configdir = $baseDir . '/config';
+	} else {
+		$configdir = getenv("SIMPLESAMLPHP_CONFIG_DIR");
+	}
+}
+
+/* Initialize the configuration. */
+SimpleSAML_Configuration::setConfigDir($configdir);
 
 $cleaner = new sspmod_statistics_LogCleaner($infile);
 $cleaner->dumpConfig();
@@ -86,6 +105,8 @@ Options:
 	--dry-run			Aggregate but do not store the results.
 	--infile			File input.
 	--outfile			File to output the results.
+	--configdir			Specify the absolute path of the config directory.
+
 
 ');
 }

--- a/www/_include.php
+++ b/www/_include.php
@@ -96,13 +96,23 @@ class SimpleSAML_IncPrefixWarn {
 /* Set the $SIMPLESAML_INCPREFIX to a reference to the class. */
 $SIMPLESAML_INCPREFIX = new SimpleSAML_IncPrefixWarn();
 
+/* Get environment variable that specifies an alernate location for the configuration files. */
+$configdir = getenv("SIMPLESAMLPHP_CONFIG_DIR");
 
-$configdir = dirname(dirname(__FILE__)) . '/config';
-if (!file_exists($configdir . '/config.php')) {
-	header('Content-Type: text/plain');
-	echo("You have not yet created the simpleSAMLphp configuration files.\n");
-	echo("See: http://rnd.feide.no/content/installing-simplesamlphp#id434777\n");
-	exit(1);
+/* Check if environment variable is set and if the directory exists.
+ * If neither condition is met use the default configuration directory.
+ */
+if (empty($configdir) || !file_exists($configdir)) {
+	$configdir = dirname(dirname(__FILE__)) . '/config';
+	if (!file_exists($configdir . '/config.php')) {
+		header('Content-Type: text/plain');
+		echo("You have not yet created the simpleSAMLphp configuration files.\n");
+		echo("See: http://rnd.feide.no/content/installing-simplesamlphp#id434777\n");
+		exit(1);
+	}
+} else {
+	/* Set the configuration directory to the new location. */
+	SimpleSAML_Configuration::setConfigDir($configdir);
 }
 
 /* Set the timezone. */


### PR DESCRIPTION
Updated code in _include.php to optionally set an alternate configuration directory locaion.  Updated the Memcache Sync, Log clearner and analyzer to accept two optional command line arguments for setting an alternate configuration direcotry location.  The code now will look for the environment variable SIMPLESAMLPHP_CONFIG_DIR for an alternate configuration location.