### PR TITLE
Use the RelayState defined in the SP metadata if the IdP does not include in the auth response.

### DIFF
--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -79,10 +79,17 @@ if (!empty($stateId)) {
 	}
 } else {
 	/* This is an unsolicited response. */
+	
+	$relayState = $response->getRelayState();
+	
+	if(empty($relayState)){
+		$relayState = $spMetadata->getValue("RelayState");
+	}
+		
 	$state = array(
 		'saml:sp:isUnsolicited' => TRUE,
 		'saml:sp:AuthId' => $sourceId,
-		'saml:sp:RelayState' => SimpleSAML_Utilities::checkURLAllowed($response->getRelayState()),
+		'saml:sp:RelayState' => SimpleSAML_Utilities::checkURLAllowed($relayState),
 	);
 }
 


### PR DESCRIPTION
This is related to Issue #99 where the RelayState that is defined in the SP metadata is not used when the IdP fails to include it in the authentication response.  The code fix contained in this pull request updates the code to use it.
