### PR TITLE
Make SQLPersistentNameID more flexible

### DIFF
--- a/modules/saml/docs/nameid.txt
+++ b/modules/saml/docs/nameid.txt
@@ -69,12 +69,24 @@ This filter generates and stores a persistent NameID in a SQL datastore.
 To use this filter, simpleSAMLphp must be configured to use a SQL datastore.
 See the `store.type` configuration option in `config.php`.
 
-This filter will only create new NameIDs when the SP specifies `AllowCreate="true"` in the authentication request.
-
 ### Options
 
 `attribute`
 :   The name of the attribute we should use as the unique user ID.
+
+`allowUnspecified`
+:   Whether a persistent NameID should be created if the SP does not specify any NameID format in the request.
+    The default is `FALSE`.
+
+`allowDifferent`
+:   Whether a persistent NameID should be created if there are only other NameID formats specified in the request or the SP's metadata.
+    The default is `FALSE`.
+
+`alwaysCreate`
+:   Whether to ignore an explicit `AllowCreate="false"` in the authentication request's NameIDPolicy.
+    The default is `FALSE`, which will only create new NameIDs when the SP specifies `AllowCreate="true"` in the authentication request.
+
+Setting both `allowUnspecified` and `alwaysCreate` to `TRUE` causes `saml:SQLPersistentNameID` to behave like `saml:PersistentNameID` (and other NameID generation filters), at the expense of creating unnecessary entries in the SQL datastore.
 
 
 `saml:PersistentNameID2TargetedID`


### PR DESCRIPTION
SQLPersistentNameID is very conservative about adding entries into the data store, and will only do so in situations where it knows they're explicitly wanted. This is a problem if there are situations where you want it to behave more like other NameID generation filters -- for instance, to create a persistent NameID even if the SP did not explicitly ask for it.

This patch makes it more flexible, whilst still preserving the existing behaviour as the default. It allows you to  override three of the existing checks by means of config booleans.