### PR TITLE
Moved logic pertaining to finding configdir to central location, added ability to set via environment variable

### DIFF
--- a/bin/memcacheSync.php
+++ b/bin/memcacheSync.php
@@ -24,7 +24,7 @@ $baseDir = dirname(dirname(__FILE__));
 require_once($baseDir . '/lib/_autoload.php');
 
 /* Initialize the configuration. */
-$configdir = $baseDir . '/config';
+$configdir = SimpleSAML\Utils\Config::getConfigDir();
 SimpleSAML_Configuration::setConfigDir($configdir);
 
 /* Things we should warn the user about. */

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -144,7 +144,7 @@ class SimpleSAML_Configuration {
 			if ($configSet !== 'simplesaml') {
 				throw new Exception('Configuration set \'' . $configSet . '\' not initialized.');
 			} else {
-				self::$configDirs['simplesaml'] = dirname(dirname(dirname(__FILE__))) . '/config';
+				self::$configDirs['simplesaml'] = SimpleSAML\Utils\Config::getConfigDir();
 			}
 		}
 
@@ -171,7 +171,7 @@ class SimpleSAML_Configuration {
 			if ($configSet !== 'simplesaml') {
 				throw new Exception('Configuration set \'' . $configSet . '\' not initialized.');
 			} else {
-				self::$configDirs['simplesaml'] = dirname(dirname(dirname(__FILE__))) . '/config';
+				self::$configDirs['simplesaml'] = SimpleSAML\Utils\Config::getConfigDir();
 			}
 		}
 

--- a/lib/SimpleSAML/Utils/Config.php
+++ b/lib/SimpleSAML/Utils/Config.php
@@ -55,4 +55,32 @@ class Config
 
         return $secretSalt;
     }
+
+    /**
+     * Returns the path to the config dir
+     *
+     * If the SIMPLSAMLPHP_CONFIG_DIR environment variable has been set, it takes precedence
+     * over the default $simplesamldir/config directory.
+     *
+     * @return string
+     */
+    public static function getConfigDir()
+    {
+        $configDir    = dirname(dirname(dirname(__DIR__))) . '/config';
+        $configDirEnv = getenv('SIMPLESAMLPHP_CONFIG_DIR');
+        if ($configDirEnv !== false) {
+            if (!is_dir($configDirEnv)) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Config directory specified by environment variable SIMPLESAMLPHP_CONFIG_DIR is not a ' .
+                        'directory.  Given: "%s"',
+                        $configDirEnv
+                    )
+                );
+            }
+            $configDir = $configDirEnv;
+        }
+
+        return $configDir;
+    }
 }

--- a/modules/metarefresh/bin/metarefresh.php
+++ b/modules/metarefresh/bin/metarefresh.php
@@ -23,7 +23,8 @@ if(!SimpleSAML_Module::isModuleEnabled('metarefresh')) {
 }
 
 /* Initialize the configuration. */
-SimpleSAML_Configuration::setConfigDir($baseDir . '/config');
+$configdir = SimpleSAML\Utils\Config::getConfigDir();
+SimpleSAML_Configuration::setConfigDir($configdir);
 
 /* $outputDir contains the directory we will store the generated metadata in. */
 $outputDir = $baseDir . '/metadata-generated';

--- a/modules/statistics/bin/loganalyzer.php
+++ b/modules/statistics/bin/loganalyzer.php
@@ -9,7 +9,8 @@ $baseDir = dirname(dirname(dirname(dirname(__FILE__))));
 require_once($baseDir . '/lib/_autoload.php');
 
 /* Initialize the configuration. */
-SimpleSAML_Configuration::setConfigDir($baseDir . '/config');
+$configdir = SimpleSAML\Utils\Config::getConfigDir();
+SimpleSAML_Configuration::setConfigDir($configdir);
 
 SimpleSAML\Utils\Time::initTimezone();
 

--- a/modules/statistics/bin/logcleaner.php
+++ b/modules/statistics/bin/logcleaner.php
@@ -9,7 +9,8 @@ $baseDir = dirname(dirname(dirname(dirname(__FILE__))));
 require_once($baseDir . '/lib/_autoload.php');
 
 /* Initialize the configuration. */
-SimpleSAML_Configuration::setConfigDir($baseDir . '/config');
+$configdir = SimpleSAML\Utils\Config::getConfigDir();
+SimpleSAML_Configuration::setConfigDir($configdir);
 
 
 

--- a/tests/lib/SimpleSAML/Utils/ConfigTest.php
+++ b/tests/lib/SimpleSAML/Utils/ConfigTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Tests for SimpleSAML\Utils\Config
+ */
+class Utils_ConfigTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test default config dir with not environment variable
+     */
+    public function testDefaultConfigDir()
+    {
+        // clear env var
+        putenv('SIMPLESAMLPHP_CONFIG_DIR');
+        $configDir = \SimpleSAML\Utils\Config::getConfigDir();
+
+        $this->assertEquals($configDir, dirname(dirname(dirname(dirname(__DIR__)))) . '/config');
+    }
+
+    /**
+     * Test valid dir specified by env var overrides default config dir
+     */
+    public function testEnvVariableConfigDir()
+    {
+        putenv('SIMPLESAMLPHP_CONFIG_DIR=' . __DIR__);
+        $configDir = \SimpleSAML\Utils\Config::getConfigDir();
+
+        $this->assertEquals($configDir, __DIR__);
+    }
+
+    /**
+     * Test invalid dir specified by env var results in a thrown exception
+     */
+    public function testInvalidEnvVariableConfigDirThrowsException()
+    {
+        // I used a random hash to ensure this test directory is always invalid
+        $invalidDir = __DIR__ . '/e9826ad19cbc4f5bf20c0913ffcd2ce6';
+        putenv('SIMPLESAMLPHP_CONFIG_DIR=' . $invalidDir);
+
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Config directory specified by environment variable SIMPLESAMLPHP_CONFIG_DIR is not a directory.  ' .
+            'Given: "' . $invalidDir . '"'
+        );
+
+        $configDir = \SimpleSAML\Utils\Config::getConfigDir();
+    }
+}

--- a/www/_include.php
+++ b/www/_include.php
@@ -97,7 +97,7 @@ class SimpleSAML_IncPrefixWarn {
 $SIMPLESAML_INCPREFIX = new SimpleSAML_IncPrefixWarn();
 
 
-$configdir = dirname(dirname(__FILE__)) . '/config';
+$configdir = SimpleSAML\Utils\Config::getConfigDir();
 if (!file_exists($configdir . '/config.php')) {
 	header('Content-Type: text/plain');
 	echo("You have not yet created the simpleSAMLphp configuration files.\n");


### PR DESCRIPTION
There is a similar pull request for this feature (I even borrowed the environment variable), but I wanted to try a different approach that makes this a little easier to understand.  The logic for finding the config directory is centralized.

I can make the necessary changes for the manual, but I wanted to put in the pull request and have someone look at it first before I finish it off.  If it looks good I'll finish it off.

For the bin files, the environment variable can be passed via cli like so:

```
SIMPLESAMLPHP_CONFIG_DIR=/home/user/samlconfig php modules/statistics/bin/loganalyzer.php
```