### PR TITLE
Corrected typo in core:show_metadata template

### DIFF
--- a/modules/core/templates/show_metadata.tpl.php
+++ b/modules/core/templates/show_metadata.tpl.php
@@ -7,7 +7,7 @@ $metadata['<?php echo $this->data['m']['metadata-index']; unset($this->data['m']
     echo htmlspecialchars(var_export($this->data['m'], true));
 ?>
 </pre>
-<p>[ <a href="<?php echo $this->data['blacklink']; ?>">back</a> ]</p>
+<p>[ <a href="<?php echo $this->data['backlink']; ?>">back</a> ]</p>
 
 <?php
 $this->includeAtTemplateBase('includes/footer.php'); 


### PR DESCRIPTION
There is a typo in `show_metadata.tpl.php` referencing the key "blacklink" when it is actually "backlink".