### PR TITLE
Feature/saml idp total login time

### DIFF
--- a/modules/saml/lib/IdP/SAML1.php
+++ b/modules/saml/lib/IdP/SAML1.php
@@ -41,6 +41,9 @@ class sspmod_saml_IdP_SAML1 {
 			'idpEntityID' => $idpMetadata->getString('entityid'),
 			'protocol' => 'saml1',
 		);
+		if (isset($state['saml:AuthnRequestReceivedAt'])) {
+			$statsData['logintime'] = microtime(TRUE) - $state['saml:AuthnRequestReceivedAt'];
+		}
 		SimpleSAML_Stats::log('saml:idp:Response', $statsData);
 
 		/* Generate and send response. */
@@ -122,6 +125,7 @@ class sspmod_saml_IdP_SAML1 {
 
 			'saml:shire' => $shire,
 			'saml:target' => $target,
+			'saml:AuthnRequestReceivedAt' => microtime(TRUE),
 		);
 
 		$idp->handleAuthenticationRequest($state);

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -68,6 +68,9 @@ class sspmod_saml_IdP_SAML2 {
 			'idpEntityID' => $idpMetadata->getString('entityid'),
 			'protocol' => 'saml2',
 		);
+		if (isset($state['saml:AuthnRequestReceivedAt'])) {
+			$statsData['logintime'] = microtime(TRUE) - $state['saml:AuthnRequestReceivedAt'];
+		}
 		SimpleSAML_Stats::log('saml:idp:Response', $statsData);
 
 		/* Send the response. */
@@ -124,6 +127,9 @@ class sspmod_saml_IdP_SAML2 {
 			'protocol' => 'saml2',
 			'error' => $status,
 		);
+		if (isset($state['saml:AuthnRequestReceivedAt'])) {
+			$statsData['logintime'] = microtime(TRUE) - $state['saml:AuthnRequestReceivedAt'];
+		}
 		SimpleSAML_Stats::log('saml:idp:Response:error', $statsData);
 
 		$binding = SAML2_Binding::getBinding($protocolBinding);
@@ -377,6 +383,7 @@ class sspmod_saml_IdP_SAML2 {
 			'saml:NameIDFormat' => $nameIDFormat,
 			'saml:AllowCreate' => $allowCreate,
 			'saml:Extensions' => $extensions,
+			'saml:AuthnRequestReceivedAt' => microtime(TRUE),
 		);
 
 		$idp->handleAuthenticationRequest($state);


### PR DESCRIPTION
These patches add the total login time to the statistics data logged from the IdP after authentication.

This is useful for checking how much time users actually use on the login process, and also to detect errors that cause the login process to misbehave.
