### PR TITLE
Allow regular expression matching of trusted.url.domains.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -105,6 +105,17 @@ $config = array(
     'trusted.url.domains' => array(),
 
     /*
+     * Enable regular expression matching of trusted.url.domains.
+     *
+     * Set to true to treat the values in trusted.url.domains as regular
+     * expressions. Set to false to do exact string matching.
+     *
+     * If enabled, the start and end delimiters ('^' and '$') will be added to
+     * all regular expressions in trusted.url.domains.
+     */
+    'trusted.url.regex' => false,
+
+    /*
      * Enable secure POST from HTTPS to HTTP.
      *
      * If you have some SP's on HTTP and IdP is normally on HTTPS, this option

--- a/docs/simplesamlphp-changelog.txt
+++ b/docs/simplesamlphp-changelog.txt
@@ -32,6 +32,7 @@ Released TBD
   * Added the SAML NameID to the attributes status page, when available.
   * Added attribute definitions for schacGender (schac), sisSchoolGrade and sisLegalGuardianFor (skolfederation.se).
   * Attributes required in metadata are now taken into account when parsing.
+  * Allow regular expression matching of trusted.url.domains. Off by default, set trusted.url.regex to true to enable.
 
 ### Bug fixes
 


### PR DESCRIPTION
Fixes #379