### PR TITLE
Fixed incorrect memcache_store prefix docs.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -592,7 +592,7 @@ $config = array(
 
     /*
      * This value allows you to set a prefix for memcache-keys. The default
-     * for this value is 'SimpleSAMLphp', which is fine in most cases.
+     * for this value is 'simpleSAMLphp', which is fine in most cases.
      *
      * When running multiple instances of SSP on the same host, and more
      * than one instance is using memcache, you probably want to assign


### PR DESCRIPTION
The search and replace in https://github.com/simplesamlphp/simplesamlphp/commit/f25c7815af52a751cb815709ff33abee14e130a4 was a bit overzealous and should not have changed the documentation for this variable, since the default value is still (lowercase) simpleSAMLphp.

See the actual default value here:
https://github.com/simplesamlphp/simplesamlphp/blob/master/lib/SimpleSAML/Store/Memcache.php#L26