### PR TITLE
Add support for signature.privatekey for saml-sp-remote

### DIFF
--- a/docs/simplesamlphp-reference-sp-remote.txt
+++ b/docs/simplesamlphp-reference-sp-remote.txt
@@ -249,6 +249,14 @@ The following SAML 2.0 options are available:
     * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha384`
     * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha512`
 
+`signature.privatekey`
+:   Name of private key file for this IdP, in PEM format. The filename is relative to the cert/-directory.
+:   Note that this option also exists in the IdP-hosted metadata. This entry in the SP-remote metadata overrides the option `privatekey` in the IdP-hosted metadata.
+
+`signature.privatekey_pass`
+:   Passphrase for the private key. Leave this option out if the private key is unencrypted.
+:   Note that this option only is used if `signature.privatekey` is present.
+
 `simplesaml.nameidattribute`
 :   When the value of the `NameIDFormat`-option is set to either
     `email` or `persistent`, this is the name of the attribute which

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -18,8 +18,16 @@ class sspmod_saml_Message {
 	 */
 	public static function addSign(SimpleSAML_Configuration $srcMetadata, SimpleSAML_Configuration $dstMetadata, SAML2_SignedElement $element) {
 
-		$keyArray = SimpleSAML_Utilities::loadPrivateKey($srcMetadata, TRUE);
-		$certArray = SimpleSAML_Utilities::loadPublicKey($srcMetadata, FALSE);
+		$dstPrivateKey = $dstMetadata->getString('signature.privatekey', NULL);
+
+		if($dstPrivateKey !== NULL) {
+			$keyArray = SimpleSAML_Utilities::loadPrivateKey($dstMetadata, TRUE, 'signature.');
+			$certArray = SimpleSAML_Utilities::loadPublicKey($dstMetadata, FALSE, 'signature.');
+		}
+		else {
+			$keyArray = SimpleSAML_Utilities::loadPrivateKey($srcMetadata, TRUE);
+			$certArray = SimpleSAML_Utilities::loadPublicKey($srcMetadata, FALSE);
+		}
 
 		$algo = $dstMetadata->getString('signature.algorithm', NULL);
 		if ($algo === NULL) {


### PR DESCRIPTION
Related to conversation at https://groups.google.com/forum/#!topic/simplesamlphp-dev/AyhDq1kzGD8
Regarding SAML2 IdP key rollover should allow transition per SP

This patch allows a signing key to be specified within saml2-sp-remote allowing one to pursue a signing certificate transition on the IdP, even if one or more of your partners is unable or unwilling to transition.

This is especially useful for large scale IdP's with multiple partners who may either charge development time, support, or contract costs for simple changes.
