### PR TITLE
A-Select: always add uid+organization to attributes

### DIFF
--- a/modules/aselect/docs/aselect.txt
+++ b/modules/aselect/docs/aselect.txt
@@ -21,7 +21,8 @@ named 'aselect':
         'app_id' => 'simplesamlphp',
         'server_id' => 'sso.example.com',
         'server_url' => 'https://test.sso.example.com/server',
-        'private_key' => 'file:///etc/ssl/private/aselect.key'
+        'private_key' => 'file:///etc/ssl/private/aselect.key',
+        'add_default_attributes' => FALSE
     ),
 
 The parameters:
@@ -34,6 +35,10 @@ The parameters:
 - private_key: the key you want to use for signing requests.
   If you're really sure you do not want request signing, you
   can set this option to a null value.
+- add_default_attributes: true to add default attributes
+  (uid and organization) to resulting attributes, false
+  to never do this, and null to do this only when no
+  attributes are returned.
 Options 'serverurl' and 'serverid' (without underscore) are
 supported for backwards compatibility.
 

--- a/modules/aselect/lib/Auth/Source/aselect.php
+++ b/modules/aselect/lib/Auth/Source/aselect.php
@@ -10,6 +10,7 @@ class sspmod_aselect_Auth_Source_aselect extends SimpleSAML_Auth_Source {
 	private $server_id;
 	private $server_url;
 	private $private_key;
+	private $add_default_attributes;
 
 	/**
 	 * Constructor for this authentication source.
@@ -37,6 +38,8 @@ class sspmod_aselect_Auth_Source_aselect extends SimpleSAML_Auth_Source {
 		$this->server_url = $cfg->getString('serverurl', null);
 		if($this->server_url === null)
 			$this->server_url = $cfg->getString('server_url');
+
+		$this->add_default_attributes = $cfg->getBoolean('add_default_attributes', null);
 	}
 
 	/**
@@ -46,6 +49,7 @@ class sspmod_aselect_Auth_Source_aselect extends SimpleSAML_Auth_Source {
 	 */
 	public function authenticate(&$state) {
 		$state['aselect::authid'] = $this->authId;
+		$state['aselect::add_default_attributes'] = $this->add_default_attributes;
 		$id = SimpleSAML_Auth_State::saveState($state, 'aselect:login', true);
 
 		try {

--- a/modules/aselect/www/credentials.php
+++ b/modules/aselect/www/credentials.php
@@ -38,10 +38,26 @@ try {
     }
     $creds = $aselect->verify_credentials($server_id, $credentials, $rid);
 
-    if (array_key_exists('attributes', $creds)) {
-        $state['Attributes'] = $creds['attributes'];
-    } else {
+    if ($state['aselect::add_default_attributes'] === true) {
+        // Add default attributes
         $state['Attributes'] = array('uid' => array($creds['uid']), 'organization' => array($creds['organization']));
+        if (array_key_exists('attributes', $creds)) {
+            $state['Attributes'] = array_merge($state['Attributes'], $creds['attributes']);
+        }
+    } elseif ($state['aselect::add_default_attributes'] === false) {
+        // Do not add default attributes
+        if (array_key_exists('attributes', $creds)) {
+            $state['Attributes'] = $creds['attributes'];
+        } else {
+            $state['Attributes'] = array();
+        }
+    } else {
+        // Legacy behaviour: add default attributes if no attributes are returned
+        if (array_key_exists('attributes', $creds)) {
+            $state['Attributes'] = $creds['attributes'];
+        } else {
+            $state['Attributes'] = array('uid' => array($creds['uid']), 'organization' => array($creds['organization']));
+        }
     }
 } catch (Exception $e) {
     SimpleSAML_Auth_State::throwException($state, $e);


### PR DESCRIPTION
uid and organization attributes are not always in `$creds['attributes']`, so we add an option for that.