### PR TITLE
Change attribute representation in authmemcookie

### DIFF
--- a/config-templates/authmemcookie.php
+++ b/config-templates/authmemcookie.php
@@ -81,6 +81,33 @@ $config = array(
 	 */
 	'memcache.port' => 11211,
 
+	/*
+	 * This option specifies how the attributes are represented in the memcache store.
+	 * Up until SimpleSamlPhp 1.13, the format was "implode".
+	 * In this format, the representation consists of multiple lines, one attribute-name per line.
+	 * Multi-value attributes would be concatinated with colons in between.
+	 * For backwards compatibility, this is still the standard behaviour.
+	 * 
+	 * The possible values are:
+	 * # implode
+	 *   Classic behaviour, memcache will contain one line per attribute name,
+	 *   if the attribute is multi-value, the values are concatinated with a colon (:) in between.
+	 *   Lines are separated with Windows-style newlines (\r\n)
+	 * 
+	 * # multi
+	 *   Looks like implode, except that there will not be one line per attribute name,
+	 *   but per attribute value. Multi-value attributes will be represented with multiple lines
+	 *   with identical keys.
+	 *   This option is recommended if you want to handle multi-value attributes,
+	 *   but you have to be compatible with the old format as well.
+	 *
+	 * # json
+	 *   The attributes are serialised as JSON. The root is a dictionary with the attribute name as key,
+	 *   and an array of attribute values as value.
+	 */
+	'format' => 'implode', // backwards-compatible
+	//'format' => 'json', // recommended
+
 );
 
 ?>

--- a/www/authmemcookie.php
+++ b/www/authmemcookie.php
@@ -91,12 +91,25 @@ try {
 	/* Store the authentication data in the memcache server. */
 
 	$data = '';
+	$amcConfig = SimpleSAML_Configuration::getConfig('authmemcookie.php');
+	$format = strtolower($amcConfig->getBoolean('format', 'implode'));
+	assert('in_array($format, array("implode", "multi", "json"))');
 	foreach($authData as $n => $v) {
-		if(is_array($v)) {
-			$v = implode(':', $v);
+		if(!is_array($v)) {
+			$v = array((string)$v);
+		}
+		if ($format === 'multi') {
+			$v = array(implode(':', $v));
 		}
 
-		$data .= $n . '=' . $v . "\r\n";
+		if (in_array($format, array('implode', 'multi'))) {
+			foreach($v as $v2) {
+				$data .= $n . '=' . str_replace("\r\n", "\n", $v2) . "\r\n";
+			}
+		}
+	}
+	if ($format === 'json') {
+		$data = json_encode($authData);
 	}
 
 


### PR DESCRIPTION
Allow for different representations in the config file. The current
representation gives issues when handling multi-value attributes
containing colons, like entitlements.
