### PR TITLE
composer: replace xmlseclibs svn source with our git copy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,27 +24,11 @@
     "require": {
         "php": "~5.3",
         "simplesamlphp/saml2": "~0.3",
+        "simplesamlphp/xmlseclibs": "~1.3.1",
         "openid/php-openid": "dev-master#ee669c6a9d4d95b58ecd9b6945627276807694fb as 2.2.2"
     },
     "support": {
         "issues": "https://github.com/simplesamlphp/simplesamlphp/issues",
         "source": "https://github.com/simplesamlphp/simplesamlphp"
-    },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "robrichards/xmlseclibs",
-                "version": "1.3.1",
-                "source": {
-                    "type": "svn",
-                    "url": "http://xmlseclibs.googlecode.com/svn",
-                    "reference": "trunk@50"
-                },
-                "autoload": {
-                    "files": ["xmlseclibs.php"]
-                }
-            }
-        }
-    ]
+    }
 }


### PR DESCRIPTION
This mirrors the configuration used in simplesamlphp/saml2.
It lifts the requirement to have subversion present on your machine.

You may want to run `composer update` after merging, but since this has some other side effects I didn't include it in the pull request.
