### PR TITLE
Expose RegistrationInfo in parsed metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .gitignore
 log
 config
-metadata
+./metadata
 cert
 
 !config/.gitkeep

--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -124,6 +124,11 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private $entityAttributes;
 
+    /**
+     * An associative array of attributes from the RegistrationInfo element.
+     * @var array
+     */
+    private $registrationInfo;
 
     /**
      * @var array
@@ -180,6 +185,7 @@ class SimpleSAML_Metadata_SAMLParser
         $this->scopes = $ext['scope'];
         $this->tags = $ext['tags'];
         $this->entityAttributes = $ext['EntityAttributes'];
+        $this->registrationInfo = $ext['RegistrationInfo'];
 
         // look over the RoleDescriptors
         foreach ($entityElement->RoleDescriptor as $child) {
@@ -484,6 +490,11 @@ class SimpleSAML_Metadata_SAMLParser
         $tags = array_merge($this->tags, array_diff($roleDescriptor['tags'], $this->tags));
         if (!empty($tags)) {
             $metadata['tags'] = $tags;
+        }
+
+
+        if (!empty($this->registrationInfo)) {
+            $metadata['RegistrationInfo'] = $this->registrationInfo;
         }
 
         if (!empty($this->entityAttributes)) {
@@ -993,6 +1004,7 @@ class SimpleSAML_Metadata_SAMLParser
             'scope'            => array(),
             'tags'             => array(),
             'EntityAttributes' => array(),
+            'RegistrationInfo' => array(),
             'UIInfo'           => array(),
             'DiscoHints'       => array(),
         );
@@ -1006,6 +1018,9 @@ class SimpleSAML_Metadata_SAMLParser
 
             // Entity Attributes are only allowed at entity level extensions and not at RoleDescriptor level
             if ($element instanceof SAML2_XML_md_EntityDescriptor) {
+                if ($e instanceof SAML2_XML_mdrpi_RegistrationInfo) {
+                    $ret['RegistrationInfo']['registrationAuthority'] = $e->registrationAuthority;
+                }
                 if ($e instanceof SAML2_XML_mdattr_EntityAttributes && !empty($e->children)) {
                     foreach ($e->children as $attr) {
                         // only saml:Attribute are currently supported here. The specifications also allows

--- a/tests/lib/SimpleSAML/Metadata/SAMLBuilderTest.php
+++ b/tests/lib/SimpleSAML/Metadata/SAMLBuilderTest.php
@@ -8,7 +8,7 @@ class SimpleSAML_Metadata_SAMLBuilderTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * Test the requeste attributes are valued correctly.
+     * Test the requested attributes are valued correctly.
      */
     public function testAttributes()
     {

--- a/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace SimpleSAML\Metadata;
+
+/**
+ * Test SAML parsing
+ */
+class SAMLParserTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test Registration Info is parsed
+     */
+    public function testRegistrationInfo()
+    {
+        $expected = array(
+            'registrationAuthority' => 'https://incommon.org',
+        );
+
+        $document = \SAML2_DOMDocumentFactory::fromString(
+            <<<XML
+<EntityDescriptor entityID="theEntityID"
+ xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+  <Extensions>
+    <mdrpi:RegistrationInfo registrationAuthority="https://incommon.org"/>
+     </Extensions>
+  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+  </SPSSODescriptor>
+</EntityDescriptor>
+XML
+        );
+
+
+        $entities = \SimpleSAML_Metadata_SAMLParser::parseDescriptorsElement($document->documentElement);
+        $this->assertArrayHasKey('theEntityID', $entities);
+        // RegistrationInfo is accessible in the SP or IDP metadata accessors
+        $this->assertEquals($expected, $entities['theEntityID']->getMetadata20SP()['RegistrationInfo']);
+
+    }
+}

--- a/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
@@ -33,7 +33,8 @@ XML
         $entities = \SimpleSAML_Metadata_SAMLParser::parseDescriptorsElement($document->documentElement);
         $this->assertArrayHasKey('theEntityID', $entities);
         // RegistrationInfo is accessible in the SP or IDP metadata accessors
-        $this->assertEquals($expected, $entities['theEntityID']->getMetadata20SP()['RegistrationInfo']);
+        $metadata = $entities['theEntityID']->getMetadata20SP();
+        $this->assertEquals($expected, $metadata['RegistrationInfo']);
 
     }
 }


### PR DESCRIPTION
- Add test case
- Fix .gitignore since it ignored all metadata folders

Based on https://github.com/simplesamlphp/simplesamlphp/pull/288#discussion-diff-53787274