### PR TITLE
Added OpenLDAP case for UserGroups

### DIFF
--- a/modules/ldap/docs/ldap.txt
+++ b/modules/ldap/docs/ldap.txt
@@ -451,13 +451,15 @@ a listing of all configuration options and their details.
 		 * that most products have a special query to recursively search
 		 * group membership.
 		 *
-		 * Note: Only ActiveDirectory is currently supported.
+		 * Note: Only ActiveDirectory is currently supported 
+		 * (OpenLDAP is implemented but not supported, see example below).
 		 *
 		 * Default: ''
 		 * Required: No
 		 */
 		'ldap.product' => '',
 		'ldap.product' => 'ActiveDirectory',
+		'ldap.product' => 'OpenLDAP',
 
 
 		/**
@@ -548,3 +550,14 @@ required, see the config info above for details.
 		'ldap.basedn' => 'DC=example,DC=org'
 	)
 
+Example for unsupported OpenLDAP usage. 
+Intention is to filter in 'ou=groups,dc=example,dc=com' for 
+'(memberUid = <UID>)' and take only the attributes 'cn' (=name of the group).
+
+    50 => array(
+        'class' => 'ldap:AttributeAddUsersGroups',
+        'ldap.product' => 'OpenLDAP',
+        'ldap.basedn' => 'ou=groups,dc=example,dc=org',
+        'attribute.member' => 'cn',
+        'attribute.memberof' => 'memberUid',
+    ),


### PR DESCRIPTION
This lines make it possible that the group membership information from an OpenLDAP server can be added as authproc filter. The example is more generally and should work for a basic OpenLDAP setup (at least it is compatbile with our 4 different OpenLDAP servers). It works for us (we use it) but we can't support it.
