### PR TITLE
remove misleading and unused config option

### DIFF
--- a/modules/metaedit/config-template/module_metaedit.php
+++ b/modules/metaedit/config-template/module_metaedit.php
@@ -4,7 +4,6 @@
  */
 
 $config = array (
-	'admins' => array('andreas@rnd.feide.no'),
 	'metahandlerConfig' => array('directory' => 'metadata/metaedit'),
 	'auth' => 'saml2',
 	'useridattr' => 'eduPersonPrincipalName',


### PR DESCRIPTION
this admins array is not used anywhere,
but it may be misleading to administrators who wants to restrict
the access to the metadata registry.

Please consider removing this configure options.