### PR TITLE
Add an onlyIfEmpty option to core:ScopeAttribute.

### DIFF
--- a/modules/core/docs/authproc_scopeattribute.md
+++ b/modules/core/docs/authproc_scopeattribute.md
@@ -26,6 +26,12 @@ Parameters
 
 :   If the attribute already exists, the new values will be merged into the existing attribute.
 
+`onlyIfEmpty`
+:	Only replace the targetAttribute if it is empty to begin with.
+
+:	If `true`, then the targetAttribute will only be created if it didn't already contain values. Defaults to `false`.
+
+:	This is useful if, for instance, you want to create eduPersonScopedAffiliation from eduPersonAffiliation _only_ if eduPersonScopedAffiliation was not returned by the authenticaton source.
 
 Example
 -------

--- a/modules/core/lib/Auth/Process/ScopeAttribute.php
+++ b/modules/core/lib/Auth/Process/ScopeAttribute.php
@@ -30,6 +30,13 @@ class sspmod_core_Auth_Process_ScopeAttribute extends SimpleSAML_Auth_Processing
 	 */
 	private $targetAttribute;
 
+	/**
+	 * Only modify targetAttribute if it doesn't already exist.
+	 *
+	 * @var bool
+	 */
+	private $onlyIfEmpty = false;
+
 
 	/**
 	 * Initialize this filter, parse configuration
@@ -46,6 +53,7 @@ class sspmod_core_Auth_Process_ScopeAttribute extends SimpleSAML_Auth_Processing
 		$this->scopeAttribute = $config->getString('scopeAttribute');
 		$this->sourceAttribute = $config->getString('sourceAttribute');
 		$this->targetAttribute = $config->getString('targetAttribute');
+		$this->onlyIfEmpty = $config->getBoolean('onlyIfEmpty', false);
 	}
 
 
@@ -70,6 +78,10 @@ class sspmod_core_Auth_Process_ScopeAttribute extends SimpleSAML_Auth_Processing
 
 		if (!isset($attributes[$this->targetAttribute])) {
 			$attributes[$this->targetAttribute] = array();
+		}
+
+		if ($this->onlyIfEmpty and count($attributes[$this->targetAttribute]) > 0) {
+			return;
 		}
 
 		foreach ($attributes[$this->scopeAttribute] as $scope) {

--- a/tests/modules/core/lib/Auth/Process/ScopeAttributeTest.php
+++ b/tests/modules/core/lib/Auth/Process/ScopeAttributeTest.php
@@ -191,4 +191,27 @@ class Test_Core_Auth_Process_ScopeAttribute extends PHPUnit_Framework_TestCase
         $attributes = $result['Attributes'];
         $this->assertEquals($attributes['eduPersonScopedAffiliation'], array('student@example.org'));
     }
+
+	/*
+	 * When the target attribute exists and onlyIfEmpty is set
+	 */
+	public function testOnlyIfEmpty()
+	{
+       $config = array(
+            'scopeAttribute' => 'schacHomeOrganization',
+            'sourceAttribute' => 'eduPersonAffiliation',
+            'targetAttribute' => 'eduPersonScopedAffiliation',
+			'onlyIfEmpty' => true,
+        );
+        $request = array(
+            'Attributes' => array(
+                'schacHomeOrganization' => array('example.org'),
+                'eduPersonAffiliation' => array('student'),
+				'eduPersonScopedAffiliation' => array('staff@example.org', 'member@example.org'),
+            )
+        );
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertEquals($attributes['eduPersonScopedAffiliation'], array('staff@example.org', 'member@example.org'));
+	}
 }


### PR DESCRIPTION
This makes the filter a little more useful for people who want to generate default values from another attribute only if none already exist (for instance, you want to create eduPersonScopedAffiliation from eduPersonAffiliation _only_ if eduPersonScopedAffiliation was not returned by the authenticaton source.)

The option defaults to false, thus preserving the existing behavior.