### PR TITLE
Add support for sender-vouches

### DIFF
--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -587,8 +587,9 @@ class sspmod_saml_Message {
 
 		$found = FALSE;
 		$lastError = 'No SubjectConfirmation element in Subject.';
+		$validSCMethods = array(SAML2_Const::CM_BEARER, SAML2_Const::CM_HOK, SAML2_Const::CM_VOUCHES);
 		foreach ($assertion->getSubjectConfirmation() as $sc) {
-			if ($sc->Method !== SAML2_Const::CM_BEARER && $sc->Method !== SAML2_Const::CM_HOK && $sc->Method !== SAML2_Const::CM_VOUCHES) {
+		    if (!in_array($sc->Method, $validSCMethods)) {
 				$lastError = 'Invalid Method on SubjectConfirmation: ' . var_export($sc->Method, TRUE);
 				continue;
 			}

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -588,7 +588,7 @@ class sspmod_saml_Message {
 		$found = FALSE;
 		$lastError = 'No SubjectConfirmation element in Subject.';
 		foreach ($assertion->getSubjectConfirmation() as $sc) {
-			if ($sc->Method !== SAML2_Const::CM_BEARER && $sc->Method !== SAML2_Const::CM_HOK) {
+			if ($sc->Method !== SAML2_Const::CM_BEARER && $sc->Method !== SAML2_Const::CM_HOK && $sc->Method !== SAML2_Const::CM_VOUCHES) {
 				$lastError = 'Invalid Method on SubjectConfirmation: ' . var_export($sc->Method, TRUE);
 				continue;
 			}


### PR DESCRIPTION
This patch adds support for the sender-vouches SubjectConfirmation Method, requested in issue #50. 

It also depends on the constant added in https://github.com/simplesamlphp/saml2/pull/41