### PR TITLE
Treat objectguid as a binary LDAP attribute

### DIFF
--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -541,7 +541,7 @@ class SimpleSAML_Auth_LDAP {
 					continue;
 				}
 
-				// Base64 encode jpegPhoto.
+				// Base64 encode binary attributes.
 				if (strtolower($name) === 'jpegphoto' || strtolower($name) === 'objectguid') {
 					$values[] = base64_encode($value);
 				} else


### PR DESCRIPTION
Hi!

When integrating Office365, their sync tools use the LDAP objectGUID attribute (a binary attribute) as the SAML NameID by default.

This pull request includes a commit to base64 the attribute so that the NameID is returned correctly in the SAML response.
