### PR TITLE
docs: make it work with Apache 2.4

### DIFF
--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -121,6 +121,12 @@ Find the Apache configuration file for the virtual hosts where you want to run S
             Alias /simplesaml /var/simplesamlphp/www
     </VirtualHost>
 
+If you are using Apache 2.4.6 or higher version, you have to add an extra configuration directive to play nicely with the Apache 2.4 security settings
+
+    <Directory /var/simplesamlphp/www/>
+            Require all granted
+    </Directory>
+
 Note the `Alias` directive, which gives control to SimpleSAMLphp for all urls matching `http(s)://service.example.com/simplesaml/*`. SimpleSAMLphp makes several SAML interfaces available on the web; all of them are included in the `www` subdirectory of your SimpleSAMLphp installation. You can name the alias whatever you want, but the name must be specified in the `config.php` file of simpleSAML as described in [the section called “SimpleSAMLphp configuration: config.php”](#sect.config "SimpleSAMLphp configuration: config.php"). Here is an example of how this configuration may look like in `config.php`:
 
     $config = array (

--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -119,13 +119,19 @@ Find the Apache configuration file for the virtual hosts where you want to run S
             SetEnv SIMPLESAMLPHP_CONFIG_DIR /var/simplesamlphp/config
 
             Alias /simplesaml /var/simplesamlphp/www
+
+            <Directory /var/simplesamlphp/www>
+                <IfModule !mod_authz_core.c>
+                # For Apache 2.2:
+                Order allow,deny
+                Allow from all
+                </IfModule>
+                <IfModule mod_authz_core.c>
+                # For Apache 2.4:
+                Require all granted
+                </IfModule>
+            </Directory>
     </VirtualHost>
-
-If you are using Apache 2.4.6 or higher version, you have to add an extra configuration directive to play nicely with the Apache 2.4 security settings
-
-    <Directory /var/simplesamlphp/www/>
-            Require all granted
-    </Directory>
 
 Note the `Alias` directive, which gives control to SimpleSAMLphp for all urls matching `http(s)://service.example.com/simplesaml/*`. SimpleSAMLphp makes several SAML interfaces available on the web; all of them are included in the `www` subdirectory of your SimpleSAMLphp installation. You can name the alias whatever you want, but the name must be specified in the `config.php` file of simpleSAML as described in [the section called “SimpleSAMLphp configuration: config.php”](#sect.config "SimpleSAMLphp configuration: config.php"). Here is an example of how this configuration may look like in `config.php`:
 


### PR DESCRIPTION
* Add an extra apache access control directive
  to make it work with newer Apaches
  Source: http://stackoverflow.com/questions/23337446/getting-a-403-forbidden-error-for-simplesaml-after-apache-upgrade