### PR TITLE
Change metadata-converter output to textarea

### DIFF
--- a/templates/metadata-converter.php
+++ b/templates/metadata-converter.php
@@ -32,7 +32,7 @@ if($output !== NULL) {
 		}
 
 		echo('<h3>' . htmlspecialchars($type) . '</h3>' . "\n");
-		echo('<pre class="metadatabox">' . htmlspecialchars($text) . '</pre>' . "\n");
+		echo('<textarea class="metadatabox">' . htmlspecialchars($text) . '</textarea>' . "\n");
 	}
 }
 

--- a/www/resources/default.css
+++ b/www/resources/default.css
@@ -275,6 +275,8 @@ th.rowtitle {
 	overflow: scroll; 
 	border: 1px solid #eee; 
 	padding: 2px;
+	width: 100%;
+	height: 450px;
 }
 div.preferredidp {
 	border: 1px dashed #ccc;


### PR DESCRIPTION
I found it much more pleasing to work with the metadata-converter when the output is put into a textarea instead of a pre. 

It might not be a tool you use every day (especially not if you have setup the metarefresh module), but it really helps newcomers such as me.