### PR TITLE
Add case where https is terminated at proxy but passed through in header

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -75,6 +75,11 @@ class HTTP
      */
     private static function getServerHTTPS()
     {
+        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+             // SSL terminated at proxy.
+             return TRUE;
+        }
+
         if (!array_key_exists('HTTPS', $_SERVER)) {
             // not an https-request
             return false;


### PR DESCRIPTION
Had an issue with simplesamlphp where a site was https, but saml was not working.

Tracked it down to getHttps not working.

we were behind a proxy and it was terminating SSL, so saml thought that it was receiving an http request. 

X-Forwarded-Proto is a de facto standard for indicating that the request was https (or not) so I put in some code to check for it. 

