### PR TITLE
Remove inline style to make css work

### DIFF
--- a/templates/includes/header.php
+++ b/templates/includes/header.php
@@ -125,7 +125,7 @@ if($onLoad !== '') {
 <div id="wrap">
 	
 	<div id="header">
-		<h1><a style="text-decoration: none; color: white" href="/<?php echo $this->data['baseurlpath']; ?>"><?php 
+		<h1><a href="/<?php echo $this->data['baseurlpath']; ?>"><?php 
 			echo (isset($this->data['header']) ? $this->data['header'] : 'SimpleSAMLphp');
 		?></a></h1>
 	</div>


### PR DESCRIPTION
Removed inline style so that style defined in `www/resources/default.css` actually works.