### PR TITLE
Fix assertion scope

### DIFF
--- a/lib/SimpleSAML/Auth/Source.php
+++ b/lib/SimpleSAML/Auth/Source.php
@@ -162,7 +162,7 @@ abstract class SimpleSAML_Auth_Source
      */
     public function initLogin($return, $errorURL = null, array $params = array())
     {
-        assert('is_string($authId)');
+        assert('is_string($this->authId)');
         assert('is_string($return) || is_array($return)');
         assert('is_string($errorURL) || is_null($errorURL)');
 


### PR DESCRIPTION
The authState assertion in SimpleSAML_Auth_Source::initLogin fails because of incorrectly accessing the variable it's checking.