### PR TITLE
Extract RSA or DSA PEM data from cert. 

### DIFF
--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -1125,10 +1125,14 @@ class SimpleSAML_Configuration {
 				throw new Exception($this->location . ': Unable to load certificate/public key from file "' . $file . '".');
 			}
 
-			/* Extract certificate data (if this is a certificate). */
+			/* Extract certificate data (if this is an RSA certificate). */
 			$pattern = '/^-----BEGIN CERTIFICATE-----([^-]*)^-----END CERTIFICATE-----/m';
 			if (!preg_match($pattern, $data, $matches)) {
-				throw new SimpleSAML_Error_Exception($this->location . ': Could not find PEM encoded certificate in "' . $file . '".');
+				/* Try to extract DSA certificate data */
+				$pattern = '/^-----BEGIN PUBLIC KEY-----([^-]*)^-----END PUBLIC KEY-----/m';
+				if (!preg_match($pattern, $data, $matches)) {
+					throw new SimpleSAML_Error_Exception($this->location . ': Could not find PEM encoded certificate in "' . $file . '".');
+				}
 			}
 			$certData = preg_replace('/\s+/', '', $matches[1]);
 


### PR DESCRIPTION
Google treats RSA and DSA equally in their documentation (https://developers.google.com/google-apps/help/articles/sso-keygen)

From the OpenSSL docs https://www.openssl.org/docs/apps/dsa.html:

The PEM private key format uses the header and footer lines:

 -----BEGIN DSA PRIVATE KEY-----
 -----END DSA PRIVATE KEY-----
The PEM public key format uses the header and footer lines:

 -----BEGIN PUBLIC KEY-----
 -----END PUBLIC KEY-----