### PR TITLE
fix issue CAS authentication source LDAP binding failure. #366

### DIFF
--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -605,7 +605,9 @@ class SimpleSAML_Auth_LDAP {
          * These characters are escaped by prefixing them with '\'.
          */
         $username = addcslashes($username, ',+"\\<>;*');
-        $password = addcslashes($password, ',+"\\<>;*');
+        if ($password !== null) {
+            $password = addcslashes($password, ',+"\\<>;*');
+        }
 
         if (isset($config['priv_user_dn'])) {
             $this->bind($config['priv_user_dn'], $config['priv_user_pw']);


### PR DESCRIPTION
Added check in ldap validate to check if password is null before it runs addcslashes so it does not get converted to a empty string.