### PR TITLE
Add ability to define additional attributes on ContactPerson element

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"ext-date": "*",
 		"ext-hash": "*",
 		"ext-json": "*",
-        "simplesamlphp/saml2": "dev-master#00e38f85b417be1e10a2d738dd2f5ea82edb472c as 2.2",
+        "simplesamlphp/saml2": "dev-master#a94403bfe5627c90fe3764e0ada5a44841a11e80 as 2.3.3",
         "robrichards/xmlseclibs": "~2.0",
         "whitehat101/apr1-md5": "~1.0",
         "twig/twig": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"ext-date": "*",
 		"ext-hash": "*",
 		"ext-json": "*",
-        "simplesamlphp/saml2": "dev-master#a94403bfe5627c90fe3764e0ada5a44841a11e80 as 2.3.3",
+        "simplesamlphp/saml2": "dev-master#00e38f85b417be1e10a2d738dd2f5ea82edb472c as 2.2",
         "robrichards/xmlseclibs": "~2.0",
         "whitehat101/apr1-md5": "~1.0",
         "twig/twig": "~1.0",

--- a/docs/simplesamlphp-reference-idp-hosted.md
+++ b/docs/simplesamlphp-reference-idp-hosted.md
@@ -143,14 +143,14 @@ Common options
 		'contacts' => array(
 		    array(
 		        'contactType'       => 'other',
-		        'emailAddress'      => 'abuse@example.org',
+		        'emailAddress'      => 'mailto:abuse@example.org',
 		        'givenName'         => 'John',
 		        'surName'           => 'Doe',
 		        'telephoneNumber'   => '+31(0)12345678',
 		        'company'           => 'Example Inc.',
 		        'attributes'        => array(
 		            'xmlns:remd'        => 'http://refeds.org/metadata',
-		            'remd:contactType   => 'http://refeds.org/metadata/contactType/security',
+		            'remd:contactType'  => 'http://refeds.org/metadata/contactType/security',
 		        ),
 		    ),
 		), 

--- a/docs/simplesamlphp-reference-idp-hosted.md
+++ b/docs/simplesamlphp-reference-idp-hosted.md
@@ -123,6 +123,37 @@ Common options
     any value in the SP-remote metadata overrides the one configured
     in the IdP metadata.
 
+`contacts`
+:	Specify contacts in addition to the technical contact configured through config/config.php.
+	For example, specifying a support contact:
+
+		'contacts' => array(
+		    array(
+		        'contactType'       => 'support',
+		        'emailAddress'      => 'support@example.org',
+		        'givenName'         => 'John',
+		        'surName'           => 'Doe',
+		        'telephoneNumber'   => '+31(0)12345678',
+		        'company'           => 'Example Inc.',
+		    ),
+		),
+
+:	If you have support for a trust framework that requires extra attributes on the contact person element in your IdP metadata (for example, SIRTFI), you can specify an array of attributes on a contact.
+
+		'contacts' => array(
+		    array(
+		        'contactType'       => 'other',
+		        'emailAddress'      => 'abuse@example.org',
+		        'givenName'         => 'John',
+		        'surName'           => 'Doe',
+		        'telephoneNumber'   => '+31(0)12345678',
+		        'company'           => 'Example Inc.',
+		        'attributes'        => array(
+		            'xmlns:remd'        => 'http://refeds.org/metadata',
+		            'remd:contactType   => 'http://refeds.org/metadata/contactType/security',
+		        ),
+		    ),
+		), 
 
 SAML 2.0 options
 ----------------

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -688,6 +688,10 @@ class SimpleSAML_Metadata_SAMLBuilder
         $e = new \SAML2\XML\md\ContactPerson();
         $e->contactType = $type;
 
+        if (!empty($details['attributes'])) {
+            $e->ContactPersonAttributes = $details['attributes'];
+        }
+
         if (isset($details['company'])) {
             $e->Company = $details['company'];
         }

--- a/lib/SimpleSAML/Utils/Config/Metadata.php
+++ b/lib/SimpleSAML/Utils/Config/Metadata.php
@@ -27,6 +27,12 @@ class Metadata
 
 
     /**
+     * Valid options for the ContactPerson element
+     *
+     * The 'attributes' option isn't defined in section 2.3.2.2 of the OASIS document, but
+     * it is required to allow additons to the main contact person element for trust
+     * frameworks.
+     *
      * @var array The valid configuration options for a contact configuration array.
      * @see "Metadata for the OASIS Security Assertion Markup Language (SAML) V2.0", section 2.3.2.2.
      */
