### PR TITLE
Changed how %replace is handled when 'target' is specified

### DIFF
--- a/modules/core/docs/authproc_attributealter.txt
+++ b/modules/core/docs/authproc_attributealter.txt
@@ -90,6 +90,17 @@ Get the domain of the email and put it in a separate attribute:
         '%replace',
     ),
 
+Defaulting an attribute to one value (Add it with the default before altering) unless another attribute meets a condition: 
+
+    10 => array ('class' => 'core:AttributeAdd',
+                 'myAttribute' => 'default-value'),
+    11 => array ('class' => 'core:AttributeAlter',
+        'subject' => 'entitlement',
+        'pattern' => '/faculty/',
+        'target' => 'myAttribute',
+        '%replace',
+       ),
+ 
 Remove internal, private values from eduPersonEntitlement:
 
     10 => array(

--- a/modules/core/lib/Auth/Process/AttributeAlter.php
+++ b/modules/core/lib/Auth/Process/AttributeAlter.php
@@ -152,7 +152,7 @@ class sspmod_core_Auth_Process_AttributeAlter extends SimpleSAML_Auth_Processing
                     if ($this->subject === $this->target) {
                         $value = $new_value;
                     } else {
-                        $attributes[$this->target][] = $new_value;
+                        $attributes[$this->target] = array($new_value);
                     }
                 }
             }

--- a/tests/modules/core/lib/Auth/Process/AttributeAlterTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeAlterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Test for the core:AttributeAlter filter.
+ */
+class Test_Core_Auth_Process_AttributeAlter extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Helper function to run the filter with a given configuration.
+     *
+     * @param array $config  The filter configuration.
+     * @param array $request  The request state.
+     * @return array  The state array after processing.
+     */
+    private static function processFilter(array $config, array $request)
+    {
+        $filter = new sspmod_core_Auth_Process_AttributeAlter($config, NULL);
+        $filter->process($request);
+        return $request;
+    }
+
+    /**
+     * Test the most basic functionality.
+     */
+    public function testBasic()
+    {
+        $config = array(
+            'subject' => 'test',
+            'pattern' => '/wrong/',
+            'replacement' => 'right',
+        );
+
+        $request = array(
+            'Attributes' => array(
+                 'test' => array('wrong'),
+             ),
+        );
+
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey('test', $attributes);
+        $this->assertEquals($attributes['test'], array('right'));
+    }
+
+    /**
+     * Test replacing attribute value.
+     */
+    public function testReplaceMatch()
+    {
+        $config = array(
+            'subject' => 'source',
+            'pattern' => '/wrong/',
+            'replacement' => 'right',
+            'target' => 'test',
+            '%replace',
+        );
+        $request = array(
+            'Attributes' => array(
+                'source' => array('wrong'),
+                'test'   => array('wrong'),
+            ),
+        );
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertEquals($attributes['test'], array('right'));
+    }
+
+    /**
+     * Test replacing attribute values.
+     */
+    public function testReplaceNoMatch()
+    {
+        $config = array(
+            'subject' => 'test',
+            'pattern' => '/doink/',
+            'replacement' => 'wrong',
+            'target' => 'test',
+            '%replace',
+        );
+        $request = array(
+            'Attributes' => array(
+                'source' => array('wrong'),
+                'test'   => array('right'),
+            ),
+        );
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertEquals($attributes['test'], array('right'));
+    }
+
+}
+


### PR DESCRIPTION
Currently when %replace is specified when there is a 'target', instead of replacing the targets value with the new value, the new value is appended to the array of values for the target.  Semantically I think %replace should mean replace any value in this attribute with the new value if the match hits, so this change wipes out any existing value and replaces it with the new value if the match hits.
