### PR TITLE
Make sure metadata-converter.php requires an admin user

### DIFF
--- a/www/admin/metadata-converter.php
+++ b/www/admin/metadata-converter.php
@@ -2,6 +2,9 @@
 
 require_once('../_include.php');
 
+/* Make sure that the user has admin access rights. */
+SimpleSAML_Utilities::requireAdmin();
+
 $config = SimpleSAML_Configuration::getInstance();
 
 if(array_key_exists('xmldata', $_POST)) {


### PR DESCRIPTION
Depending on server configuration this may be used in a Denial Of Service attack by tying up all webserver workers with large POST bodies.