### PR TITLE
Removed a 'if' sentence than prevents a Store class couldn't be added.

### DIFF
--- a/lib/SimpleSAML/Store.php
+++ b/lib/SimpleSAML/Store.php
@@ -47,9 +47,6 @@ abstract class SimpleSAML_Store {
 			self::$instance = new SimpleSAML_Store_SQL();
 			break;
 		default:
-			if (strpos($storeType, ':') === FALSE) {
-				throw new SimpleSAML_Error_Exception('Unknown datastore type: ' . var_export($storeType, TRUE));
-			}
 			/* Datastore from module. */
 			$className = SimpleSAML_Module::resolveClass($storeType, 'Store', 'SimpleSAML_Store');
 			self::$instance = new $className();


### PR DESCRIPTION
Removed a 'if' sentence than prevents a Store class couldn't be added it is named with a namespace instead with the sspmod_module_Store_class way.

I'm writing a module with a new SimpleSAML_Store class using namespaces. When I'm trying to load the class on my config file:

```
'store.type'                    => 'SimpleSAML\Modules\DBAL\Store\DBAL',
```

I get an exception because it expects a string with 'module:class' format. But ```SimpleSAML_Module::resolveClass($storeType, 'Store', 'SimpleSAML_Store');``` is enough to control if a class could be added or not.