### PR TITLE
Added port to the LDAP base filter configuration

### DIFF
--- a/modules/ldap/lib/Auth/Process/BaseFilter.php
+++ b/modules/ldap/lib/Auth/Process/BaseFilter.php
@@ -137,6 +137,7 @@ abstract class sspmod_ldap_Auth_Process_BaseFilter extends SimpleSAML_Auth_Proce
 			$authconfig = array();
 			$authconfig['ldap.hostname']   = @$authsource['hostname'];
 			$authconfig['ldap.enable_tls'] = @$authsource['enable_tls'];
+			$authconfig['ldap.port']       = @$authsource['port'];
 			$authconfig['ldap.timeout']    = @$authsource['timeout'];
 			$authconfig['ldap.debug']      = @$authsource['debug'];
 			$authconfig['ldap.basedn']     = (@$authsource['search.enable'] ? @$authsource['search.base'] : NULL);


### PR DESCRIPTION
The base class for the LDAP auth process filters doesn't fetch the LDAP port from the auth source configuration. This causes a "Can't connect to LDAP server" type error when using an LDAP server (or tunnel) with a port other than the default 389.