### PR TITLE
Update links to SSP homepage to point to simplesamlphp.org.

### DIFF
--- a/docs/README
+++ b/docs/README
@@ -2,13 +2,13 @@ Updated: December 19th, 2007
 
 
 All you need to know to install and configure simpleSAMLphp is available at:
-http://simplesamlphp.org/docs/
+https://simplesamlphp.org/docs/
 
 simpleSAMLphp homepage:
-http://rnd.feide.no/simplesamlphp
+https://simplesamlphp.org/
 
 simpleSAMLphp mailinglist (for support):
-http://rnd.feide.no/content/simplesamlphp-users-mailinglist
+https://simplesamlphp.org/lists
 
 
 To contact the author team:

--- a/docs/simplesamlphp-advancedfeatures.txt
+++ b/docs/simplesamlphp-advancedfeatures.txt
@@ -231,7 +231,7 @@ you are welcome to join! The forums are open for you to ask
 questions, contribute answers other further questions, request
 improvements or contribute with code or plugins of your own.
 
--  [simpleSAMLphp homepage (at Feide RnD)](http://rnd.feide.no/simplesamlphp)
+-  [simpleSAMLphp homepage](https://simplesamlphp.org)
 -  [List of all available simpleSAMLphp documentation](http://simplesamlphp.org/docs/)
 -  [Join the simpleSAMLphp user's mailing list](http://rnd.feide.no/content/simplesamlphp-users-mailinglist)
 -  [Visit and contribute to the simpleSAMLphp wiki](https://ow.feide.no/simplesamlphp:start)

--- a/docs/simplesamlphp-googleapps.txt
+++ b/docs/simplesamlphp-googleapps.txt
@@ -19,7 +19,7 @@ This document is part of the simpleSAMLphp documentation suite.
 
  * [List of all simpleSAMLphp documentation](http://simplesamlphp.org/docs)
  * [Latest news about simpleSAMLphp](http://rnd.feide.no/taxonomy/term/4). (Also conatins an RSS feed)
- * [simpleSAMLphp homepage](http://rnd.feide.no/simplesamlphp)
+ * [simpleSAMLphp homepage](https://simplesamlphp.org)
 
 
 ## Introduction
@@ -242,7 +242,7 @@ Support
 
 If you need help to make this work, or want to discuss simpleSAMLphp with other users of the software, you are fortunate: Around simpleSAMLphp there is a great Open source community, and you are welcome to join! The forums are open for you to ask questions, contribute answers other further questions, request improvements or contribute with code or plugins of your own.
 
--  [simpleSAMLphp homepage (at Feide RnD)](http://rnd.feide.no/simplesamlphp)
+-  [simpleSAMLphp homepage](https://simplesamlphp.org)
 -  [List of all available simpleSAMLphp documentation](http://simplesamlphp.org/docs/)
 -  [Join the simpleSAMLphp user's mailing list](http://rnd.feide.no/content/simplesamlphp-users-mailinglist)
 -  [Visit and contribute to the simpleSAMLphp wiki](https://ow.feide.no/simplesamlphp:start)

--- a/docs/simplesamlphp-idp.txt
+++ b/docs/simplesamlphp-idp.txt
@@ -230,7 +230,7 @@ Support
 
 If you need help to make this work, or want to discuss simpleSAMLphp with other users of the software, you are fortunate: Around simpleSAMLphp there is a great Open source community, and you are welcome to join! The forums are open for you to ask questions, contribute answers other further questions, request improvements or contribute with code or plugins of your own.
 
-- [simpleSAMLphp homepage (at Feide RnD)](http://rnd.feide.no/simplesamlphp)
+- [simpleSAMLphp homepage](https://simplesamlphp.org)
 - [List of all available simpleSAMLphp documentation](http://simplesamlphp.org/docs/)
 - [Join the simpleSAMLphp user's mailing list](http://rnd.feide.no/content/simplesamlphp-users-mailinglist)
 - [Visit and contribute to the simpleSAMLphp wiki](https://ow.feide.no/simplesamlphp:start)

--- a/docs/simplesamlphp-install.txt
+++ b/docs/simplesamlphp-install.txt
@@ -19,7 +19,7 @@ This document is part of the simpleSAMLphp documentation suite.
 
  * [List of all simpleSAMLphp documentation](http://simplesamlphp.org/docs)
  * [Latest news about simpleSAMLphp](http://rnd.feide.no/taxonomy/term/4). (Also conatins an RSS feed)
- * [simpleSAMLphp homepage](http://rnd.feide.no/simplesamlphp)
+ * [simpleSAMLphp homepage](https://simplesamlphp.org)
 
 
 Development version
@@ -232,7 +232,7 @@ Support
 
 If you need help to make this work, or want to discuss simpleSAMLphp with other users of the software, you are fortunate: Around simpleSAMLphp there is a great Open source community, and you are welcome to join! The forums are open for you to ask questions, contribute answers other further questions, request improvements or contribute with code or plugins of your own.
 
--  [simpleSAMLphp homepage (at Feide RnD)](http://rnd.feide.no/simplesamlphp)
+-  [simpleSAMLphp homepage](https://simplesamlphp.org)
 -  [List of all available simpleSAMLphp documentation](http://simplesamlphp.org/docs/)
 -  [Join the simpleSAMLphp user's mailing list](http://rnd.feide.no/content/simplesamlphp-users-mailinglist)
 -  [Visit and contribute to the simpleSAMLphp wiki](https://ow.feide.no/simplesamlphp:start)

--- a/docs/simplesamlphp-maintenance.txt
+++ b/docs/simplesamlphp-maintenance.txt
@@ -18,7 +18,7 @@ This document is part of the simpleSAMLphp documentation suite.
 
  * [List of all simpleSAMLphp documentation](http://simplesamlphp.org/docs)
  * [Latest news about simpleSAMLphp](http://rnd.feide.no/taxonomy/term/4). (Also conatins an RSS feed)
- * [simpleSAMLphp homepage](http://rnd.feide.no/simplesamlphp)
+ * [simpleSAMLphp homepage](https://simplesamlphp.org)
 
 
 
@@ -205,7 +205,7 @@ Support
 
 If you need help to make this work, or want to discuss simpleSAMLphp with other users of the software, you are fortunate: Around simpleSAMLphp there is a great Open source community, and you are welcome to join! The forums are open for you to ask questions, contribute answers other further questions, request improvements or contribute with code or plugins of your own.
 
--  [simpleSAMLphp homepage (at Feide RnD)](http://rnd.feide.no/simplesamlphp)
+-  [simpleSAMLphp homepage (at Feide RnD)](https://simplesamlphp.org)
 -  [List of all available simpleSAMLphp documentation](http://simplesamlphp.org/docs/)
 -  [Join the simpleSAMLphp user's mailing list](http://rnd.feide.no/content/simplesamlphp-users-mailinglist)
 -  [Visit and contribute to the simpleSAMLphp wiki](https://ow.feide.no/simplesamlphp:start)

--- a/docs/simplesamlphp-scoping.txt
+++ b/docs/simplesamlphp-scoping.txt
@@ -97,7 +97,7 @@ Support
 
 If you need help to make this work, or want to discuss simpleSAMLphp with other users of the software, you are fortunate: Around simpleSAMLphp there is a great Open source community, and you are welcome to join! The forums are open for you to ask questions, contribute answers other further questions, request improvements or contribute with code or plugins of your own.
 
-- [simpleSAMLphp homepage (at Feide RnD)](http://rnd.feide.no/simplesamlphp)
+- [simpleSAMLphp homepage](https://simplesamlphp.org)
 - [List of all available simpleSAMLphp documentation](http://simplesamlphp.org/docs/)
 - [Join the simpleSAMLphp user's mailing list](http://rnd.feide.no/content/simplesamlphp-users-mailinglist)
 - [Visit and contribute to the simpleSAMLphp wiki](https://ow.feide.no/simplesamlphp:start)

--- a/docs/simplesamlphp-sp.txt
+++ b/docs/simplesamlphp-sp.txt
@@ -205,7 +205,7 @@ Support
 
 If you need help to make this work, or want to discuss simpleSAMLphp with other users of the software, you are fortunate: Around simpleSAMLphp there is a great Open source community, and you are welcome to join! The forums are open for you to ask questions, contribute answers other further questions, request improvements or contribute with code or plugins of your own.
 
--  [simpleSAMLphp homepage (at Feide RnD)](http://rnd.feide.no/simplesamlphp)
+-  [simpleSAMLphp homepage](https://simplesamlphp.org)
 -  [List of all available simpleSAMLphp documentation](http://simplesamlphp.org/docs/)
 -  [Join the simpleSAMLphp user's mailing list](http://rnd.feide.no/content/simplesamlphp-users-mailinglist)
 -  [Visit and contribute to the simpleSAMLphp wiki](https://ow.feide.no/simplesamlphp:start)

--- a/metadata-templates/saml20-idp-hosted.php
+++ b/metadata-templates/saml20-idp-hosted.php
@@ -2,7 +2,7 @@
 /**
  * SAML 2.0 IdP configuration for simpleSAMLphp.
  *
- * See: https://rnd.feide.no/content/idp-hosted-metadata-reference
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
  */
 
 $metadata['__DYNAMIC:1__'] = array(

--- a/metadata-templates/saml20-idp-remote.php
+++ b/metadata-templates/saml20-idp-remote.php
@@ -4,7 +4,7 @@
  *
  * Remember to remove the IdPs you don't use from this file.
  *
- * See: https://rnd.feide.no/content/idp-remote-metadata-reference
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-remote 
  */
 
 /*

--- a/metadata-templates/saml20-sp-remote.php
+++ b/metadata-templates/saml20-sp-remote.php
@@ -2,7 +2,7 @@
 /**
  * SAML 2.0 remote SP metadata for simpleSAMLphp.
  *
- * See: http://simplesamlphp.org/docs/trunk/simplesamlphp-reference-sp-remote
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-sp-remote
  */
 
 /*

--- a/metadata-templates/shib13-idp-hosted.php
+++ b/metadata-templates/shib13-idp-hosted.php
@@ -2,7 +2,7 @@
 /**
  * SAML 1.1 IdP configuration for simpleSAMLphp.
  *
- * See: https://rnd.feide.no/content/idp-hosted-metadata-reference
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
  */
 
 $metadata['__DYNAMIC:1__'] = array(

--- a/metadata-templates/shib13-idp-remote.php
+++ b/metadata-templates/shib13-idp-remote.php
@@ -4,7 +4,7 @@
  *
  * Remember to remove the IdPs you don't use from this file.
  *
- * See: https://rnd.feide.no/content/idp-remote-metadata-reference
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-remote
  */
 
 /*

--- a/metadata-templates/shib13-sp-hosted.php
+++ b/metadata-templates/shib13-sp-hosted.php
@@ -2,7 +2,7 @@
 /**
  * SAML 1.1 SP configuration for simpleSAMLphp.
  *
- * See: https://rnd.feide.no/content/sp-hosted-metadata-reference
+ * See: https://simplesamlphp.org/docs/stable/saml:sp
  */
 
 /*

--- a/metadata-templates/shib13-sp-remote.php
+++ b/metadata-templates/shib13-sp-remote.php
@@ -2,7 +2,7 @@
 /**
  * SAML 1.1 remote SP metadata for simpleSAMLphp.
  *
- * See: https://rnd.feide.no/content/sp-remote-metadata-reference
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-sp-remote
  */
 
 /*

--- a/modules/core/www/frontpage_welcome.php
+++ b/modules/core/www/frontpage_welcome.php
@@ -33,7 +33,7 @@ $allLinks = array(
 );
 
 $links_welcome[] = array(
-	'href' => 'https://rnd.feide.no/view/simplesamlphpdocs',
+	'href' => 'https://simplesamlphp.org/docs/stable/',
 	'text' => '{core:frontpage:doc_header}',
 );
 

--- a/www/errorreport.php
+++ b/www/errorreport.php
@@ -73,7 +73,7 @@ $message = '<h1>SimpleSAMLphp Error Report</h1>
 <p>Referer: <tt>' . htmlspecialchars($data['referer']) . '</tt></p>
 
 <hr />
-<div class="footer">This message was sent using simpleSAMLphp. Visit <a href="http://rnd.feide.no/simplesamlphp">simpleSAMLphp homepage</a>.</div>
+<div class="footer">This message was sent using simpleSAMLphp. Visit the <a href="http://simplesamlphp.org/">simpleSAMLphp homepage</a>.</div>
 
 ';
 


### PR DESCRIPTION
This is more than just cosmetics, as the rnd.feide.no links redirect
people to the SSP 1.5 documentation which is rather outdated.
