### PR TITLE
Allow the optional Subject NameID to be set in a SAML AuthnRequest

### DIFF
--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -52,6 +52,13 @@ All these parameters override the equivalent option from the configuration.
 
 :   *Note*: SAML 2 specific.
 
+`saml:NameID`
+:   Add a Subject element with a NameID to the SAML AuthnRequest for the IdP.
+    This is an associative array with the fields for the NameID.
+    Example: `array('Value' => 'user@example.org', 'Format' => SAML2_Const::NAMEID_UNSPECIFIED)`
+
+:   *Note*: SAML 2 specific.
+
 
 Authentication data
 -------------------

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -205,6 +205,13 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 			$ar->setIsPassive((bool)$state['isPassive']);
 		}
 
+		if (isset($state['saml:NameID'])) {
+			if (!is_array($state['saml:NameID'])) {
+				throw new SimpleSAML_Error_Exception('Invalid value of $state[\'saml:NameID\'].');
+			}
+			$ar->setNameId($state['saml:NameID']);
+		}
+
 		if (isset($state['saml:NameIDPolicy'])) {
 			if (is_string($state['saml:NameIDPolicy'])) {
 				$policy = array(


### PR DESCRIPTION
Add "saml:NameID" option for use with SimpleSAML_Auth_Simple that allows the Subject NameID to be set in a SAML AuthnRequest.