### PR TITLE
fix SimpleSAML\Utils\getBaseURL return value

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -444,7 +444,7 @@ class HTTP
             $protocol .= '://';
 
             $hostname = self::getServerHost();
-            $port = self::getServerPort();
+            $port = ':'.self::getServerPort();
             $path = '/'.$globalConfig->getBaseURL();
 
             return $protocol.$hostname.$port.$path;


### PR DESCRIPTION
getServerPort does not return “:portnumber” which is expected by
getBaseURL to construct a correct redirection url