### PR TITLE
Also check $errno against PHP's error_reporting.

### DIFF
--- a/www/_include.php
+++ b/www/_include.php
@@ -54,7 +54,7 @@ function SimpleSAML_error_handler($errno, $errstr, $errfile = NULL, $errline = 0
 	}
 
 
-	if ($errno & SimpleSAML_Utilities::$logMask) {
+	if ($errno & SimpleSAML_Utilities::$logMask || ! ($errno & error_reporting() )) {
 		/* Masked error. */
 		return FALSE;
 	}


### PR DESCRIPTION
This is necessary to make sure that if a minimum PHP error level
has been set, this is also respected by SSP's error handler. Most
notably, this will make calls prefixed with '@', the PHP warning
silencer, actually silence the warnings. The SSP code tries to
makes use of the @ sign on various places around the code, but
this will only work if it's actually checked here.
