### PR TITLE
Adfs

### DIFF
--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -47,7 +47,7 @@ class sspmod_adfs_IdP_ADFS {
 	public static function ADFS_GenerateResponse($issuer, $target, $nameid, $attributes) {
 		$issueInstant = SimpleSAML\Utils\Time::generateTimestamp();
 		$notBefore = SimpleSAML\Utils\Time::generateTimestamp(time() - 30);
-		$assertionExpire = SimpleSAML\Utils\Time::generateTimestamp(time() + 60 * 5);
+		$assertionExpire = SimpleSAML\Utils\Time::generateTimestamp(time() + 60 * 60);
 		$assertionID = SimpleSAML\Utils\Random::generateID();
 		$nameidFormat = 'http://schemas.xmlsoap.org/claims/UPN';
 		$result =

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -72,8 +72,8 @@ class sspmod_adfs_IdP_ADFS {
 			if ((!is_array($values)) || (count($values) == 0)) continue;
 			$hasValue = FALSE;
 			if (strpos($name, '/')) {
-				$r = '<saml:Attribute AttributeNamespace="'.substr($name, 0, strrpos($name, '/', -1)).
-					'" AttributeName="'.substr($name, strrpos($name, '/', -1) + 1).'">';
+				$r = '<saml:Attribute AttributeNamespace="'.htmlspecialchars(substr($name, 0, strrpos($name, '/', -1))).
+					'" AttributeName="'.htmlspecialchars(substr($name, strrpos($name, '/', -1) + 1)).'">';
 			} else {
 				$r = '<saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/claims" AttributeName="' .
 					htmlspecialchars($name) .'">';

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -70,7 +70,13 @@ class sspmod_adfs_IdP_ADFS {
 		foreach ($attributes as $name => $values) {
 			if ((!is_array($values)) || (count($values) == 0)) continue;
 			$hasValue = FALSE;
-			$r = '<saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/claims" AttributeName="' . htmlspecialchars($name) .'">';
+			if (strpos($name, '/')) {
+				$r = '<saml:Attribute AttributeNamespace="'.substr($name, 0, strrpos($name, '/', -1)).
+					'" AttributeName="'.substr($name, strrpos($name, '/', -1) + 1).'">';
+			} else {
+				$r = '<saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/claims" AttributeName="' .
+					htmlspecialchars($name) .'">';
+			}
 			foreach ($values as $value) {
 				if ( (!isset($value)) || ($value === '')) continue;
 				$r .= '<saml:AttributeValue>' . htmlspecialchars($value) . '</saml:AttributeValue>';

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -38,6 +38,7 @@ class sspmod_adfs_IdP_ADFS {
 			'ForceAuthn' => $forceAuthn,
 			'isPassive' => $isPassive,
 			'adfs:wctx' => $wctx,
+			'adfs:wreply' => (array_key_exists('wreply',$_GET)) ? $_GET['wreply'] : ''
 		);
 
 		$idp->handleAuthenticationRequest($state);		
@@ -163,7 +164,7 @@ class sspmod_adfs_IdP_ADFS {
 		$wresult = sspmod_adfs_IdP_ADFS::ADFS_SignResponse($response, $privateKeyFile, $certificateFile);
 
 		$wctx = $state['adfs:wctx'];
-		sspmod_adfs_IdP_ADFS::ADFS_PostResponse($spMetadata->getValue('prp'), $wresult, $wctx);
+		sspmod_adfs_IdP_ADFS::ADFS_PostResponse(($state['adfs:wreply']) ? $state['adfs:wreply'] : $spMetadata->getValue('prp'), $wresult, $wctx);
 	}
 /*
 	public static function handleAuthError(SimpleSAML_Error_Exception $exception, array $state) {


### PR DESCRIPTION
Two improvements to the ADFS module:
1. Honour namespace when available... Fall back to use 'http://schemas.xmlsoap.org/claims' if none given... Namespaces can be added to the attributes using the core:AttributeMap name2claim. This enables the use of locally defined claims.
2. Honour adfs:wreply parameter when available... Using with sharepoint apps, the URL of an app is dynamically created... A static config in SSP can't be used. Using the adfs:wreply to let sharepoint dynamically fill in the return url is a solotion for this problem. If no adfs:wreply parameter is present, the default behaviour (use the configured prp url) is used.
