### PR TITLE
Fix PHP notices "Undefined index" in as_login.php.

### DIFF
--- a/modules/core/www/as_login.php
+++ b/modules/core/www/as_login.php
@@ -6,11 +6,11 @@
  * @package SimpleSAMLphp
  */
 
-if (!is_string($_REQUEST['ReturnTo'])) {
+if (!isset($_REQUEST['ReturnTo'])) {
 	throw new SimpleSAML_Error_BadRequest('Missing ReturnTo parameter.');
 }
 
-if (!is_string($_REQUEST['AuthId'])) {
+if (!isset($_REQUEST['AuthId'])) {
 	throw new SimpleSAML_Error_BadRequest('Missing AuthId parameter.');
 }
 


### PR DESCRIPTION
Sometimes appear in error logs as:

PHP Notice:  Undefined index: ReturnTo in .../modules/core/www/as_login.php on line 9
PHP Notice:  Undefined index: AuthId in .../modules/core/www/as_login.php on line 13