### PR TITLE
Enhance the metadata import to preserve the "required" flag of requested attributes

### DIFF
--- a/lib/SimpleSAML/Auth/Simple.php
+++ b/lib/SimpleSAML/Auth/Simple.php
@@ -248,7 +248,7 @@ class SimpleSAML_Auth_Simple {
 	/**
 	 * Retrieve authentication data.
 	 *
-	 * @param string $name  The name of the parameter, e.g. 'Attribute', 'Expire' or 'saml:sp:IdP'.
+	 * @param string $name  The name of the parameter, e.g. 'Attributes', 'Expire' or 'saml:sp:IdP'.
 	 * @return mixed|NULL  The value of the parameter, or NULL if it isn't found or we are unauthenticated.
 	 */
 	public function getAuthData($name) {

--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -605,6 +605,9 @@ class SimpleSAML_Metadata_SAMLParser {
 		if (array_key_exists('attributes', $spd)) {
 			$ret['attributes'] = $spd['attributes'];
 		}
+		if (array_key_exists('attributes.required', $spd)) {
+			$ret['attributes.required'] = $spd['attributes.required'];
+		}
 		if (array_key_exists('attributes.NameFormat', $spd)) {
 			$ret['attributes.NameFormat'] = $spd['attributes.NameFormat'];
 		}
@@ -1073,9 +1076,14 @@ class SimpleSAML_Metadata_SAMLParser {
 
 		$format = NULL;
 		$sp['attributes'] = array();
+		$sp['attributes.required'] = array();
 		foreach ($element->RequestedAttribute AS $child) {
 			$attrname = $child->Name;
 			$sp['attributes'][] = $attrname;
+			
+			if ($child->isRequired) {
+				$sp['attributes.required'][] = $attrname;
+			}
 
 			if ($child->NameFormat !== NULL) {
 				$attrformat = $child->NameFormat;
@@ -1096,6 +1104,9 @@ class SimpleSAML_Metadata_SAMLParser {
 			 * should have one or more attributes.
 			 */
 			unset($sp['attributes']);
+		}
+		if (empty($sp['attributes.required'])) {
+			unset($sp['attributes.required']);
 		}
 
 		if ($format !== SAML2_Const::NAMEFORMAT_UNSPECIFIED && $format !== NULL) {

--- a/modules/aselect/www/credentials.php
+++ b/modules/aselect/www/credentials.php
@@ -49,8 +49,7 @@ try {
     if (array_key_exists('attributes', $creds)) {
         $state['Attributes'] = $creds['attributes'];
     } else {
-        $res = $creds['res'];
-        $state['Attributes'] = array('uid' => array($res['uid']), 'organization' => array($res['organization']));
+        $state['Attributes'] = array('uid' => array($creds['uid']), 'organization' => array($creds['organization']));
     }
 } catch (Exception $e) {
     SimpleSAML_Auth_State::throwException($state, $e);

--- a/modules/aselect/www/credentials.php
+++ b/modules/aselect/www/credentials.php
@@ -6,48 +6,55 @@
  *
  * @author Wessel Dankers, Tilburg University
  */
-	if (!array_key_exists('ssp_state', $_REQUEST))
-		throw new SimpleSAML_Error_Exception("Missing ssp_state parameter");
-	$id = $_REQUEST['ssp_state'];
+if (!array_key_exists('ssp_state', $_REQUEST)) {
+    throw new SimpleSAML_Error_Exception("Missing ssp_state parameter");
+}
+$id = $_REQUEST['ssp_state'];
 
-	// sanitize the input
-	$sid = SimpleSAML_Utilities::parseStateID($id);
-	if (!is_null($sid['url'])) {
-		SimpleSAML_Utilities::checkURLAllowed($sid['url']);
-	}
+// sanitize the input
+$sid = SimpleSAML_Utilities::parseStateID($id);
+if (!is_null($sid['url'])) {
+    SimpleSAML_Utilities::checkURLAllowed($sid['url']);
+}
 
-	$state = SimpleSAML_Auth_State::loadState($id, 'aselect:login');
+$state = SimpleSAML_Auth_State::loadState($id, 'aselect:login');
 
-	if(!array_key_exists('a-select-server', $_REQUEST))
-		SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_Exception("Missing a-select-server parameter"));
-	$server_id = $_REQUEST['a-select-server'];
+if (!array_key_exists('a-select-server', $_REQUEST)) {
+    SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_Exception("Missing a-select-server parameter"));
+}
+$server_id = $_REQUEST['a-select-server'];
 
-	if(!array_key_exists('aselect_credentials', $_REQUEST))
-		SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_Exception("Missing aselect_credentials parameter"));
-	$credentials = $_REQUEST['aselect_credentials'];
+if (!array_key_exists('aselect_credentials', $_REQUEST)) {
+    SimpleSAML_Auth_State::throwException($state,
+                                          new SimpleSAML_Error_Exception("Missing aselect_credentials parameter"));
+}
+$credentials = $_REQUEST['aselect_credentials'];
 
-	if(!array_key_exists('rid', $_REQUEST))
-		SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_Exception("Missing rid parameter"));
-	$rid = $_REQUEST['rid'];
+if (!array_key_exists('rid', $_REQUEST)) {
+    SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_Exception("Missing rid parameter"));
+}
+$rid = $_REQUEST['rid'];
 
-	try {
-		if(!array_key_exists('aselect::authid', $state))
-			throw new SimpleSAML_Error_Exception("ASelect authentication source missing in state");
-		$authid = $state['aselect::authid'];
-		$aselect = SimpleSAML_Auth_Source::getById($authid);
-		if(is_null($aselect))
-			throw new SimpleSAML_Error_Exception("Could not find authentication source with id $authid");
-		$creds = $aselect->verify_credentials($server_id, $credentials, $rid);
+try {
+    if (!array_key_exists('aselect::authid', $state)) {
+        throw new SimpleSAML_Error_Exception("ASelect authentication source missing in state");
+    }
+    $authid = $state['aselect::authid'];
+    $aselect = SimpleSAML_Auth_Source::getById($authid);
+    if (is_null($aselect)) {
+        throw new SimpleSAML_Error_Exception("Could not find authentication source with id $authid");
+    }
+    $creds = $aselect->verify_credentials($server_id, $credentials, $rid);
 
-		if(array_key_exists('attributes', $creds)) {
-			$state['Attributes'] = $creds['attributes'];
-		} else {
-			$res = $creds['res'];
-			$state['Attributes'] = array('uid' => array($res['uid']), 'organization' => array($res['organization']));
-		}
-	} catch(Exception $e) {
-		SimpleSAML_Auth_State::throwException($state, $e);
-	}
+    if (array_key_exists('attributes', $creds)) {
+        $state['Attributes'] = $creds['attributes'];
+    } else {
+        $res = $creds['res'];
+        $state['Attributes'] = array('uid' => array($res['uid']), 'organization' => array($res['organization']));
+    }
+} catch (Exception $e) {
+    SimpleSAML_Auth_State::throwException($state, $e);
+}
 
-	SimpleSAML_Auth_Source::completeAuth($state);
-	SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_Exception("Internal error in A-Select component"));
+SimpleSAML_Auth_Source::completeAuth($state);
+SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_Exception("Internal error in A-Select component"));


### PR DESCRIPTION
To allow for more focused attribute release it would be useful if the metadata import would preserve which of the requested attributes are required. This patch collects the required attributes into an “attributes.required” element.