### PR TITLE
Fix call-time pass-by-reference

### DIFF
--- a/modules/openidProvider/lib/Server.php
+++ b/modules/openidProvider/lib/Server.php
@@ -445,7 +445,7 @@ class sspmod_openidProvider_Server {
             'isPassive'=>TRUE
     	);
 
-    	$pc->processStatePassive(&$state);
+    	$pc->processStatePassive($state);
     	$attributes = $state['Attributes'];
 
     	//Process SREG requests


### PR DESCRIPTION
To support PHP >= 5.4, call-time pass-by-reference must be avoided.
See http://fr2.php.net/manual/en/language.references.pass.php
