### PR TITLE
Add LDAP privileged read functionality for releasing private attributes to authX509 module

### DIFF
--- a/modules/authX509/docs/authX509.txt
+++ b/modules/authX509/docs/authX509.txt
@@ -54,6 +54,12 @@ example authsources.php entry:
         'search.base' => 'dc=example,dc=net',
         'authX509:x509attributes' => array('UID' => 'uid'),
         'authX509:ldapusercert' => array('userCertificate;binary'),
+        'privread' => FALSE,
+        'privldap' => 'ldap.example.net',
+        'privenableTLS' => TRUE,
+        'privusername' => NULL,
+        'privpassword' => NULL,
+
     ),
 
 The configuration is the same as for the LDAP module, except for


### PR DESCRIPTION
I tried releasing private attributes from LDAP with X509 authentication but I realised that I could only make anonymous LDAP queries so I made some changes. This adds the option to use extra credentials for privileged read.
