### PR TITLE
protectmetadata was not enforced for SP metadata.

### DIFF
--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -5,6 +5,9 @@ if (!array_key_exists('PATH_INFO', $_SERVER)) {
 }
 
 $config = SimpleSAML_Configuration::getInstance();
+if ($config->getBoolean('admin.protectmetadata', false)) {
+	SimpleSAML_Utilities::requireAdmin();
+}
 $sourceId = substr($_SERVER['PATH_INFO'], 1);
 $source = SimpleSAML_Auth_Source::getById($sourceId);
 if ($source === NULL) {


### PR DESCRIPTION
This check was not ported to the saml2 module.