### PR TITLE
add some checks to prevent appending to SCRIPT_NAME when it isn't nec…

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -742,11 +742,13 @@ class HTTP
         $url .= $_SERVER['SCRIPT_NAME'];
 
         /* In some environments, $_SERVER['SCRIPT_NAME'] already ends with $_SERVER['PATH_INFO'].
-         * Only append $_SERVER['PATH_INFO'] if it's set and missing.
+         * Only append $_SERVER['PATH_INFO'] if it's set and missing from script name.
          */
-        $end = substr($_SERVER['SCRIPT_NAME'], 0 - strlen($_SERVER['PATH_INFO']));
-        if (isset($_SERVER['PATH_INFO']) && ( $end !== $_SERVER['PATH_INFO'])) {
-            $url .= $_SERVER['PATH_INFO'];
+        if (isset($_SERVER['PATH_INFO'])) {
+            $end = substr($_SERVER['SCRIPT_NAME'], 0 - strlen($_SERVER['PATH_INFO']));
+            if ( $end !== $_SERVER['PATH_INFO'] ) {
+                $url .= $_SERVER['PATH_INFO'];
+            }
         }
         return $url;
     }

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -740,7 +740,12 @@ class HTTP
     {
         $url = self::getSelfURLHost();
         $url .= $_SERVER['SCRIPT_NAME'];
-        if (isset($_SERVER['PATH_INFO'])) {
+
+        /* In some environments, $_SERVER['SCRIPT_NAME'] already ends with $_SERVER['PATH_INFO'].
+         * Only append $_SERVER['PATH_INFO'] if it's set and missing.
+         */
+        $end = substr($_SERVER['SCRIPT_NAME'], 0 - strlen($_SERVER['PATH_INFO']));
+        if (isset($_SERVER['PATH_INFO']) && ( $end !== $_SERVER['PATH_INFO'])) {
             $url .= $_SERVER['PATH_INFO'];
         }
         return $url;

--- a/www/module.php
+++ b/www/module.php
@@ -123,7 +123,15 @@ try {
 
     if (preg_match('#\.php$#D', $path)) {
         // PHP file - attempt to run it
-        $_SERVER['SCRIPT_NAME'] .= '/'.$module.'/'.$url;
+
+        /* In some environments, $_SERVER['SCRIPT_NAME'] is already set with the full url.
+         * Check for that case, and append script name only if necessary.
+         */
+        $script = "/$module/$url";
+        if (stripos($_SERVER['SCRIPT_NAME'], $script) === false) {
+            $_SERVER['SCRIPT_NAME'] .= '/'.$module.'/'.$url;
+        }
+
         require($path);
         exit();
     }


### PR DESCRIPTION
…essary

This PR address issue #5 in what is hopefully a compatible way. As mentioned in my comment on that issue, certain environments populate `$_SERVER['SCRIPT_NAME']` differently, so this patch will check that variable before appending to it.