### PR TITLE
Sort IdP's in alphabetical order in dropdown.

### DIFF
--- a/templates/selectidp-dropdown.php
+++ b/templates/selectidp-dropdown.php
@@ -38,6 +38,12 @@ foreach ($this->data['idplist'] AS $idpentry) {
 		<input type="hidden" name="returnIDParam" value="<?php echo htmlspecialchars($this->data['returnIDParam']); ?>" />
 		<select id="dropdownlist" name="idpentityid">
 		<?php
+
+		usort($this->data['idplist'], function($idpentry1, $idpentry2) {
+			return strcmp($this->t('idpname_' . $idpentry1['entityid']),
+			              $this->t('idpname_' . $idpentry2['entityid']));
+
+		});
 			
 		foreach ($this->data['idplist'] AS $idpentry) {
 


### PR DESCRIPTION
Currently, the select IdP dropdown lists the IdP in the order that they appear in metadata. For InCommon metadata, this makes it very difficult to find and select a particular school.

The attached patch sorts the list in alphabetical order using each IdP's name. There may be better ways to do this within SimpleSamlPHP, but this fix is working well for us.

(copied from Google Code issue tracker)