@@ -37,6 +43,7 @@ class Metadata
         'surName',
         'telephoneNumber',
         'company',
+        'attributes',
     );
 
 
@@ -106,6 +113,13 @@ class Metadata
                 self::$VALID_CONTACT_TYPES
             ));
             throw new \InvalidArgumentException('"contactType" is mandatory and must be one of '.$types.".");
+        }
+
+        // check attributes is an associative array
+        if (isset($contact['attributes'])) {
+            if (empty($contact['attributes']) || empty(array_filter(array_keys($contact['attributes']), 'is_string'))) {
+                throw new \InvalidArgumentException('"attributes" must be an array and cannot be empty.');
+            }
         }
 
         // try to fill in givenName and surName from name

--- a/lib/SimpleSAML/Utils/Config/Metadata.php
+++ b/lib/SimpleSAML/Utils/Config/Metadata.php
@@ -117,7 +117,10 @@ class Metadata
 
         // check attributes is an associative array
         if (isset($contact['attributes'])) {
-            if (empty($contact['attributes']) || !is_array($contact['attributes']) || count(array_filter(array_keys($contact['attributes']), 'is_string')) == 0) {
+            if (empty($contact['attributes']) 
+                || !is_array($contact['attributes']) 
+                || count(array_filter(array_keys($contact['attributes']), 'is_string')) === 0
+            ) {
                 throw new \InvalidArgumentException('"attributes" must be an array and cannot be empty.');
             }
         }

--- a/lib/SimpleSAML/Utils/Config/Metadata.php
+++ b/lib/SimpleSAML/Utils/Config/Metadata.php
@@ -117,7 +117,7 @@ class Metadata
 
         // check attributes is an associative array
         if (isset($contact['attributes'])) {
-            if (empty($contact['attributes']) || !is_array($contact['attributes']) || empty(array_filter(array_keys($contact['attributes']), 'is_string'))) {
+            if (empty($contact['attributes']) || !is_array($contact['attributes']) || count(array_filter(array_keys($contact['attributes']), 'is_string')) == 0) {
                 throw new \InvalidArgumentException('"attributes" must be an array and cannot be empty.');
             }
         }

--- a/lib/SimpleSAML/Utils/Config/Metadata.php
+++ b/lib/SimpleSAML/Utils/Config/Metadata.php
@@ -117,7 +117,7 @@ class Metadata
 
         // check attributes is an associative array
         if (isset($contact['attributes'])) {
-            if (empty($contact['attributes']) || empty(array_filter(array_keys($contact['attributes']), 'is_string'))) {
+            if (empty($contact['attributes']) || !is_array($contact['attributes']) || empty(array_filter(array_keys($contact['attributes']), 'is_string'))) {
                 throw new \InvalidArgumentException('"attributes" must be an array and cannot be empty.');
             }
         }

--- a/tests/lib/SimpleSAML/Utils/Config/MetadataTest.php
+++ b/tests/lib/SimpleSAML/Utils/Config/MetadataTest.php
@@ -215,6 +215,7 @@ class MetadataTest extends \PHPUnit_Framework_TestCase
         }
         $contact['contactType'] = 'technical';
         $contact['name'] = 'to_be_removed';
+        $contact['attributes'] = array('test' => 'testval');
         $parsed = Metadata::getContact($contact);
         foreach (array_keys($parsed) as $key) {
             $this->assertEquals($parsed[$key], $contact[$key]);


### PR DESCRIPTION
This will allow you to configure an attributes array on contact definitions for trust frameworks such as SIRTFI. This is a continuation from the simplesamlphp/saml2 pull [#79](https://github.com/simplesamlphp/saml2/pull/79).

I thought about having a SIRTFI class that could be included onto the contact person element, but I couldn't think of a clean way of adding it on, but I am open to discussion about that. There are also some todo's on the addContact function that I decided was out of scope for this PR that would have to be addressed if I went down the route of having a separate class for SIRTFI.

Also, saml2 doesn't have a new tag with the updated PR that I submitted there, so I've simply updated the commit hash in the composer config. That can be fixed whenever a new tag is created with the changes that were made to support this in saml2.