### PR TITLE
Remove setting ReturnURL for default SimpleSAML_Auth states

### DIFF
--- a/lib/SimpleSAML/Auth/Source.php
+++ b/lib/SimpleSAML/Auth/Source.php
@@ -179,12 +179,7 @@ abstract class SimpleSAML_Auth_Source
                 'SimpleSAML_Auth_Source.logoutSource' => $this->authId,
             ),
         ));
-
-        if (is_string($return)) {
-            $state['SimpleSAML_Auth_Default.ReturnURL'] = $return; // TODO: remove in 2.0
-            $state['SimpleSAML_Auth_Source.ReturnURL'] = $return;
-        }
-
+		
         if ($errorURL !== null) {
             $state[SimpleSAML_Auth_State::EXCEPTION_HANDLER_URL] = $errorURL;
         }


### PR DESCRIPTION
[RFC BEFORE MERGE]

I'm not sure if this is the correct way to do this, but the SAML2 spec states
that the relayState param must be 80 bytes or less. If ReturnURL is set here, it
is set to `https://my-site.gov/simplesaml/module.php/core/postredirect.php?RedirId=_54b431cf9a27821d0eeeb17072e7ee5648075f6e81`,
which is always >80 bytes when adding the domain.

It seems there may have been a way to override this `relayState` in previous
versions of SimpleSAMLphp, as I've found references in `authsources.php` to
setting an array parameter of `'RelayState' => null`, but that doesn't appear to
work anymore. Is that a better solution? I'm happy to re-work my pull request if
that's the case.