### PR TITLE
Better handling of multi-line logs (e.g., with backtrace)

### DIFF
--- a/lib/SimpleSAML/Error/Error.php
+++ b/lib/SimpleSAML/Error/Error.php
@@ -211,7 +211,7 @@ class SimpleSAML_Error_Error extends SimpleSAML_Error_Exception
         $etrace = implode("\n", $data);
 
         $reportId = bin2hex(openssl_random_pseudo_bytes(4));
-        SimpleSAML_Logger::error('Error report with id '.$reportId.' generated.');
+        SimpleSAML_Logger::notice('Error report with id '.$reportId.' generated.');
 
         $config = SimpleSAML_Configuration::getInstance();
         $session = SimpleSAML_Session::getSessionFromRequest();

--- a/lib/SimpleSAML/Error/Exception.php
+++ b/lib/SimpleSAML/Error/Exception.php
@@ -182,10 +182,7 @@ class SimpleSAML_Error_Exception extends Exception
     public function logError()
     {
 
-        $lines = $this->format();
-        foreach ($lines as $line) {
-            SimpleSAML_Logger::error($line);
-        }
+        $this->log('error');
     }
 
 
@@ -197,10 +194,7 @@ class SimpleSAML_Error_Exception extends Exception
     public function logWarning()
     {
 
-        $lines = $this->format();
-        foreach ($lines as $line) {
-            SimpleSAML_Logger::warning($line);
-        }
+        $this->log('warning');
     }
 
 
@@ -212,10 +206,18 @@ class SimpleSAML_Error_Exception extends Exception
     public function logInfo()
     {
 
-        $lines = $this->format();
-        foreach ($lines as $line) {
-            SimpleSAML_Logger::debug($line);
-        }
+        $this->log('debug');
+    }
+
+
+    /**
+     * Abstracted logging method.
+     *
+     * @param string $level The log level (method to be called.)
+     */
+    private function log($level) {
+
+        SimpleSAML_Logger::$level($this->format());
     }
 
 
@@ -227,10 +229,7 @@ class SimpleSAML_Error_Exception extends Exception
     public function logDebug()
     {
 
-        $lines = $this->format();
-        foreach ($lines as $line) {
-            SimpleSAML_Logger::debug($line);
-        }
+        $this->log('debug');
     }
 
 

--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -350,8 +350,13 @@ class SimpleSAML_Logger
         }
 
         if (self::$logLevel >= $level || $statsLog) {
+            $raw_input = array($string);
             if (is_array($string)) {
+                $raw_input = $string;
                 $string = implode(",", $string);
+            }
+            if ((self::$format == 'json') && method_exists(self::$loggingHandler, 'setArray')) {
+                self::$loggingHandler->setArray($raw_input);
             }
 
             $formats = array('%trackid', '%msg', '%srcip', '%stat');


### PR DESCRIPTION
Hopefully this PR isn't too broad, but I've attempted to clean up some of the logging logic particularly when it comes to handling multi-line messages. Reading through the existing code, most messages destined for the log appear as $string, and a string is assumed, though the Logger's log() function includes an implode() if it's indeed passed an array.

I ship my logs off to an offsite log aggregation service, using rsyslog as an intermediary. Furthermore I like to package log messages as JSON, either in the application or with an rsyslog template. This PR is backwards-compatible with existing configurations but will result in only one "main" error message being logged, as opposed to the foreach() that was running which resulted in one log message per line. That can become a bit unwieldy with the backtrace.

If the logging service is syslog and the format is set to "json," the message is maintained as an array and is then JSON-encoded.

Also this downgrades the "Error report generated" message to a notice, since it is not itself the error, but simply a note about the logged error.

Includes some abstraction in Exception.php as the result of the removal of those foreach() loops.
