### PR TITLE
detect SSL through proxy servers or load balancers

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -73,6 +73,11 @@ class HTTP
      */
     private static function getServerHTTPS()
     {
+        // if the request came through a SSL terminated proxy or load balancer
+        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+            return true;
+        }
+
         if (!array_key_exists('HTTPS', $_SERVER)) {
             // not an https-request
             return false;


### PR DESCRIPTION
This pull request allows detecting SSL when running through a load balancer or proxy server.

It uses the standard X-Forwarded-Proto header to determine SSL termination.