### PR TITLE
Use REQUEST_URI instead of SCRIPT_PATH to build the URL without params

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -739,10 +739,8 @@ class HTTP
     public static function getSelfURLNoQuery()
     {
         $url = self::getSelfURLHost();
-        $url .= $_SERVER['SCRIPT_NAME'];
-        if (isset($_SERVER['PATH_INFO'])) {
-            $url .= $_SERVER['PATH_INFO'];
-        }
+        $url .= strtok($_SERVER["REQUEST_URI"], '?');
+
         return $url;
     }
 


### PR DESCRIPTION
In some cases (ie : rewriting URLs with Apache2), the script path and URL can be different, which means that HTTP::getSelfURLNoQuery() returns the wrong URL.

Using REQUEST_URI instead of SCRIPT_PATH and PATH_INFO seems more reliable and is consistent with the HTTP::getSelfURL() method.