### PR TITLE
Fix Exception type and set timeout when fetching metadata

### DIFF
--- a/modules/core/dictionaries/no_state.definition.json
+++ b/modules/core/dictionaries/no_state.definition.json
@@ -8,6 +8,9 @@
 	"suggestions": {
 		"en": "Suggestions for resolving this problem:"
 	},
+	"suggestion_badlink": {
+		"en": "Check that the link you used to access the web site is correct."
+	},
 	"suggestion_goback": {
 		"en": "Go back to the previous page and try again."
 	},
@@ -16,6 +19,9 @@
 	},
 	"causes": {
 		"en": "This error may be caused by:"
+	},
+	"cause_badlink": {
+		"en": "The link used to get here was bad, perhaps as the result of evil auto completion or just a bad link or bookmark."
 	},
 	"cause_backforward": {
 		"en": "Using the back and forward buttons in the web browser."

--- a/modules/core/dictionaries/no_state.translation.json
+++ b/modules/core/dictionaries/no_state.translation.json
@@ -83,6 +83,9 @@
 		"cs": "N\u00e1vrhy pro vy\u0159e\u0161en\u00ed tohoto probl\u00e9mu:",
 		"eu": "Arazo hau konpontzeko iradokizunak:"
 	},
+	"suggestion_badlink": {
+		"sv": "Kontrollera att länken du använde för att komma åt webplatsen är korrekt."
+	},
 	"suggestion_goback": {
 		"no": "G\u00e5 tilbake til forrige side og pr\u00f8v p\u00e5 nytt.",
 		"nn": "G\u00e5 tilbake til forrige side og pr\u00f8v p\u00e5 nytt.",
@@ -166,6 +169,9 @@
 		"ru": "\u042d\u0442\u0430 \u043e\u0448\u0438\u0431\u043a\u0430 \u043c\u043e\u0436\u0435\u0442 \u0431\u044b\u0442\u044c \u0432\u044b\u0437\u0432\u0430\u043d\u0430:",
 		"cs": "Tato chyba m\u016f\u017ee b\u00fdt zp\u016fsoben\u00e1:",
 		"eu": "Errore hau honek eragin dezake:"
+	},
+	"cause_badlink": {
+		"sv": "Länken till websidan var felaktig, kanske till följd av elak automatisk ifyllning, en trasig länk eller ett trasigt bokmärke."
 	},
 	"cause_backforward": {
 		"no": "Bruk av \"frem\"- og \"tilbake\"-knappene i nettleseren.",

--- a/modules/core/templates/no_state.tpl.php
+++ b/modules/core/templates/no_state.tpl.php
@@ -2,12 +2,14 @@
 
 echo('<h3>' . $this->t('{core:no_state:suggestions}') . '</h3>');
 echo('<ul>');
+echo('<li>' . $this->t('{core:no_state:suggestion_badlink}') . '</li>');
 echo('<li>' . $this->t('{core:no_state:suggestion_goback}') . '</li>');
 echo('<li>' . $this->t('{core:no_state:suggestion_closebrowser}') . '</li>');
 echo('</ul>');
 
 echo('<h3>' . $this->t('{core:no_state:causes}') . '</h3>');
 echo('<ul>');
+echo('<li>' . $this->t('{core:no_state:cause_badlink}') . '</li>');
 echo('<li>' . $this->t('{core:no_state:cause_backforward}') . '</li>');
 echo('<li>' . $this->t('{core:no_state:cause_openbrowser}') . '</li>');
 echo('<li>' . $this->t('{core:no_state:cause_nocookie}') . '</li>');

--- a/modules/core/www/loginuserpass.php
+++ b/modules/core/www/loginuserpass.php
@@ -10,7 +10,7 @@
  */
 
 if (!array_key_exists('AuthState', $_REQUEST)) {
-	throw new SimpleSAML_Error_BadRequest('Missing AuthState parameter.');
+	throw new SimpleSAML_Error_NoState('Missing AuthState parameter.');
 }
 $authStateId = $_REQUEST['AuthState'];
 

--- a/modules/metarefresh/lib/MetaLoader.php
+++ b/modules/metarefresh/lib/MetaLoader.php
@@ -159,7 +159,7 @@ class sspmod_metarefresh_MetaLoader {
 			}
 		}
 
-		return array('http' => array('header' => $rawheader));
+		return array('http' => array('header' => $rawheader, 'timeout' => 5));
 	}
 
 


### PR DESCRIPTION
If the AuthState is missing, usually because the users has saved a bookmark or in some other way is following a link that is half way in to the authentication process. Reading the code, it seems obvious that the author had the NoState exception in mind for this, but it was not used. Also, add some friendly error information.

The timeout in MetaLoader.php is important as well:
