### PR TITLE
Check that IdP names contain content before attempting translation.

### DIFF
--- a/templates/selectidp-dropdown.php
+++ b/templates/selectidp-dropdown.php
@@ -10,18 +10,18 @@ $this->data['autofocus'] = 'dropdownlist';
 $this->includeAtTemplateBase('includes/header.php');
 
 foreach ($this->data['idplist'] AS $idpentry) {
-	if (isset($idpentry['UIInfo']['DisplayName'])) {
+	if (!empty($idpentry['UIInfo']['DisplayName'])) {
 		/* TODO: remove this branch, If ['UIInfo']['DisplayName'] is available, it will get through to 'name' in the
 		 * metadata parsed with SSP >= 1.13.0, so this code is no longer necessary. Keep it now to avoid breaking
 		 * metadata parsed with previous versions.
 		 */
 		$this->includeInlineTranslation('idpname_' . $idpentry['entityid'], $idpentry['UIInfo']['DisplayName']);
-	} elseif (isset($idpentry['name'])) {
+	} elseif (!empty($idpentry['name'])) {
 		$this->includeInlineTranslation('idpname_' . $idpentry['entityid'], $idpentry['name']);
-	} elseif (isset($idpentry['OrganizationDisplayName'])) {
+	} elseif (!empty($idpentry['OrganizationDisplayName'])) {
 		$this->includeInlineTranslation('idpname_' . $idpentry['entityid'], $idpentry['OrganizationDisplayName']);
 	}
-	if (isset($idpentry['description']))
+	if (!empty($idpentry['description']))
 		$this->includeInlineTranslation('idpdesc_' . $idpentry['entityid'], $idpentry['description']);
 }
 


### PR DESCRIPTION
When you have a saml20-idp-remote metadata entry which has an empty array in it for any of the different display names, getTranslation will throw an unhandled exception which even ends up in the drop down list:

```
SimpleSAML_Error_Error: UNHANDLEDEXCEPTION
Backtrace:
0 /srv/simplesamlphp/www/module.php:179 (N/A)
Caused by: Exception: Nothing to return from translation.
Backtrace:
6 /srv/simplesamlphp/lib/SimpleSAML/XHTML/Template.php:328 (SimpleSAML_XHTML_Template::getTranslation)
5 /srv/simplesamlphp/lib/SimpleSAML/XHTML/Template.php:414 (SimpleSAML_XHTML_Template::t)
4 /srv/simplesamlphp/templates/selectidp-dropdown.php:49 (require)
3 /srv/simplesamlphp/lib/SimpleSAML/XHTML/Template.php:581 (SimpleSAML_XHTML_Template::show)
2 /srv/simplesamlphp/lib/SimpleSAML/XHTML/IdPDisco.php:528 (SimpleSAML_XHTML_IdPDisco::handleRequest)
1 /srv/simplesamlphp/modules/saml/www/disco.php:8 (require)
0 /srv/simplesamlphp/www/module.php:134 (N/A)
```

It's easy to reproduce by adding
`name => array( ),`
to any entry in saml20-idp-remote.php and test your authsource. simpleSAMLphp's metadata converter will actually generate configs that contain such empty arrays, that's how I found out.
