### PR TITLE
Fix required attributes duplication

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -1217,10 +1217,6 @@ class SimpleSAML_Metadata_SAMLParser
             $attrname = $child->Name;
             $sp['attributes'][] = $attrname;
 
-            if ($child->isRequired) {
-                $sp['attributes.required'][] = $attrname;
-            }
-
             if ($child->isRequired !== null && $child->isRequired === true) {
                 $sp['attributes.required'][] = $attrname;
             }


### PR DESCRIPTION
While parsing the XML metadata file of SP, attributes in AttributeConsumerService marked as required where added multiple times causing duplication of attribute keys in `attributes.required` section.