### PR TITLE
Set PHP session cookie configuation to be true by default.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -310,7 +310,7 @@ $config = array(
      */
     'session.phpsession.cookiename' => null,
     'session.phpsession.savepath' => null,
-    'session.phpsession.httponly' => false,
+    'session.phpsession.httponly' => true,
 
     /*
      * Option to override the default settings for the auth token cookie

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -211,7 +211,7 @@ class SimpleSAML_SessionHandlerPHP extends SimpleSAML_SessionHandler {
 			$ret['path'] = $config->getBoolean('session.phpsession.limitedpath', FALSE) ? '/' . $config->getBaseURL() : '/';
 		}
 
-		$ret['httponly'] = $config->getBoolean('session.phpsession.httponly', FALSE);
+		$ret['httponly'] = $config->getBoolean('session.phpsession.httponly', TRUE);
 
 		return $ret;
 	}


### PR DESCRIPTION
It's obviously more secure and therefore better as a default.