### PR TITLE
Avoid travis segfaulting phpunit withn PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   - php: hhvm
 before_script: composer update --dev
 script:
-- php vendor/phpunit/phpunit/phpunit --configuration tools/phpunit
+- if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then php vendor/phpunit/phpunit/phpunit --configuration tools/phpunit; else php vendor/phpunit/phpunit/phpunit --configuration tools/phpunit --no-coverage; fi
 - bin/check-syntax.sh
 after_success:
 - if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then php vendor/bin/coveralls -v; fi


### PR DESCRIPTION
The segfault happens in the coverage report. Since we send coverage
info only with PHP 5.6, avoid running it entirely, saves buildtime aswell.