### PR TITLE
CAS Server module should store its tickets in the central store

### DIFF
--- a/modules/casserver/config-templates/module_casserver.php
+++ b/modules/casserver/config-templates/module_casserver.php
@@ -13,8 +13,6 @@ $config = array (
 	// Legal values: saml2, shib13
 	'auth' => 'saml2',
 	
-	'ticketcache' => 'ticketcache',
-
 	'attrname' => 'mail', // 'eduPersonPrincipalName',
 	#'attributes' => TRUE, // enable transfer of attributes
 	

--- a/modules/casserver/www/login.php
+++ b/modules/casserver/www/login.php
@@ -39,10 +39,8 @@ if (!$as->isAuthenticated()) {
 
 $attributes = $as->getAttributes();
 
-$path = $casconfig->resolvePath($casconfig->getValue('ticketcache', '/tmp'));
-
 $ticket = str_replace( '_', 'ST-', SimpleSAML_Utilities::generateID() );
-storeTicket($ticket, $path, array('service' => $service,
+storeTicket($ticket, array('service' => $service,
 	'forceAuthn' => $forceAuthn,
 	'attributes' => $attributes,
 	'proxies' => array(),

--- a/modules/casserver/www/proxy.php
+++ b/modules/casserver/www/proxy.php
@@ -22,12 +22,10 @@ $legal_service_urls = $casconfig->getValue('legal_service_urls');
 if (!checkServiceURL($targetService, $legal_service_urls))
 	throw new Exception('Service parameter provided to CAS server is not listed as a legal service: [service] = ' . $service);
 
-$path = $casconfig->resolvePath($casconfig->getValue('ticketcache', 'ticketcache'));
-
-$ticket = retrieveTicket($pgt, $path, false);
+$ticket = retrieveTicket($pgt, false);
 if ($ticket['validbefore'] > time()) {
 	$pt = str_replace( '_', 'PT-', SimpleSAML_Utilities::generateID() );
-	storeTicket($pt, $path, array(
+	storeTicket($pt, array(
 		'service' => $targetService,
 		'forceAuthn' => false,
 		'attributes' => $ticket['attributes'],

--- a/modules/casserver/www/serviceValidate.php
+++ b/modules/casserver/www/serviceValidate.php
@@ -24,8 +24,7 @@ try {
 /* Load simpleSAMLphp, configuration and metadata */
 	$casconfig = SimpleSAML_Configuration::getConfig('module_casserver.php');
 	
-	$path = $casconfig->resolvePath($casconfig->getValue('ticketcache', 'ticketcache'));
-	$ticketcontent = retrieveTicket($ticket, $path);
+	$ticketcontent = retrieveTicket($ticket);
 	
 	$usernamefield = $casconfig->getValue('attrname', 'eduPersonPrincipalName');
 	$dosendattributes = $casconfig->getValue('attributes', FALSE);
@@ -49,7 +48,7 @@ try {
 				'proxies' => array_merge(array($service), $ticketcontent['proxies']),
 				'validbefore' => time() + 60);
 			SimpleSAML_Utilities::fetch($pgtUrl . '?pgtIou=' . $pgtiou . '&pgtId=' . $pgt);
-			storeTicket($pgt, $path, $content);
+			storeTicket($pgt, $content);
 			$pgtiouxml = "\n<cas:proxyGrantingTicket>$pgtiou</cas:proxyGrantingTicket>\n";
 		}
 		


### PR DESCRIPTION
This means that if an institution is load-balancing across two nodes, the CAS ticket
can be properly stored in the multiple memcache nodes. The previous behavior
stored the ticket information in a file. Storing in a file means that load-balancing
is very difficult and storing in a file is much slower than using memcache.