### PR TITLE
Crude translation

### DIFF
--- a/dictionaries/login.translation.json
+++ b/dictionaries/login.translation.json
@@ -296,7 +296,7 @@
 		"es": "&iexcl;Muy mal! - Sin su nombre de usuario y su clave de acceso usted no se puede identificar y acceder al servicio. A lo mejor hay alguien que puede ayudarle. &iexcl;P&oacute;ngase en contacto con el centro de ayuda de su universidad!",
 		"fr": "Pas de chance! Sans votre identifiant et votre mot de passe vous ne pouvez pas vous authentifier et acc\u00e9der au service. Il y a peut-\u00eatre quelqu'un pour vous aider.  Contactez le help desk de votre universit\u00e9!",
 		"de": "Tut uns leid - Ohne Nutzername und Passwort k\u00f6nnen Sie sich nicht authentifizieren und somit den Dienst nicht nutzen. M\u00f6glicherweise kann ihnen jemand helfen, kontaktieren Sie dazu den Helpdesk ihrer Einrichtung.",
-		"nl": "Vette pech! - Zonder je gebruikersnaam en wachtwoord kun je je niet authenticeren en dus niet gebruikmaken van deze dienst.",
+		"nl": "Zonder je gebruikersnaam en wachtwoord kun je je niet authenticeren en dus niet gebruikmaken van deze dienst.",
 		"lb": "Pesch gehaat! - Ouni aeren Benotzernumm an d'Passwuert k\u00ebnn der aerch net authentifiz\u00e9iren an op den Service zougraiffen.",
 		"sl": "\u017dal se brez uporabni\u0161kega imena in gesla ne morete prijaviti in uporabljati storitev.",
 		"da": "Desv\u00e6rre, uden korrekt brugernavn og kodeord kan du ikke f\u00e5 adgang til tjenesten. M\u00e5ske kan help-desk p\u00e5 din hjemmeinstitution hj\u00e6lpe dig!",


### PR DESCRIPTION
"Vette pech" (fat chance) appears to offend some of our users. The translations for these seem to vary wildly:
* dr: "pas de chance" (no luck)
* de: "Tut uns leid" (we are sorry)
* it, da,... : this part is left out. This is the best option in my opinion.