### PR TITLE
Fix issue with Facebook authentication retrieving only user id and name

### DIFF
--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -201,6 +201,10 @@ $config = array(
         // which additional data permissions to request from user
         // see http://developers.facebook.com/docs/authentication/permissions/ for the full list
         // 'req_perms' => 'email,user_birthday',
+        // Which additional user profile fields to request.
+        // When empty, only the app-specific user id and name will be returned
+        // See https://developers.facebook.com/docs/graph-api/reference/v2.6/user for the full list
+        // 'user_fields' => 'email,birthday,third_party_id,name,first_name,last_name',
     ),
     */
 

--- a/modules/authfacebook/lib/Auth/Source/Facebook.php
+++ b/modules/authfacebook/lib/Auth/Source/Facebook.php
@@ -40,6 +40,21 @@ class sspmod_authfacebook_Auth_Source_Facebook extends SimpleSAML_Auth_Source {
 
 
 	/**
+	 * A comma-separated list of user profile fields to request.
+	 *
+	 * Note that some user fields require appropriate permissions. For
+	 * example, to retrieve the user's primary email address, "email" must
+	 * be specified in both the req_perms and the user_fields parameter.
+	 *
+	 * When empty, only the app-specific user id and name will be returned.
+	 *
+	 * See the Graph API specification for all available user fields:
+	 * https://developers.facebook.com/docs/graph-api/reference/v2.6/user
+	 */
+	private $user_fields;
+
+
+	/**
 	 * Constructor for this authentication source.
 	 *
 	 * @param array $info  Information about this authentication source.
@@ -57,6 +72,7 @@ class sspmod_authfacebook_Auth_Source_Facebook extends SimpleSAML_Auth_Source {
 		$this->api_key = $cfgParse->getString('api_key');
 		$this->secret = $cfgParse->getString('secret');
 		$this->req_perms = $cfgParse->getString('req_perms', NULL);
+		$this->user_fields = $cfgParse->getString('user_fields', NULL);
 	}
 
 
@@ -91,7 +107,7 @@ class sspmod_authfacebook_Auth_Source_Facebook extends SimpleSAML_Auth_Source {
 
 		if (isset($uid) && $uid) {
 			try {
-				$info = $facebook->api("/" . $uid);
+				$info = $facebook->api("/" . $uid . ($this->user_fields ? "?fields=" . $this->user_fields : ""));
 			} catch (FacebookApiException $e) {
 				throw new SimpleSAML_Error_AuthSource($this->authId, 'Error getting user profile.', $e);
 			}
@@ -108,8 +124,8 @@ class sspmod_authfacebook_Auth_Source_Facebook extends SimpleSAML_Auth_Source {
 			}
 		}
 
-		if (array_key_exists('username', $info)) {
-			$attributes['facebook_user'] = array($info['username'] . '@facebook.com');
+		if (array_key_exists('third_party_id', $info)) {
+			$attributes['facebook_user'] = array($info['third_party_id'] . '@facebook.com');
 		} else {
 			$attributes['facebook_user'] = array($uid . '@facebook.com');
 		}


### PR DESCRIPTION
As of Facebook Graph API v2.4, the returned user object only contains the `id` and `name`. As a result you need to specify in the request url which additional fields you want the API to return. Effectively, the `/{user-id}` call should become `/{user-id}?fields=email,first_name,etc..`.

This PR adds the `user_fields` option to the authfacebook module configuration:
```
/**
 * A comma-separated list of user profile fields to request.
 *
 * Note that some user fields require appropriate permissions. For
 * example, to retrieve the user's primary email address, "email" must
 * be specified in both the req_perms and the user_fields parameter.
 *
 * When empty, only the app-specific user id and name will be returned.
 *
 * See the Graph API specification for all available user fields:
 * https://developers.facebook.com/docs/graph-api/reference/v2.6/user
 */
private $user_fields;
```

Also note that the `username` field is no longer part of the Facebook user object. The `third_party_id` property is the closest alternative, i.e. 

> A string containing an anonymous, but unique identifier for the person. You can use this identifier with third parties 

As such, the `facebook_user` attribute is now based on the  `third_party_id` (if available) and in conjunction with facebook2name filter this will become the user's ePPN. Ideally, this should be mapped to an eduPersonUniqueId which is also opaque. However, a `third_party_id` string can contain non alphanumeric characters which are not permitted in the uid portion of an ePUID. The plain `id` property on the other hand is app-specific so the ePTID is the right place for it. That being said, my question is whether authfacebook should continue constructing ePPNs based on the plain `id` in the absence of the `third_party_id`. What do you think?

Reported issue #320 might be related to this PR, although not getting the user's email address could be due to the `email` permission missing from the `req_perms` config.