### PR TITLE
Show a user friendly error page

### DIFF
--- a/modules/core/www/authenticate.php
+++ b/modules/core/www/authenticate.php
@@ -23,13 +23,11 @@ if (array_key_exists(SimpleSAML_Auth_State::EXCEPTION_PARAM, $_REQUEST)) {
     $state = SimpleSAML_Auth_State::loadExceptionState();
     assert('array_key_exists(SimpleSAML_Auth_State::EXCEPTION_DATA, $state)');
     $e = $state[SimpleSAML_Auth_State::EXCEPTION_DATA];
-
-    header('Content-Type: text/plain');
-    echo "Exception during login:\n";
-    foreach ($e->format() as $line) {
-        echo $line."\n";
-    }
-    exit(0);
+    
+    // Log the exception with the usage of SimpleSAML_Error_Error and show a
+	// styled error page.
+	SimpleSAML_exception_handler($e);
+	// The implemenation of SimpleSAML_exception_handler will invoke exit
 }
 
 if (!$as->isAuthenticated()) {


### PR DESCRIPTION
The authenticate.php file checks for the presence of the an exception within the state. If this is present the exception is formatted for logging and shown as plain text to the end user.

This has several disadvantages:
- The end user doesn't receive a user friendly error page.
- The exception is not logged within the authenticate.php
- Internal directory structure is exposed

For an example of such an situation/error see:
http://stackoverflow.com/questions/30511003/simplesamlphp-error

With the usage of SimpleSAML_exception_handler we'll solve the disadvantages.