### PR TITLE
AllowCreate is hardcoded

### DIFF
--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -402,10 +402,16 @@ class sspmod_saml_Message {
 			$nameIdPolicy = $spMetadata->getString('NameIDFormat', SAML2_Const::NAMEID_TRANSIENT);
 		}
 
+		if ($spMetadata->hasValue('AllowCreatePolicy')) {
+			$allowCreatePolicy = $spMetadata->getBoolean('AllowCreatePolicy', TRUE);
+		} else {
+			$allowCreatePolicy = TRUE;
+		}
+
 		if ($nameIdPolicy !== NULL) {
 			$ar->setNameIdPolicy(array(
 				'Format' => $nameIdPolicy,
-				'AllowCreate' => TRUE,
+				'AllowCreate' => $allowCreatePolicy,
 			));
 		}
 


### PR DESCRIPTION
This PR allows you to set AllowCreatePolicy (values TRUE or FALSE) in a Service Provider configured in the authsources.php. For example: 

> 'taxnotes-dev' => array(
        'saml:SP',
        'certificate' => 'D...',
        'entityID' => 'X...',
        'AllowCreatePolicy' => FALSE,
        'NameIDPolicy' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
    ),

Which will look like: 

>  < samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" AllowCreate="false" />


This is the second step in allowing Service Providers to configure the AllowCreate propriety in the NameIdPolicy in order to meet some IdP's specifications.

In order for this patch to work, this PR has to be accepted:  [SAML2](https://github.com/simplesamlphp/saml2/pull/63). The [SAML2 library](https://github.com/simplesamlphp/saml2/blob/master/src/SAML2/AuthnRequest.php) makes a validation for the AllowCreate property which does not accept anything but 'true'.

This is a use case I faced while implementing SSO for the [SPNEGO](https://en.wikipedia.org/wiki/SPNEGO) Identity Provider. 

Due the SPNEGO's specification you cannot logout a SPNEGO user gracefully **and** when trying to login again(after the user logs out) the user will get an exception. Therefore, it is necesary to send “allowcreate=false” in the SAML request token in order to let the SPNEGO IdP know that it is 'OK' to not refresh/try to authenticate the user in every SAML insertion.

Note: I'm creating this PR against the 1.13 version since I have only fully tested this version. 1.14/master seems to be a candidate for this 'enhancement'.