### PR TITLE
Bug fix to include the subject nameid in the data returned from a SAML 1.0 SSO authentication.

### DIFF
--- a/lib/SimpleSAML/Auth/Default.php
+++ b/lib/SimpleSAML/Auth/Default.php
@@ -98,7 +98,7 @@ class SimpleSAML_Auth_Default {
 		}
 
 		/* Add those that should always be included. */
-		foreach (array('Attributes', 'Expire', 'LogoutState', 'AuthnInstant', 'RememberMe') as $a) {
+		foreach (array('Attributes', 'Expire', 'LogoutState', 'AuthnInstant', 'RememberMe', 'saml:sp:NameID') as $a) {
 			if (isset($state[$a])) {
 				$persistentAuthState[$a] = $state[$a];
 			}

--- a/modules/saml/www/sp/saml1-acs.php
+++ b/modules/saml/www/sp/saml1-acs.php
@@ -85,6 +85,8 @@ $logoutState = array(
 	);
 $state['LogoutState'] = $logoutState;
 
+$state['saml:sp:NameID'] = $response->getNameID();
+
 $source->handleResponse($state, $responseIssuer, $attributes);
 assert('FALSE');
 


### PR DESCRIPTION
Fixed a bug where the subject nameid was not being returned back to the SP after successful authentication.