### PR TITLE
Bugfix for empty attributes array

### DIFF
--- a/modules/negotiate/lib/Auth/Source/Negotiate.php
+++ b/modules/negotiate/lib/Auth/Source/Negotiate.php
@@ -151,7 +151,7 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
                 $user = $auth->getAuthenticatedUser();
                 SimpleSAML\Logger::info('Negotiate - authenticate(): '.$user.' authenticated.');
                 $lookup = $this->lookupUserData($user);
-                if ($lookup) {
+                if ($lookup || $lookup === Array()) {
                     $state['Attributes'] = $lookup;
                     // Override the backend so logout will know what to look for
                     $state['LogoutState'] = array(

--- a/modules/negotiate/lib/Auth/Source/Negotiate.php
+++ b/modules/negotiate/lib/Auth/Source/Negotiate.php
@@ -116,9 +116,9 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
             assert('FALSE');
         }
 
-        SimpleSAML\Logger::debug('Negotiate - authenticate(): looking for Negotate');
+        SimpleSAML\Logger::debug('Negotiate - authenticate(): looking for Negotiate');
         if (!empty($_SERVER['HTTP_AUTHORIZATION'])) {
-            SimpleSAML\Logger::debug('Negotiate - authenticate(): Negotate found');
+            SimpleSAML\Logger::debug('Negotiate - authenticate(): Negotiate found');
             $this->ldap = new SimpleSAML_Auth_LDAP(
                 $this->hostname,
                 $this->enableTLS,


### PR DESCRIPTION
An empty array shouldn't lead to an aborted logon.
Example when we try to get the 'mail' attribute:
UserA has a value set in the mail-attribute and passes the test -> Negotiate logon succeeds
UserB has an empty mail-attribute and fails the test -> Negotiate logon fails and the user has to log on manually (fallback to LDAP is initiated)