### PR TITLE
sqlite3 tests require the ext-sqlite3 module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "whitehat101/apr1-md5": "~1.0"
     },
     "require-dev": {
+        "ext-sqlite3": "*",
         "phpunit/phpunit": "~3.7",
         "satooshi/php-coveralls": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "whitehat101/apr1-md5": "~1.0"
     },
     "require-dev": {
-        "ext-sqlite3": "*",
+        "ext-pdo_sqlite": "*",
         "phpunit/phpunit": "~3.7",
         "satooshi/php-coveralls": "^1.0"
     },


### PR DESCRIPTION
add sqlite3 as a dev dependency. you might not notice this when running
tests locally otherwise.