### PR TITLE
Allow the config page to be protected separately.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -78,10 +78,11 @@ $config = array(
     'auth.adminpassword' => '123',
 
     /*
-     * Set this options to true if you want to require administrator password to access the web interface
-     * or the metadata pages, respectively.
+     * Set this options to true if you want to require administrator password to access the web interface,
+     * just the config page, or the metadata pages, respectively.
      */
     'admin.protectindexpage' => false,
+    'admin.protectconfigpage' => false,
     'admin.protectmetadata' => false,
 
     /*

--- a/modules/core/www/frontpage_config.php
+++ b/modules/core/www/frontpage_config.php
@@ -7,7 +7,9 @@ $config = SimpleSAML_Configuration::getInstance();
 $session = SimpleSAML_Session::getSessionFromRequest();
 
 // Check if valid local session exists.
-if ($config->getBoolean('admin.protectindexpage', false)) {
+if ($config->getBoolean('admin.protectindexpage', false) or
+    $config->getBoolean('admin.protectconfigpage', false)
+) {
     SimpleSAML\Utils\Auth::requireAdmin();
 }
 $loginurl = SimpleSAML\Utils\Auth::getAdminLoginURL();


### PR DESCRIPTION
The admin.protectindexpage setting allows for the entire web interface to be protected. However, some people might want to allow their users to make use of the auth sources test page and/or display an alternative welcome page without revealing internal configuration information. Thus this change gives more fine-grained control over the config page.

It preserves the existing behaviour by defaulting admin.protectconfigpage to false, and because the config page still respects the admin.protectindexpage setting.