### PR TITLE
fixed notice related to eu not being in langnames

### DIFF
--- a/templates/includes/header.php
+++ b/templates/includes/header.php
@@ -157,6 +157,7 @@ if($onLoad !== '') {
 					'sam' => 'Åarjelh-saemien giele', // Southern Sami
 					'da' => 'Dansk', // Danish
 					'en' => 'English',
+					'eu' => 'English',
 					'de' => 'Deutsch', // German
 					'sv' => 'Svenska', // Swedish
 					'fi' => 'Suomeksi', // Finnish


### PR DESCRIPTION
Either we need to ad 'eu' to $langnames or remove 'eu' from config-templates 'language.available'.
