### PR TITLE
Fix multiauth selected source timeout

### DIFF
--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -149,7 +149,7 @@ class sspmod_multiauth_Auth_Source_MultiAuth extends SimpleSAML_Auth_Source {
 
 		/* Save the selected authentication source for the logout process. */
 		$session = SimpleSAML_Session::getSessionFromRequest();
-		$session->setData(self::SESSION_SOURCE, $state[self::AUTHID], $authId);
+		$session->setData(self::SESSION_SOURCE, $state[self::AUTHID], $authId, SimpleSAML_Session::DATA_TIMEOUT_SESSION_END);
 
 		try {
 			$as->authenticate($state);


### PR DESCRIPTION
By default, multiauth only stores the selected authentication source for the datastore length, which is 4 hours. The default session length is 8 hours. If you try logging out between the 4 and 8 hour marks, you will get an exception saying "Invalid authentication source during logout".

My fix is to store the auth source until session expiration when it won't be needed anymore.