### PR TITLE
Bug/session not saved till after redirect

### DIFF
--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -290,6 +290,15 @@ class SimpleSAML_Session
      */
     public function __destruct()
     {
+        $this->save();
+    }
+    
+    /**
+     * Saves the session to the session handler if the session has been
+     * marked as dirty. Do nothing otherwise.
+     */
+    public function save()
+    {
         if (!$this->dirty) {
             // session hasn't changed - don't bother saving it
             return;

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -119,6 +119,8 @@ class HTTP
      * HTTP version is 1.1. Otherwise, a "HTTP 302 Found" redirection will be used.
      *
      * The function will also generate a simple web page with a clickable link to the target page.
+     * 
+     * The function requests that the session is saved if dirty to ensure it is available after the redirect.
      *
      * @param string   $url The URL we should redirect to. This URL may include query parameters. If this URL is a
      *     relative URL (starting with '/'), then it will be turned into an absolute URL by prefixing it with the
@@ -134,6 +136,7 @@ class HTTP
      * @author Olav Morken, UNINETT AS <olav.morken@uninett.no>
      * @author Mads Freek Petersen
      * @author Jaime Perez, UNINETT AS <jaime.perez@uninett.no>
+     * @author Brett Merrick, Our School Ltd <brett.merrick@ourschool.co.nz>
      */
     private static function redirect($url, $parameters = array())
     {
@@ -159,6 +162,10 @@ class HTTP
         if (strlen($url) > 2048) {
             \SimpleSAML_Logger::warning('Redirecting to a URL longer than 2048 bytes.');
         }
+
+        // ensure session is saved and available after redirect
+        $session = \SimpleSAML_Session::getSessionFromRequest();
+        $session->save();
 
         // set the location header
         header('Location: '.$url, true, $code);


### PR DESCRIPTION
Occasionally a request that was the result of a redirect would attempt to load the session state before it had been saved by the previous request.

This caused either an unnecessary repeat of the redirect, or a SimpleSAML_Error_NoState: NOSTATE error.

The following log excerpt with additional debug messages reveals the sequencing issue.

###### Here the session state is read by the subsequent request after it is set which _is_ ok
```
Sep 25 11:30:30 dev01 simplesamlphp[18535]: [2015-09-25 11:30:30.291000] Redirect header sent
Sep 25 11:30:30 dev01 simplesamlphp[18535]: [2015-09-25 11:30:30.701500] Key set simpleSAMLphp.session.e9e35f8009185e9e8dbcd5c917c99048
-- 
Sep 25 11:30:31 dev01 simplesamlphp[13758]: [2015-09-25 11:30:31.963500] Key read simpleSAMLphp.session.e9e35f8009185e9e8dbcd5c917c99048
Sep 25 11:30:31 dev01 simplesamlphp[13758]: 7 [3c790b3d3a] Received message:
Sep 25 11:30:31 dev01 simplesamlphp[13758]: 7 [3c790b3d3a] <samlp:Response 
--
Sep 25 11:30:32 dev01 simplesamlphp[13758]: 7 [3c790b3d3a] Session: doLogin("1")
Sep 25 11:30:32 dev01 simplesamlphp[13758]: [2015-09-25 11:30:32.040200] Redirect header sent
```
###### Later the session state is set after it is read by the subsequent request which _is not_ ok
```
Sep 25 11:30:32 dev01 simplesamlphp[17980]: [2015-09-25 11:30:32.395400] Key read simpleSAMLphp.session.e9e35f8009185e9e8dbcd5c917c99048
Sep 25 11:30:32 dev01 simplesamlphp[17980]: 7 [3c790b3d3a] Session: '1' not valid because we are not authenticated.
Sep 25 11:30:32 dev01 simplesamlphp[13758]: [2015-09-25 11:30:32.429000] Key set simpleSAMLphp.session.e9e35f8009185e9e8dbcd5c917c99048
Sep 25 11:30:32 dev01 simplesamlphp[17980]: 7 [3c790b3d3a] Saved state: '_71671ba4009ce28926a6042542e7af1c844ad078ec'
```

This pull request separates the save method from the session destructor, and ensures that the session is saved with an explicit call immediately prior to sending the redirect header.