### PR TITLE
Deal with cases where there is no SubjectConfirmationData.

### DIFF
--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -667,6 +667,11 @@ class sspmod_saml_Message {
 				}
 			}
 
+			// If no SubjectConfirmationData then don't do anything.
+			if (!$scd) {
+				continue;
+			}
+
 			if ($scd->NotBefore && $scd->NotBefore > time() + 60) {
 				$lastError = 'NotBefore in SubjectConfirmationData is in the future: ' . $scd->NotBefore;
 				continue;

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -669,6 +669,7 @@ class sspmod_saml_Message {
 
 			// If no SubjectConfirmationData then don't do anything.
 			if (!$scd) {
+				$lastError = 'No SubjectConfirmationData provided';
 				continue;
 			}
 


### PR DESCRIPTION
I had a case where a saml packet contained this 

` 
<SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer" />
`

This caused SSP to fail. As subject confirmation data is not defined.

I have looked at the spec (well the xml schema) and it seems to be valid. 

`
<element ref="saml:SubjectConfirmationData" minOccurs="0"/>
`

I'll agree that it doesn't make any sense to have such a element but if it is not invalid we should not be having a fatal error.