### PR TITLE
Add attribute mappings for eduPersonUniqueId

### DIFF
--- a/attributemap/name2oid.php
+++ b/attributemap/name2oid.php
@@ -54,6 +54,7 @@ $attributemap = array(
     'eduPersonPrincipalName'        => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6',
     'eduPersonScopedAffiliation'    => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.9',
     'eduPersonTargetedID'           => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.10',
+    'eduPersonUniqueId'             => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13',
     'email'                         => 'urn:oid:1.2.840.113549.1.9.1',
     'emailAddress'                  => 'urn:oid:1.2.840.113549.1.9.1',
     'employeeNumber'                => 'urn:oid:2.16.840.1.113730.3.1.3',

--- a/attributemap/name2urn.php
+++ b/attributemap/name2urn.php
@@ -54,6 +54,7 @@ $attributemap = array(
     'eduPersonPrincipalName'        => 'urn:mace:dir:attribute-def:eduPersonPrincipalName',
     'eduPersonScopedAffiliation'    => 'urn:mace:dir:attribute-def:eduPersonScopedAffiliation',
     'eduPersonTargetedID'           => 'urn:mace:dir:attribute-def:eduPersonTargetedID',
+    'eduPersonUniqueId'             => 'urn:mace:dir:attribute-def:eduPersonUniqueId',
     'email'                         => 'urn:mace:dir:attribute-def:email',
     'emailAddress'                  => 'urn:mace:dir:attribute-def:emailAddress',
     'employeeNumber'                => 'urn:mace:dir:attribute-def:employeeNumber',

--- a/attributemap/oid2name.php
+++ b/attributemap/oid2name.php
@@ -66,6 +66,7 @@ $attributemap = array(
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.1'   => 'eduPersonAffiliation',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.11'  => 'eduPersonAssurance',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.10'  => 'eduPersonTargetedID',
+    'urn:oid:1.3.6.1.4.1.5923.1.1.1.13'  => 'eduPersonUniqueId',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.2'   => 'eduPersonNickname',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.3'   => 'eduPersonOrgDN',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.4'   => 'eduPersonOrgUnitDN',

--- a/attributemap/oid2urn.php
+++ b/attributemap/oid2urn.php
@@ -66,6 +66,7 @@ $attributemap = array(
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.1'   => 'urn:mace:dir:attribute-def:eduPersonAffiliation',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.11'  => 'urn:mace:dir:attribute-def:eduPersonAssurance',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.10'  => 'urn:mace:dir:attribute-def:eduPersonTargetedID',
+    'urn:oid:1.3.6.1.4.1.5923.1.1.1.13'  => 'urn:mace:dir:attribute-def:eduPersonUniqueId',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.2'   => 'urn:mace:dir:attribute-def:eduPersonNickname',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.3'   => 'urn:mace:dir:attribute-def:eduPersonOrgDN',
     'urn:oid:1.3.6.1.4.1.5923.1.1.1.4'   => 'urn:mace:dir:attribute-def:eduPersonOrgUnitDN',

--- a/attributemap/urn2name.php
+++ b/attributemap/urn2name.php
@@ -54,6 +54,7 @@ $attributemap = array(
     'urn:mace:dir:attribute-def:eduPersonPrincipalName'           => 'eduPersonPrincipalName',
     'urn:mace:dir:attribute-def:eduPersonScopedAffiliation'       => 'eduPersonScopedAffiliation',
     'urn:mace:dir:attribute-def:eduPersonTargetedID'              => 'eduPersonTargetedID',
+    'urn:mace:dir:attribute-def:eduPersonUniqueId'                => 'eduPersonUniqueId',
     'urn:mace:dir:attribute-def:email'                            => 'email',
     'urn:mace:dir:attribute-def:emailAddress'                     => 'emailAddress',
     'urn:mace:dir:attribute-def:employeeNumber'                   => 'employeeNumber',

--- a/attributemap/urn2oid.php
+++ b/attributemap/urn2oid.php
@@ -54,6 +54,7 @@ $attributemap = array(
     'urn:mace:dir:attribute-def:eduPersonPrincipalName'           => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6',
     'urn:mace:dir:attribute-def:eduPersonScopedAffiliation'       => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.9',
     'urn:mace:dir:attribute-def:eduPersonTargetedID'              => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.10',
+    'urn:mace:dir:attribute-def:eduPersonUniqueId'                => 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13',
     'urn:mace:dir:attribute-def:email'                            => 'urn:oid:1.2.840.113549.1.9.1',
     'urn:mace:dir:attribute-def:emailAddress'                     => 'urn:oid:1.2.840.113549.1.9.1',
     'urn:mace:dir:attribute-def:employeeNumber'                   => 'urn:oid:2.16.840.1.113730.3.1.3',

--- a/dictionaries/attributes.definition.json
+++ b/dictionaries/attributes.definition.json
@@ -50,6 +50,9 @@
 	"attribute_edupersonprincipalname": {
 		"en": "Person's principal name at home organization"
 	},
+	"attribute_edupersonuniqueid": {
+		"en": "Person's non-reassignable, persistent pseudonymous ID at home organization"
+	},
 	"attribute_o": {
 		"en": "Organization name"
 	},


### PR DESCRIPTION
This adds the attribute mappings for [eduPersonUniqueId](http://software.internet2.edu/eduperson/internet2-mace-dir-eduperson-201310.html#eduPersonUniqueId) (defined in eduPerson 201305).

Should I include the commit for the definition of `attribute_edupersonuniqueid` in this PR or you prefer a separate one?