### PR TITLE
Avoid data-collision with memcache

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -763,6 +763,18 @@ $config = array(
         ),
     ),
 
+    /*
+     * This value is the name under which the data which the data should be
+     * stored in memcache. It defaults to 'simpleSAMLphp', which is fine
+     * in most cases.
+     *
+     * Change this value when you have multiple instances of SimpleSAMLphp
+     * running on the same host that all use memcache to avoid data
+     * collision.
+     *
+     */
+    'memcache_store.name' => null,
+
 
     /*
      * This value is the duration data should be stored in memcache. Data

--- a/lib/SimpleSAML/Store/Memcache.php
+++ b/lib/SimpleSAML/Store/Memcache.php
@@ -25,7 +25,10 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
 		assert('is_string($type)');
 		assert('is_string($key)');
 
-		return SimpleSAML_Memcache::get('simpleSAMLphp.' . $type . '.' . $key);
+		$config = SimpleSAML_Configuration::getInstance();
+		$name = $config->getString('memcache_store.name', 'simpleSAMLphp');
+
+		return SimpleSAML_Memcache::get($name . '.' . $type . '.' . $key);
 	}
 
 
@@ -46,7 +49,10 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
 			$expire = 0;
 		}
 
-		SimpleSAML_Memcache::set('simpleSAMLphp.' . $type . '.' . $key, $value, $expire);
+		$config = SimpleSAML_Configuration::getInstance();
+		$name = $config->getString('memcache_store.name', 'simpleSAMLphp');
+
+		SimpleSAML_Memcache::set($name . '.' . $type . '.' . $key, $value, $expire);
 	}
 
 


### PR DESCRIPTION
Avoid data-collision when running multiple instances of SSP on the same host that are all configured to use memcache