### PR TITLE
Added 'secure' session cookie option

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -366,6 +366,7 @@ $config = array(
     'session.phpsession.cookiename' => null,
     'session.phpsession.savepath' => null,
     'session.phpsession.httponly' => true,
+    'session.phpsession.secure' => true,
 
     /*
      * Option to override the default settings for the auth token cookie

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -234,6 +234,7 @@ class SimpleSAML_SessionHandlerPHP extends SimpleSAML_SessionHandler
         }
 
         $ret['httponly'] = $config->getBoolean('session.phpsession.httponly', true);
+        $ret['secure'] = $config->getBoolean('session.phpsession.secure', true);
 
         return $ret;
     }


### PR DESCRIPTION
Along with the `httponly` cookie option, the `secure` option is another good one to use.

https://www.owasp.org/index.php/SecureFlag