### PR TITLE
Fix missing argument

### DIFF
--- a/modules/negotiate/lib/Auth/Source/Negotiate.php
+++ b/modules/negotiate/lib/Auth/Source/Negotiate.php
@@ -333,7 +333,7 @@ EOF;
         if (!$this->ldap->bind($this->admin_user, $this->admin_pw)) {
             $msg = 'Unable to authenticate system user (LDAP_INVALID_CREDENTIALS) '.var_export($this->admin_user, true);
             SimpleSAML_Logger::error('Negotiate - authenticate(): '.$msg);
-            throw new SimpleSAML_Error_AuthSource($msg);
+            throw new SimpleSAML_Error_AuthSource('negotiate', $msg);
         }
     }
 


### PR DESCRIPTION
This fixes:
[Tue Feb 16 13:50:09 2016] [error] [client 10.48.224.4] PHP Warning:  Missing argument 2 for SimpleSAML_Error_AuthSource::__construct(), called in /apps/simplesamlphp-bd-1.14.0/modules/negotiate/lib/Auth/Source/Negotiate.php on line 336 
[Tue Feb 16 13:50:09 2016] [error] [client 10.48.224.4] PHP Notice:  Undefined variable: reason in /apps/simplesamlphp-bd-1.14.0/lib/SimpleSAML/Error/AuthSource.php(31)