### PR TITLE
Fix Certificate check for SubjectConfirmations with Holder Of Key methods

### DIFF
--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -614,12 +614,9 @@ class sspmod_saml_Message {
 				/* Extract certificate data (if this is a certificate). */
 				$clientCert = $_SERVER['SSL_CLIENT_CERT'];
 				$pattern = '/^-----BEGIN CERTIFICATE-----([^-]*)^-----END CERTIFICATE-----/m';
-				$matchResult = preg_match($pattern, $clientCert, $matches);
-				if ($matchResult === 0) {
-				    $lastError = 'No valid client certificate provided during TLS Handshake with SP';
-				    continue;
-				} elseif ($matchResult === FALSE) {
-				    $lastError = 'Could not validate client certificate provided during TLS handshake with SP';
+				if (!preg_match($pattern, $clientCert, $matches)) {
+				    $lastError = 'Error while looking for client certificate during TLS handshake with SP, the client certificate does not '
+				                 . 'have the expected structure';
 				    continue;
 				}
 				/* We have a valid client certificate from the browser. */


### PR DESCRIPTION
Both the pattern and the if-check were not correct, which means that the certificate would not be marked as invalid if it did not have the correct format. This rectifies that situation.
