### PR TITLE
Add the existing Afrikaans translation into the list of supported languages

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -609,7 +609,7 @@ $config = array(
     'language.available' => array(
         'en', 'no', 'nn', 'se', 'da', 'de', 'sv', 'fi', 'es', 'fr', 'it', 'nl', 'lb', 'cs',
         'sl', 'lt', 'hr', 'hu', 'pl', 'pt', 'pt-br', 'tr', 'ja', 'zh', 'zh-tw', 'ru', 'et',
-        'he', 'id', 'sr', 'lv', 'ro', 'eu', 'el'
+        'he', 'id', 'sr', 'lv', 'ro', 'eu', 'el', 'af'
     ),
     'language.rtl' => array('ar', 'dv', 'fa', 'ur', 'he'),
     'language.default' => 'en',

--- a/templates/includes/header.php
+++ b/templates/includes/header.php
@@ -180,6 +180,7 @@ if($onLoad !== '') {
 						'lv' => 'Latviešu', // Latvian
 						'ro' => 'Românește', // Romanian
 						'eu' => 'Euskara', // Basque
+						'af' => 'Afrikaans', // Afrikaans
 			);
 			
 			$textarray = array();


### PR DESCRIPTION
The Afrikaans translation is complete enough that end-user facing parts of SimpleSAMLphp can use it. This will allow South African users to make use of the translation (indeed, find out it exists) without having to edit code.