### PR TITLE
Fix handleLogout ignoring wreply override

### DIFF
--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -175,6 +175,13 @@ class sspmod_adfs_IdP_ADFS {
 	}
 	
 	public static function receiveLogoutMessage(SimpleSAML_IdP $idp) {
+		// if a redirect is to occur based on wreply, we will redirect to url as
+		// this implies an override to normal sp notification.
+		if(isset($_GET['wreply']) && !empty($_GET['wreply'])) {
+			$idp->doLogoutRedirect(SimpleSAML_Utilities::checkURLAllowed($_GET['wreply']));
+			assert(FALSE);
+		}
+
 		$state = array(
 			'Responder' => array('sspmod_adfs_IdP_ADFS', 'sendLogoutResponse'),
 		);


### PR DESCRIPTION
This is the fix for https://groups.google.com/forum/#!topic/simplesamlphp/Ga8dbqNc92M
Per http://msdn.microsoft.com/en-us/library/bb608217.aspx
wreply is in fact supposed to replace the normal behavior, and is optional.
Tested to work correctly in our Dev, GoDaddy QA  will be verifying it as well, but I see no issue.
