### PR TITLE
Test for https://github.com/simplesamlphp/simplesamlphp/pull/400

### DIFF
--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -52,6 +52,13 @@ All these parameters override the equivalent option from the configuration.
 
 :   *Note*: SAML 2 specific.
 
+`saml:NameID`
+:   Add a Subject element with a NameID to the SAML AuthnRequest for the IdP.
+    This is an associative array with the fields for the NameID.
+    Example: `array('Value' => 'user@example.org', 'Format' => SAML2_Const::NAMEID_UNSPECIFIED)`
+
+:   *Note*: SAML 2 specific.
+
 
 Authentication data
 -------------------

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -205,6 +205,13 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 			$ar->setIsPassive((bool)$state['isPassive']);
 		}
 
+		if (isset($state['saml:NameID'])) {
+			if (!is_array($state['saml:NameID'])) {
+				throw new SimpleSAML_Error_Exception('Invalid value of $state[\'saml:NameID\'].');
+			}
+			$ar->setNameId($state['saml:NameID']);
+		}
+
 		if (isset($state['saml:NameIDPolicy'])) {
 			if (is_string($state['saml:NameIDPolicy'])) {
 				$policy = array(

--- a/tests/modules/core/lib/Auth/Source/Auth_Source_SP_Test.php
+++ b/tests/modules/core/lib/Auth/Source/Auth_Source_SP_Test.php
@@ -113,12 +113,14 @@ class Auth_Source_SP_Test extends PHPUnit_Framework_TestCase
         /** @var $xml DOMElement */
         $xml=$ar->toSignedXML();
         // echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $q=SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/@Destination');
         $this->assertEquals(
             $this->idpConfigArray['SingleSignOnService'][0]['Location'],
-            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/@Destination')[0]->value);
+            $q[0]->value);
+        $q=SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Issuer');
         $this->assertEquals(
             'http://localhost/simplesaml/module.php/saml/sp/metadata.php/default-sp',
-            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Issuer')[0]->textContent);
+            $q[0]->textContent);
     }
 
     /** Test setting a Subject
@@ -138,12 +140,14 @@ class Auth_Source_SP_Test extends PHPUnit_Framework_TestCase
         /** @var $xml DOMElement */
         $xml=$ar->toSignedXML();
         //echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $q=SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Subject/saml:NameID/@Format');
         $this->assertEquals(
             $state['saml:NameID']['Format'],
-            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Subject/saml:NameID/@Format')[0]->value);
+            $q[0]->value);
+        $q=SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Subject/saml:NameID');
         $this->assertEquals(
             $state['saml:NameID']['Value'],
-            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Subject/saml:NameID')[0]->textContent);
+            $q[0]->textContent);
     }
 
     /** Test setting an AuthnConextClassRef
@@ -156,16 +160,18 @@ class Auth_Source_SP_Test extends PHPUnit_Framework_TestCase
         /** @var SAML2_AuthnRequest $ar */
         $ar = $this->CreateAuthnRequest($state);
 
+        $a=$ar->getRequestedAuthnContext();
         $this->assertEquals(
             $state['saml:AuthnContextClassRef'],
-            $ar->getRequestedAuthnContext()['AuthnContextClassRef'][0] );
+            $a['AuthnContextClassRef'][0] );
 
         /** @var $xml DOMElement */
         $xml=$ar->toSignedXML();
         //echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $q=SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef');
         $this->assertEquals(
             $state['saml:AuthnContextClassRef'],
-            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef')[0]->textContent);
+            $q[0]->textContent);
     }
 
     /** Test setting ForcedAuthn
@@ -185,9 +191,10 @@ class Auth_Source_SP_Test extends PHPUnit_Framework_TestCase
         /** @var $xml DOMElement */
         $xml=$ar->toSignedXML();
         //echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $q=SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/@ForceAuthn');
         $this->assertEquals(
             $state['ForceAuthn'] ? 'true' : 'false',
-            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/@ForceAuthn')[0]->value);
+            $q[0]->value);
     }
 
 }

