### PR TITLE
Added support for load balancer-terminated SSL.

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -75,6 +75,10 @@ class HTTP
      */
     private static function getServerHTTPS()
     {
+        if (array_key_exists('HTTP_X_FORWARDED_PROTO', $_SERVER) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+            // Server is behind load balancer.
+            return true;
+        }
         if (!array_key_exists('HTTPS', $_SERVER)) {
             // not an https-request
             return false;
@@ -101,6 +105,7 @@ class HTTP
     private static function getServerPort()
     {
         $port = (isset($_SERVER['SERVER_PORT'])) ? $_SERVER['SERVER_PORT'] : '80';
+        $port = (isset($_SERVER['HTTP_X_FORWARDED_PORT'])) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : $port;
         if (self::getServerHTTPS()) {
             if ($port !== '443') {
                 return ':'.$port;


### PR DESCRIPTION
Currently, if SSL is terminated at a load balancer in front of your server running SimpleSAMLphp, the library thinks the base url is http even if you visit it via https, which is non-intuitive to say the least.

The current workaround is to manually specify the base path url (including https) in these environments, but it would be much more user-friendly, flexible, and harmless to handle this automatically.