### PR TITLE
Corrected logic in checkSessionCookie

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -271,7 +271,7 @@ class HTTP
      */
     public static function checkSessionCookie($retryURL = null)
     {
-        if (!is_string($retryURL) || !is_null($retryURL)) {
+        if (!is_string($retryURL) && !is_null($retryURL)) {
             throw new \InvalidArgumentException('Invalid input parameters.');
         }
 


### PR DESCRIPTION
Raise InvalidArgumentException if $retryURL is not a string AND is not null