--- a/tests/modules/core/lib/Auth/Source/Auth_Source_SP_Test.php
+++ b/tests/modules/core/lib/Auth/Source/Auth_Source_SP_Test.php
@@ -1,0 +1,193 @@
+<?php
+
+// Custom Exception to throw to terminate a TestCase
+class ExitTestException extends Exception {
+    private $testResult;
+
+    public function __construct($testResult) {
+        parent::__construct("ExitTestException", 0, null);
+        $this->testResult = $testResult;
+    }
+
+    function getTestResult() {
+        return $this->testResult;
+    }
+}
+
+
+/* Wrap the SSP sspmod_saml_Auth_Source_SP class
+   - Use introspection to make startSSO2Test available
+   - Override sendSAML2AuthnRequest() to catch the AuthnRequest being sent
+*/
+class sspmod_saml_Auth_Source_SP_Tester extends \sspmod_saml_Auth_Source_SP
+{
+    public function __construct($info, $config) {
+        parent::__construct($info, $config);
+    }
+
+    public function startSSO2Test(SimpleSAML_Configuration $idpMetadata, array $state) {
+        $reflector = new ReflectionObject($this);
+        $method=$reflector->getMethod('startSSO2');
+        $method->setAccessible(true);
+        $method->invoke($this, $idpMetadata, $state);
+    }
+
+    // Override
+    public function sendSAML2AuthnRequest(array &$state, SAML2_Binding $binding, SAML2_AuthnRequest $ar) {
+        // Exit test. Continuing would mean running into a assert(FALSE)
+        throw new ExitTestException(
+            array(
+                'state' => $state,
+                'binding' => $binding,
+                'ar' => $ar,
+            )
+        );
+    }
+}
+
+class Auth_Source_SP_Test extends PHPUnit_Framework_TestCase
+{
+    private $idpMetadata = NULL;
+    private $idpConfigArray = array(
+        'metadata-set' => 'saml20-idp-remote',
+        'entityid' => 'https://engine.surfconext.nl/authentication/idp/metadata',
+        'SingleSignOnService' =>
+            array (
+                0 =>
+                    array (
+                        'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                        'Location' => 'https://engine.surfconext.nl/authentication/idp/single-sign-on',
+                    ),
+            ),
+        'keys' =>
+            array (
+                0 =>
+                    array (
+                        'encryption' => false,
+                        'signing' => true,
+                        'type' => 'X509Certificate',
+                        'X509Certificate' => 'MIID3zCCAsegAwIBAgIJAMVC9xn1ZfsuMA0GCSqGSIb3DQEBCwUAMIGFMQswCQYDVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNodDEQMA4GA1UEBwwHVXRyZWNodDEVMBMGA1UECgwMU1VSRm5ldCBCLlYuMRMwEQYDVQQLDApTVVJGY29uZXh0MSYwJAYDVQQDDB1lbmdpbmUuc3VyZmNvbmV4dC5ubCAyMDE0MDUwNTAeFw0xNDA1MDUxNDIyMzVaFw0xOTA1MDUxNDIyMzVaMIGFMQswCQYDVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNodDEQMA4GA1UEBwwHVXRyZWNodDEVMBMGA1UECgwMU1VSRm5ldCBCLlYuMRMwEQYDVQQLDApTVVJGY29uZXh0MSYwJAYDVQQDDB1lbmdpbmUuc3VyZmNvbmV4dC5ubCAyMDE0MDUwNTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKthMDbB0jKHefPzmRu9t2h7iLP4wAXr42bHpjzTEk6gttHFb4l/hFiz1YBI88TjiH6hVjnozo/YHA2c51us+Y7g0XoS7653lbUN/EHzvDMuyis4Xi2Ijf1A/OUQfH1iFUWttIgtWK9+fatXoGUS6tirQvrzVh6ZstEp1xbpo1SF6UoVl+fh7tM81qz+Crr/Kroan0UjpZOFTwxPoK6fdLgMAieKSCRmBGpbJHbQ2xxbdykBBrBbdfzIX4CDepfjE9h/40ldw5jRn3e392jrS6htk23N9BWWrpBT5QCk0kH3h/6F1Dm6TkyG9CDtt73/anuRkvXbeygI4wml9bL3rE8CAwEAAaNQME4wHQYDVR0OBBYEFD+Ac7akFxaMhBQAjVfvgGfY8hNKMB8GA1UdIwQYMBaAFD+Ac7akFxaMhBQAjVfvgGfY8hNKMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAC8L9D67CxIhGo5aGVu63WqRHBNOdo/FAGI7LURDFeRmG5nRw/VXzJLGJksh4FSkx7aPrxNWF1uFiDZ80EuYQuIv7bDLblK31ZEbdg1R9LgiZCdYSr464I7yXQY9o6FiNtSKZkQO8EsscJPPy/Zp4uHAnADWACkOUHiCbcKiUUFu66dX0Wr/v53Gekz487GgVRs8HEeT9MU1reBKRgdENR8PNg4rbQfLc3YQKLWK7yWnn/RenjDpuCiePj8N8/80tGgrNgK/6fzM3zI18sSywnXLswxqDb/J+jgVxnQ6MrsTf1urM8MnfcxG/82oHIwfMh/sXPCZpo+DTLkhQxctJ3M=',
+                    ),
+            ),
+    );
+
+    private function getIdpMetadata() {
+
+        if (!$this->idpMetadata) {
+            $this->idpMetadata = new SimpleSAML_Configuration($this->idpConfigArray, 'Auth_Source_SP_Test::getIdpMetadata()');
+        }
+
+        return $this->idpMetadata;
+    }
+
+    /** Create a SAML AuthnRequest using sspmod_saml_Auth_Source_SP
+     * @param $state State Array to use in the test. This is an array of the Parameters described in section 2 of
+     *               https://simplesamlphp.org/docs/development/saml:sp
+     * @return SAML2_AuthnRequest
+     */
+    private function CreateAuthnRequest($state = array()) {
+        $info=array( 'AuthId' => 'default-sp' );
+        $config=array();
+        $as = new \sspmod_saml_Auth_Source_SP_Tester($info, $config);
+
+        /** @var SAML2_AuthnRequest $ar */
+        $ar=NULL;
+        try {
+            $as->startSSO2Test($this->getIdpMetadata(), $state);
+            $this->assertTrue(FALSE, 'Expected ExitTestException');
+        }
+        catch (ExitTestException $e) {
+            $r = $e->getTestResult();
+            $ar = $r['ar'];
+        }
+        return $ar;
+    }
+
+    /** Test generating a authnrequest
+     * @test **/
+    public function TestAuthnRequest() {
+        /** @var SAML2_AuthnRequest $ar */
+        $ar = $this->CreateAuthnRequest();
+
+        // Assert values in the generated AuthnRequest
+        /** @var $xml DOMElement */
+        $xml=$ar->toSignedXML();
+        // echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $this->assertEquals(
+            $this->idpConfigArray['SingleSignOnService'][0]['Location'],
+            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/@Destination')[0]->value);
+        $this->assertEquals(
+            'http://localhost/simplesaml/module.php/saml/sp/metadata.php/default-sp',
+            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Issuer')[0]->textContent);
+    }
+
+    /** Test setting a Subject
+      * @test **/
+    public function TestNameID() {
+        $state=array(
+            'saml:NameID' => array('Value' => 'user@example.org', 'Format' => SAML2_Const::NAMEID_UNSPECIFIED)
+        );
+
+        /** @var SAML2_AuthnRequest $ar */
+        $ar = $this->CreateAuthnRequest($state);
+
+        $nameID=$ar->getNameId();
+        $this->assertEquals($state['saml:NameID']['Value'], $nameID['Value']);
+        $this->assertEquals($state['saml:NameID']['Format'], $nameID['Format']);
+
+        /** @var $xml DOMElement */
+        $xml=$ar->toSignedXML();
+        //echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $this->assertEquals(
+            $state['saml:NameID']['Format'],
+            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Subject/saml:NameID/@Format')[0]->value);
+        $this->assertEquals(
+            $state['saml:NameID']['Value'],
+            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/saml:Subject/saml:NameID')[0]->textContent);
+    }
+
+    /** Test setting an AuthnConextClassRef
+      * @test **/
+    public function TestAuthnContextClassRef() {
+        $state=array(
+            'saml:AuthnContextClassRef' => 'http://example.com/myAuthnContextClassRef'
+        );
+
+        /** @var SAML2_AuthnRequest $ar */
+        $ar = $this->CreateAuthnRequest($state);
+
+        $this->assertEquals(
+            $state['saml:AuthnContextClassRef'],
+            $ar->getRequestedAuthnContext()['AuthnContextClassRef'][0] );
+
+        /** @var $xml DOMElement */
+        $xml=$ar->toSignedXML();
+        //echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $this->assertEquals(
+            $state['saml:AuthnContextClassRef'],
+            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef')[0]->textContent);
+    }
+
+    /** Test setting ForcedAuthn
+     * @test **/
+    public function TestForcedAuthn() {
+        $state=array(
+            'ForceAuthn' => true
+        );
+
+        /** @var SAML2_AuthnRequest $ar */
+        $ar = $this->CreateAuthnRequest($state);
+
+        $this->assertEquals(
+            $state['ForceAuthn'],
+            $ar->getForceAuthn() );
+
+        /** @var $xml DOMElement */
+        $xml=$ar->toSignedXML();
+        //echo $xml->ownerDocument->saveXML($xml);  // Print XML
+        $this->assertEquals(
+            $state['ForceAuthn'] ? 'true' : 'false',
+            SAML2_Utils::xpQuery($xml, '/samlp:AuthnRequest/@ForceAuthn')[0]->value);
+    }
+
+}


### PR DESCRIPTION
Hi Jamie,

As you suggested in https://github.com/simplesamlphp/simplesamlphp/pull/400 I worked on some tests for sspmod_saml_Auth_Source_SP to test the "saml:NameID" parameter.

It took a few tries to to find a way to test the code where I made changes. I ended up creating a wrapper around sspmod_saml_Auth_Source_SP so I could just test the private sspmod_saml_Auth_Source_SP::startSSO2() function. By overriding sspmod_saml_Auth_Source_SP::sendSAML2AuthnRequest() the result can be captured, using an exception to prevent running into the assert(FALSE) in https://github.com/simplesamlphp/simplesamlphp/blob/master/modules/saml/lib/Auth/Source/SP.php#L280

It would be nice to be able to test though the public interface like, https://github.com/simplesamlphp/simplesamlphp/blob/master/modules/saml/lib/Auth/Source/SP.php#L305. The problem I ran into is that that required creating a more complete SSP config which involved many dependencies. Is there a way? It would be interesting to be able to construct a SSP configuration in a TestCase as that would be helpful for testing more functionality and other modules as well.

Anyway, the tests run. Let me know what you think.