### PR TITLE
Isolate persistent state in SimpleSAML_Auth_Source::loginCompleted

### DIFF
--- a/lib/SimpleSAML/Auth/Source.php
+++ b/lib/SimpleSAML/Auth/Source.php
@@ -217,8 +217,8 @@ abstract class SimpleSAML_Auth_Source
         // save session state
         $session = SimpleSAML_Session::getSessionFromRequest();
         $authId = $state['SimpleSAML_Auth_Default.id'];
-        $state = SimpleSAML_Auth_State::extractPersistentAuthState($state);
-        $session->doLogin($authId, $state);
+        $persistentState = SimpleSAML_Auth_State::extractPersistentAuthState($state);
+        $session->doLogin($authId, $persistentState);
 
         if (is_string($return)) { // redirect...
             \SimpleSAML\Utils\HTTP::redirectTrustedURL($return);


### PR DESCRIPTION
When SimpleSAMLPHP runs an IDP with multiauth as the authentication source, upon successful login, the redirect back to the multiauth plugin fails with:

SimpleSAML_Error_Assertion: Assertion failed: 'isset($state["core:IdP"])'

I tracked this down to a recent refactoring of SimpleSAML_Auth_Source::loginCompleted(). $state is filtered which destroys much of the state data passed to "call_user_func($return, $state);" within the same function.

This change simply isolates the filter so the callback has full state information.