### PR TITLE
Created default 'cert' directory as suggested in issue #193

### DIFF
--- a/cert/.gitignore
+++ b/cert/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
A `cert` directory placeholder file to help avoid confusion described in issue #193.