### PR TITLE
Configurable LinkedIn attributes

### DIFF
--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -212,10 +212,13 @@ $config = array(
     // LinkedIn OAuth Authentication API.
     // Register your application to get an API key here:
     //  https://www.linkedin.com/secure/developer
+    // Attributes definition:
+    //  https://developer.linkedin.com/docs/fields
     'linkedin' => array(
         'authlinkedin:LinkedIn',
         'key' => 'xxxxxxxxxxxxxxxx',
         'secret' => 'xxxxxxxxxxxxxxxx',
+        'attributes' => 'id,first-name,last-name,headline,summary,specialties,picture-url,email-address',
     ),
     */
 

--- a/modules/authlinkedin/docs/oauthlinkedin.md
+++ b/modules/authlinkedin/docs/oauthlinkedin.md
@@ -1,7 +1,7 @@
 Using the LinkedIn authentication source with SimpleSAMLphp
 ===========================================================
 
-Remember to configure `authsources.php`, with both Consumer key and secret.
+Remember to configure `authsources.php`, with both Consumer key and secret. Optionally you can set which attributes are requested from LinkedIn, the list of available attributes can be foudnd here <https://developer.linkedin.com/docs/fields>.
 
 To get an API key and a secret, register the application at:
 

--- a/modules/authlinkedin/docs/oauthlinkedin.md
+++ b/modules/authlinkedin/docs/oauthlinkedin.md
@@ -1,7 +1,7 @@
 Using the LinkedIn authentication source with SimpleSAMLphp
 ===========================================================
 
-Remember to configure `authsources.php`, with both Consumer key and secret. Optionally you can set which attributes are requested from LinkedIn, the list of available attributes can be foudnd here <https://developer.linkedin.com/docs/fields>.
+Remember to configure `authsources.php`, with both Consumer key and secret. Optionally you can set which attributes are requested from LinkedIn, the list of available attributes can be found here <https://developer.linkedin.com/docs/fields>.
 
 To get an API key and a secret, register the application at:
 

--- a/modules/authlinkedin/lib/Auth/Source/LinkedIn.php
+++ b/modules/authlinkedin/lib/Auth/Source/LinkedIn.php
@@ -22,6 +22,7 @@ class sspmod_authlinkedin_Auth_Source_LinkedIn extends SimpleSAML_Auth_Source {
 
 	private $key;
 	private $secret;
+	private $attributes;
 
 
 	/**
@@ -46,6 +47,12 @@ class sspmod_authlinkedin_Auth_Source_LinkedIn extends SimpleSAML_Auth_Source {
 			throw new Exception('LinkedIn authentication source is not properly configured: missing [secret]');
 
 		$this->secret = $config['secret'];
+
+		if (array_key_exists('attributes', $config))
+			$this->attributes = $config['attributes'];
+		else
+			// Default values if the attributes are not set in config (ref https://developer.linkedin.com/docs/fields)
+			$this->attributes = 'id,first-name,last-name,headline,summary,specialties,picture-url,email-address';
 	}
 
 
@@ -97,8 +104,7 @@ class sspmod_authlinkedin_Auth_Source_LinkedIn extends SimpleSAML_Auth_Source {
 		SimpleSAML\Logger::debug("Got an access token from the OAuth service provider [" .
 			$accessToken->key . "] with the secret [" . $accessToken->secret . "]");
 
-		// TODO: configure attributes (http://developer.linkedin.com/docs/DOC-1061) from config? Limited options via LinkedIn
-		$userdata = $consumer->getUserInfo('https://api.linkedin.com/v1/people/~:(id,first-name,last-name,headline,summary,specialties,picture-url)', $accessToken, array('http' => array('header' => 'x-li-format: json')));
+		$userdata = $consumer->getUserInfo('https://api.linkedin.com/v1/people/~:(' . $this->attributes . ')', $accessToken, array('http' => array('header' => 'x-li-format: json')));
 
 		$attributes = array();
 		foreach($userdata AS $key => $value) {

--- a/modules/authlinkedin/lib/Auth/Source/LinkedIn.php
+++ b/modules/authlinkedin/lib/Auth/Source/LinkedIn.php
@@ -48,11 +48,12 @@ class sspmod_authlinkedin_Auth_Source_LinkedIn extends SimpleSAML_Auth_Source {
 
 		$this->secret = $config['secret'];
 
-		if (array_key_exists('attributes', $config))
+		if (array_key_exists('attributes', $config)) {
 			$this->attributes = $config['attributes'];
-		else
+		} else {
 			// Default values if the attributes are not set in config (ref https://developer.linkedin.com/docs/fields)
 			$this->attributes = 'id,first-name,last-name,headline,summary,specialties,picture-url,email-address';
+		}
 	}
 
 


### PR DESCRIPTION
- Attributes which can be get from LinkedIn are now configurable
- By default these attributes are requested: id,first-name,last-name,headline,summary,specialties,picture-url,email-address
- Added email-address attribute into the default set
- Fixed link to the documentation