### PR TITLE
Avoid memcache data collision

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -763,6 +763,18 @@ $config = array(
         ),
     ),
 
+    /*
+     * This value is the name under which the data which the data should be
+     * stored in memcache. It defaults to 'simpleSAMLphp', which is fine
+     * in most cases.
+     *
+     * Change this value when you have multiple instances of SimpleSAMLphp
+     * running on the same host that all use memcache to avoid data
+     * collision.
+     *
+     */
+    'memcache_store.name' => null,
+
 
     /*
      * This value is the duration data should be stored in memcache. Data

--- a/lib/SimpleSAML/Store/Memcache.php
+++ b/lib/SimpleSAML/Store/Memcache.php
@@ -5,12 +5,13 @@
  *
  * @package simpleSAMLphp
  */
-class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
-
+class SimpleSAML_Store_Memcache extends SimpleSAML_Store
+{
 	/**
 	 * Initialize the memcache datastore.
 	 */
-	protected function __construct() {
+	protected function __construct()
+	{
 	}
 
 
@@ -21,7 +22,8 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
 	 * @param string $key  The key.
 	 * @return mixed|NULL  The value.
 	 */
-	public function get($type, $key) {
+	public function get($type, $key)
+	{
 		assert('is_string($type)');
 		assert('is_string($key)');
 
@@ -40,12 +42,13 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
 	 * @param mixed $value  The value.
 	 * @param int|NULL $expire  The expiration time (unix timestamp), or NULL if it never expires.
 	 */
-	public function set($type, $key, $value, $expire = NULL) {
+	public function set($type, $key, $value, $expire = null)
+	{
 		assert('is_string($type)');
 		assert('is_string($key)');
 		assert('is_null($expire) || (is_int($expire) && $expire > 2592000)');
 
-		if ($expire === NULL) {
+		if ($expire === null) {
 			$expire = 0;
 		}
 
@@ -62,11 +65,15 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
 	 * @param string $type  The datatype.
 	 * @param string $key  The key.
 	 */
-	public function delete($type, $key) {
+	public function delete($type, $key)
+	{
 		assert('is_string($type)');
 		assert('is_string($key)');
 
-		SimpleSAML_Memcache::delete('simpleSAMLphp.' . $type . '.' . $key);
+		$config = SimpleSAML_Configuration::getInstance();
+		$name = $config->getString('memcache_store.name', 'simpleSAMLphp');
+
+		SimpleSAML_Memcache::delete($name . '.' . $type . '.' . $key);
 	}
 
 }

--- a/lib/SimpleSAML/Store/Memcache.php
+++ b/lib/SimpleSAML/Store/Memcache.php
@@ -75,5 +75,4 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store
 
 		SimpleSAML_Memcache::delete($name . '.' . $type . '.' . $key);
 	}
-
 }

--- a/lib/SimpleSAML/Store/Memcache.php
+++ b/lib/SimpleSAML/Store/Memcache.php
@@ -25,7 +25,10 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
 		assert('is_string($type)');
 		assert('is_string($key)');
 
-		return SimpleSAML_Memcache::get('simpleSAMLphp.' . $type . '.' . $key);
+		$config = SimpleSAML_Configuration::getInstance();
+		$name = $config->getString('memcache_store.name', 'simpleSAMLphp');
+
+		return SimpleSAML_Memcache::get($name . '.' . $type . '.' . $key);
 	}
 
 
@@ -46,7 +49,10 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store {
 			$expire = 0;
 		}
 
-		SimpleSAML_Memcache::set('simpleSAMLphp.' . $type . '.' . $key, $value, $expire);
+		$config = SimpleSAML_Configuration::getInstance();
+		$name = $config->getString('memcache_store.name', 'simpleSAMLphp');
+
+		SimpleSAML_Memcache::set($name . '.' . $type . '.' . $key, $value, $expire);
 	}
 
 


### PR DESCRIPTION
Avoid memcache data collision when running multiple SSP instances on the same host