### PR TITLE
Allow for toggling Kerberos replay cache

### DIFF
--- a/modules/negotiate/lib/Auth/Source/Negotiate.php
+++ b/modules/negotiate/lib/Auth/Source/Negotiate.php
@@ -28,6 +28,7 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
     protected $admin_user = null;
     protected $admin_pw = null;
     protected $attributes = null;
+    protected $rcache = null;
 
 
     /**
@@ -66,6 +67,7 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
         $this->admin_user = $config->getString('adminUser', null);
         $this->admin_pw = $config->getString('adminPassword', null);
         $this->attributes = $config->getArray('attributes', null);
+        $this->rcache = $config->getBoolean('rcache', null);
     }
 
 
@@ -135,6 +137,12 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
                 if (strtolower($mech) != 'negotiate') {
                     SimpleSAML\Logger::debug('Negotiate - authenticate(): No "Negotiate" found. Skipping.');
                 }
+            }
+            
+            if ($this->rcache === true) {
+                putenv("KRB5RCACHETYPE=dfl");
+            } elseif ($this->rcache === false) {
+                putenv("KRB5RCACHETYPE=none");
             }
 
             $auth = new KRB5NegotiateAuth($this->keytab);


### PR DESCRIPTION
Replay cache is known to cause performance issues ([reference](http://web.mit.edu/KERBEROS/krb5-devel/doc/basic/rcache_def.html#performance-issues)), so it may be desirable to disable it.

Personally I ran into a (known) issue where replay cache-files were not freed/removed, causing Apache to stop working after a while (too many files open). This issue has been fixed in krb5-libs 1.13, but version 1.10 is still the default on many operating systems (RHEL 6).
