### PR TITLE
Disable the loading of external entities in XML documents.

### DIFF
--- a/lib/SimpleSAML/Utilities.php
+++ b/lib/SimpleSAML/Utilities.php
@@ -1930,6 +1930,17 @@ class SimpleSAML_Utilities {
 		date_default_timezone_set($serverTimezone);
 	}
 
+	/**
+	 * Disable the loading of external entities in XML documents to prevent local and
+	 * remote file inclusion attacks. This is in most cases already disabled by default
+	 * in system libraries, but to be safe we explicitly disable it also.
+	 */
+	public static function disableXMLEntityLoader() {
+		/* Function only present in PHP >= 5.2.11 while we support 5.2+ */
+		if ( function_exists('libxml_disable_entity_loader') ) {
+			libxml_disable_entity_loader();
+		}
+	}
 
 	/**
 	 * Atomically write a file.

--- a/www/_include.php
+++ b/www/_include.php
@@ -107,5 +107,5 @@ if (!file_exists($configdir . '/config.php')) {
 
 /* Set the timezone. */
 SimpleSAML_Utilities::initTimezone();
-
-?>
+/* Disable XML external entity loading explicitly. */
+SimpleSAML_Utilities::disableXMLEntityLoader();


### PR DESCRIPTION
To prevent local and remote file inclusion attacks. This is in most cases
already disabled by default in system libraries, so this will be a no-op to
most systems, but to be safe we explicitly disable it also.

Fixes #74