### PR TITLE
An attempt to slightly improve the NameFormat selection for attributes released by the IdP

### DIFF
--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -727,6 +727,16 @@ class sspmod_saml_IdP_SAML2 {
 	private static function getAttributeNameFormat(SimpleSAML_Configuration $idpMetadata,
 		SimpleSAML_Configuration $spMetadata) {
 
+		/* First check if NameFormat configured for IdP matches NameFormats declared
+		   in SP metadata ACS RequestedAttribute(s) */
+		$spAttributeNameFormat = $spMetadata->getArray('attributes.NameFormats', NULL);
+		$idpAttributeNameFormat = $idpMetadata->getString('attributes.NameFormat', NULL);
+		if ($idpAttributeNameFormat !== NULL &&
+		    is_array($spAttributeNameFormat) &&
+		    in_array($idpAttributeNameFormat, $spAttributeNameFormat)) {
+			return $idpAttributeNameFormat;
+		}
+
 		/* Try SP metadata first. */
 		$attributeNameFormat = $spMetadata->getString('attributes.NameFormat', NULL);
 		if ($attributeNameFormat !== NULL) {


### PR DESCRIPTION
Imperfect yet non-intrusive.

The status quo ante:
- XML->native metadata (via e.g. metarefresh) takes a very conservative
  approach for picking the NameFormat from the RequestedAttribute(s) in
  (the first ACS found in) SP metadata: it aborts if both Shib-style and
  SAML2-URI NameFormat(s) are found.
- NameFormat selection for the attributes to be asserted by the IdP
  blindly prefers the NameFormat detected in SP metadata, even when the
  IdP has been explicitly configured to prefer a specific NameFormat
  (which is thus almost never used).

This patch:
- Takes a more careful (and perhaps realistic) approach at detecting the
  SP-derived NameFormat and also stores (in attributes.NameFormats) all
  NameFormats found in the (the first) ACS RequestedAttribute elements.
- Checks if the IdP-configured NameFormat matches any of the NameFormats
  detected in SP metadata (attributes.NameFormats). This comes before
  any other tests in the NameFormat selection for the IdP assertion.
