### PR TITLE
Windows dir separator

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -718,13 +718,16 @@ class HTTP
      * @author Andreas Solberg, UNINETT AS <andreas.solberg@uninett.no>
      * @author Olav Morken, UNINETT AS <olav.morken@uninett.no>
      * @author Jaime Perez, UNINETT AS <jaime.perez@uninett.no>
+	 * @author Matt Beamish, GSG AS <matt.beamish@gsg.wa.edu.au>
      */
     public static function getSelfURL()
     {
         $url = self::getBaseURL();
         $cfg = \SimpleSAML_Configuration::getInstance();
-        $baseDir = $cfg->getBaseDir();
-        $rel_path = str_replace($baseDir.'www/', '', realpath($_SERVER['SCRIPT_FILENAME']));
+		/* Maintain 'ends with slash' structure from config but handle IIS/Windows cases where
+		   a straight replace won't work. */
+        $baseDir = str_replace("/",DIRECTORY_SEPARATOR,$cfg->getBaseDir());
+        $rel_path = str_replace($baseDir.'www'.DIRECTORY_SEPARATOR, '', realpath($_SERVER['SCRIPT_FILENAME']));
         $pos = strpos($_SERVER['REQUEST_URI'], $rel_path) + strlen($rel_path);
         return $url.$rel_path.substr($_SERVER['REQUEST_URI'], $pos);
     }

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -724,11 +724,13 @@ class HTTP
     {
         $url = self::getBaseURL();
         $cfg = \SimpleSAML_Configuration::getInstance();
-		/* Maintain 'ends with slash' structure from config but handle IIS/Windows cases where
-		   a straight replace won't work. */
-        $baseDir = str_replace("/",DIRECTORY_SEPARATOR,$cfg->getBaseDir());
-        $rel_path = str_replace($baseDir.'www'.DIRECTORY_SEPARATOR, '', realpath($_SERVER['SCRIPT_FILENAME']));
-        $pos = strpos($_SERVER['REQUEST_URI'], $rel_path) + strlen($rel_path);
+		
+		// Standardize forward slashes
+		$baseDir = str_replace('\\','/',$cfg->getBaseDir());
+		$filePath = str_replace('\\','/',realpath($_SERVER['SCRIPT_FILENAME']));
+		$rel_path = str_replace($baseDir.'www/', '', $filePath);
+
+		$pos = strpos($_SERVER['REQUEST_URI'], $rel_path) + strlen($rel_path);
         return $url.$rel_path.substr($_SERVER['REQUEST_URI'], $pos);
     }
 


### PR DESCRIPTION
Solved an issue whereby the absolute path was being added at the end of URLs returned from getSelfUrl under IIS on Windows.