### PR TITLE
Updated newSessionId function to allow for just the session id to be …

### DIFF
--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -77,18 +77,22 @@ class SimpleSAML_SessionHandlerPHP extends SimpleSAML_SessionHandler {
 		}
 
 		/* Generate new (secure) session id. */
-		$sessionId = SimpleSAML_Utilities::stringToHex(SimpleSAML_Utilities::generateRandomBytes(16));
-		SimpleSAML_Session::createSession($sessionId);
 
-		if (session_id() !== '') {
-			/* Session already started, close it. */
-			session_write_close();
-		}
+		/**
+		*
+		* Regenerate the session id instead of destroying the current session.
+		* This will keep the current session data intact once the new session id
+		* has been generated.
+		*
+		*/
+		$old_session_id = session_id();
+		
+		// regenerates the session id, set to TRUE to delete the old associated files (set to false to keep)
+        session_regenerate_id(TRUE);
+        $new_session_id = session_id();
 
-		session_id($sessionId);
-		session_start();
-
-		return session_id();
+        // returns the new session
+		return $new_session_id;
 	}
 
 


### PR DESCRIPTION
…regenerated and not destroy the whole session.

session_regenerate_id(TRUE) is avaliable in PHP 4 >= 4.3.2 and PHP 5, this way the session is not destroyed when the id is regenerated, while still aiding in the prevention of session fixation and session hijacking attacks. 

This allows our system to set some session variables before the login attempt that are needed for when the user is redirected back.
