### PR TITLE
Ldap fallthrough

### DIFF
--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -336,12 +336,15 @@ $config = array(
         //'remember.username.checked' => FALSE,
 
         // The way the organization as part of the username should be handled.
-        // Three possible values:
-        // - 'none':   No handling of the organization. Allows '@' to be part
-        //             of the username.
-        // - 'allow':  Will allow users to type 'username@organization'.
-        // - 'force':  Force users to type 'username@organization'. The dropdown
-        //             list will be hidden.
+        // Four possible values:
+        // - 'none':        No handling of the organization. Allows '@' to be
+        //                  part of the username.
+        // - 'allow':       Will allow users to type 'username@organization'.
+        // - 'force':       Force users to type 'username@organization'. The
+        //                  dropdown list will be hidden.
+        // - 'fallthrough': The dropdown list of organizations is hidden. When
+        //                  the user tries to log in, each organization is tried
+        //                  in turn.
         //
         // The default is 'none'.
         'username_organization_method' => 'none',

--- a/modules/core/lib/Auth/UserPassOrgBase.php
+++ b/modules/core/lib/Auth/UserPassOrgBase.php
@@ -34,10 +34,11 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 
 	/**
 	 * What way do we handle the organization as part of the username.
-	 * Three values:
+	 * Four values:
 	 *  'none': Force the user to select the correct organization from the dropdown box.
 	 *  'allow': Allow the user to enter the organization as part of the username.
 	 *  'force': Remove the dropdown box.
+	 *  'fallthrough': Remove the dropdown box, try each organization in turn.
 	 */
 	private $usernameOrgMethod;
 
@@ -91,17 +92,18 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	/**
 	 * Configure the way organizations as part of the username is handled.
 	 *
-	 * There are three possible values:
+	 * There are four possible values:
 	 * - 'none': Force the user to select the correct organization from the dropdown box.
 	 * - 'allow': Allow the user to enter the organization as part of the username.
 	 * - 'force': Remove the dropdown box.
+	 * - 'fallthrough': Remove the dropdown box, try each organization in turn.
 	 *
 	 * If unconfigured, the default is 'none'.
 	 *
 	 * @param string $usernameOrgMethod  The method which should be used.
 	 */
 	protected function setUsernameOrgMethod($usernameOrgMethod) {
-		assert('in_array($usernameOrgMethod, array("none", "allow", "force"), TRUE)');
+		assert('in_array($usernameOrgMethod, array("none", "allow", "force", "fallthrough"), TRUE)');
 
 		$this->usernameOrgMethod = $usernameOrgMethod;
 	}
@@ -110,10 +112,11 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	/**
 	 * Retrieve the way organizations as part of the username should be handled.
 	 *
-	 * There are three possible values:
+	 * There are four possible values:
 	 * - 'none': Force the user to select the correct organization from the dropdown box.
 	 * - 'allow': Allow the user to enter the organization as part of the username.
 	 * - 'force': Remove the dropdown box.
+	 * - 'fallthrough': Remove the dropdown box, try each organization in turn.
 	 *
 	 * @return string  The method which should be used.
 	 */
@@ -219,7 +222,7 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 		}
 
 		$orgMethod = $source->getUsernameOrgMethod();
-		if ($orgMethod !== 'none') {
+		if ($orgMethod !== 'none' && $orgMethod !== 'fallthrough') {
 			$tmp = explode('@', $username, 2);
 			if (count($tmp) === 2) {
 				$username = $tmp[0];
@@ -267,7 +270,7 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 		}
 
 		$orgMethod = $source->getUsernameOrgMethod();
-		if ($orgMethod === 'force') {
+		if ($orgMethod === 'force' || $orgMethod === 'fallthrough') {
 			return NULL;
 		}
 

--- a/modules/ldap/lib/Auth/Source/LDAPMulti.php
+++ b/modules/ldap/lib/Auth/Source/LDAPMulti.php
@@ -131,14 +131,11 @@ class sspmod_ldap_Auth_Source_LDAPMulti extends sspmod_core_Auth_UserPassOrgBase
 	 */
 	private function loginAllOrgs($username, $password, array $sasl_args = NULL) {
 		foreach ($this->orgs as $org => $orgDescription) {
-			$userdetails = NULL;
 			try {
 				$userdetails = $this->ldapOrgs[$org]->login($username, $password, $sasl_args);
+				return $userdetails;
 			} catch (SimpleSAML_Error_Error $e) {
 				// User didn't exist in that organization, so keep going.
-			}
-			if ($userdetails !== NULL) {
-				return $userdetails;
 			}
 		}
 


### PR DESCRIPTION
Add an option to the ldap:LDAPMulti auth type so instead of having to specify the organization a user is in (or trying to work it out), let it try each organization in turn.
