### PR TITLE
[NOT FOR MERGE] Add common headers that reverse proxies set

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -73,7 +73,23 @@ class HTTP
      */
     private static function getServerHTTPS()
     {
-        if (!array_key_exists('HTTPS', $_SERVER)) {
+        // Convention for (non-standard) proxy signaling a HTTPS forward, see
+        // https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+		if(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https') {
+			return true;
+		}
+
+        // Less conventional proxy header
+		if(isset($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) == 'https') {
+			return true;
+		}
+
+        // Microsoft proxy convention: https://support.microsoft.com/?kbID=307347
+		if(isset($_SERVER['HTTP_FRONT_END_HTTPS']) && strtolower($_SERVER['HTTP_FRONT_END_HTTPS']) == 'on') {
+			return true;
+		}
+
+		if (!array_key_exists('HTTPS', $_SERVER)) {
             // not an https-request
             return false;
         }


### PR DESCRIPTION
These proxy headers are often set by reverse proxies, or web servers like nginx
that are capable of proxying requests to a backend application server that runs
SimpleSAMLphp.

I've marked this as 'not for merge' because theoretically anyone could set these
headers, and we want to make sure that they're only set by trusted proxies. I
propose using an environment variable to enumerate a list of trusted IP
addresses, and setting a define() with a boolean true/false for a quick check
point, e.g. `if(TRUSTED_PROXY && isset(...`, however I don't know how this
should be handled in the SimpleSAMLphp codebase.

Are there any thoughts on how this could be handled better? Ideally we wouldn't
hard-code things in config.php, because these would likely vary per-environment
(development environments may not have them, and trusted proxies are likely
different IP addresses in staging/pre-prod environments and production).

Any thoughts on how to solve this properly?