### PR TITLE
fix cas ldap configuration

### DIFF
--- a/modules/cas/lib/Auth/Source/CAS.php
+++ b/modules/cas/lib/Auth/Source/CAS.php
@@ -177,8 +177,18 @@ class sspmod_cas_Auth_Source_CAS  extends SimpleSAML_Auth_Source  {
 		$service =  SimpleSAML\Module::getModuleURL('cas/linkback.php', array('stateID' => $stateID));
 		list($username, $casattributes) = $this->casValidation($ticket, $service);
 		$ldapattributes = array();
+
+		$config = SimpleSAML_Configuration::loadFromArray($this->_ldapConfig, 'Authentication source ' . var_export($this->authId, TRUE));
+
 		if ($this->_ldapConfig['servers']) {
-			$ldap = new SimpleSAML_Auth_LDAP($this->_ldapConfig['servers'], $this->_ldapConfig['enable_tls']);
+			$ldap = new SimpleSAML_Auth_LDAP(
+                $config->getString('servers'),
+                $config->getBoolean('enable_tls', FALSE),
+                $config->getBoolean('debug', FALSE),
+                $config->getInteger('timeout', 0),
+                $config->getInteger('port', 389),
+                $config->getBoolean('referrals', TRUE)
+            );
 			$ldapattributes = $ldap->validate($this->_ldapConfig, $username);
 		}
 		$attributes = array_merge_recursive($casattributes, $ldapattributes);


### PR DESCRIPTION
This is meant to fix an issue where not all LDAP configuration attributes are applied when using CAS ldap configuration. Most importantly is the referrals attribute which makes ldap lookups against Active Directory fail if set to TRUE. 

Example CAS authsource:

``` php
'cas' => array(
        'cas:CAS',
        'cas' => array(
                'login' => 'https://cas.example.com/login',
                'validate' => 'https://cas.example.com/validate',
                'logout' => 'https://cas.example.com/logout'
        ),
        'ldap' => array(
                'servers' => 'ldaps://ad.example.com',
                'referrals' => FALSE,
                'enable_tls' => TRUE,
                'searchbase' => 'DC=ad,DC=example,DC=com',
                'searchattributes' => 'sAMAccountName',
                'attributes' => array('sAMAccountName', 'mail', 'memberOf'),
                'priv_user_dn' => 'user@example.com',
                'priv_user_pw' => 'password',
        ),
),
```
# 

Using the existing SimpleSAML_Configuration class, I have included the available arguments for the  SimpleSAML_Auth_LDAP constructor.

This is similar to how the ldap module is currently setting its arguments for the  SimpleSAML_Auth_LDAP constructor.
