### PR TITLE
Bug/previous sessions

### DIFF
--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -138,6 +138,9 @@ class SimpleSAML_Session implements Serializable
      * Private constructor that restricts instantiation to either getSessionFromRequest() for the current session or
      * getSession() for a specific one.
      *
+     * Note that this constructor is not called with every request. The object
+     * is also loaded from storage via SessionHandler->loadSession()
+     *
      * @param boolean $transient Whether to create a transient session or not.
      */
     private function __construct($transient = false)
@@ -235,7 +238,9 @@ class SimpleSAML_Session implements Serializable
 
 
     /**
-     * Retrieves the current session. Creates a new session if there's not one.
+     * Returns the SimpleSAML_Session for this session
+     * - Retrieves from storage the first time this function is called during a request
+     * - Creates new object if this is the first request of a new session
      *
      * @return SimpleSAML_Session The current session.
      * @throws Exception When session couldn't be initialized and the session fallback is disabled by configuration.

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -27,9 +27,11 @@ class SimpleSAML_SessionHandlerPHP extends SimpleSAML_SessionHandler
      *   - name: the name of the session, as returned by session_name().
      *   - cookie_params: the parameters of the session cookie, as returned by session_get_cookie_params().
      *
+     * Note that SimpleSAML_Session->maintainPreviousSession() may update this value
+     *
      * @var array
      */
-    private $previous_session = array();
+    public $previous_session = array();
 
 
     /**

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -215,7 +215,7 @@ class SimpleSAML_SessionHandlerPHP extends SimpleSAML_SessionHandler
 
 
     /**
-     * Load the session from the PHP session array.
+     * Load the SimpleSamlPHP session from the PHP session array.
      *
      * @param string|null $sessionId The ID of the session we should load, or null to use the default.
      *


### PR DESCRIPTION
Related issues:

https://github.com/simplesamlphp/simplesamlphp/pull/349
https://github.com/simplesamlphp/simplesamlphp/issues/365
https://github.com/simplesamlphp/simplesamlphp/pull/224

This extends the patch for those issues, saving the previous_session across multiple requests. 