### PR TITLE
Add attributes.noconsent option to correspond with the Consent module

### DIFF
--- a/modules/consent/docs/consent.md
+++ b/modules/consent/docs/consent.md
@@ -160,6 +160,12 @@ The following options can be used when configuring the Consent module
     the attributes that should have it value hidden. Default behaviour is that 
     all attribute values are shown
 
+`noconsentattributes`
+:   Allows certain attributes to be excluded from the attribute hash when
+    `includeValues` is TRUE (and as a side effect, to be hidden from display
+	as `hiddenAttributes` does). Set to an array of the attributes that should
+	be excluded. Default behaviour is to include all values in the hash.
+
 `showNoConsentAboutService`
 :   Whether we will show a link to more information about the service from the
     no consent page. Defaults to `TRUE`.

--- a/modules/consentAdmin/config-templates/module_consentAdmin.php
+++ b/modules/consentAdmin/config-templates/module_consentAdmin.php
@@ -6,23 +6,23 @@
  * @package SimpleSAMLphp
  */
 $config = array(
-	/*
-	 * Configuration for the database connection.
-	 */
-	'consentadmin'  => array(
-		'consent:Database',
-		'dsn'		=>	'mysql:host=DBHOST;dbname=DBNAME',
-		'username'	=>	'USERNAME', 
-		'password'	=>	'PASSWORD',
-	),
-	
-	// Hash attributes including values or not
-	'attributes.hash' => TRUE,
+    /*
+     * Configuration for the database connection.
+     */
+    'consentadmin'  => array(
+        'consent:Database',
+        'dsn'       =>  'mysql:host=DBHOST;dbname=DBNAME',
+        'username'  =>  'USERNAME',
+        'password'  =>  'PASSWORD',
+    ),
 
-	// Where to direct the user after logout
-    // REMEMBER to prefix with http:// otherwise the relaystate is only appended 
+    // Hash attributes including values or not
+    'attributes.hash' => TRUE,
+
+    // Where to direct the user after logout
+    // REMEMBER to prefix with http:// otherwise the relaystate is only appended
     // to saml2 logout URL
-	'returnURL' => 'http://www.wayf.dk',
+    'returnURL' => 'http://www.wayf.dk',
 
     // Shows description of the services if set to true (defaults to true)
     'showDescription' => true,

--- a/modules/consentAdmin/config-templates/module_consentAdmin.php
+++ b/modules/consentAdmin/config-templates/module_consentAdmin.php
@@ -19,6 +19,9 @@ $config = array(
     // Hash attributes including values or not
     'attributes.hash' => TRUE,
 
+    // If you set noconsentattributes in the consent module, this must match
+    // 'attributes.noconsent' => array(),
+
     // Where to direct the user after logout
     // REMEMBER to prefix with http:// otherwise the relaystate is only appended
     // to saml2 logout URL

--- a/modules/consentAdmin/docs/consentAdmin.md
+++ b/modules/consentAdmin/docs/consentAdmin.md
@@ -44,7 +44,9 @@ Setting optional parameters
 In order to make the consentAdmin module work together with the consent
 module correctly, you need to set the configuration 'attributes.hash'
 according to the value of 'includeValues' configuration in the consent
-module.
+module. Likewise, if you've used the 'noconsentattributes' configuration
+option in the consent module, you should also set the 'attributes.noconsent'
+configuration option here to match.
 
 You should also set the 'returnURL' configuration in order to pass on your
 users when the press the 'Logout' link.

--- a/modules/consentAdmin/www/consentAdmin.php
+++ b/modules/consentAdmin/www/consentAdmin.php
@@ -22,7 +22,8 @@ function driveProcessingChain(
     $sp_entityid,
     $attributes,
     $userid,
-    $hashAttributes = false
+    $hashAttributes = false,
+    $noconsentAttributes = array()
 ) {
 
     /*
@@ -48,6 +49,13 @@ function driveProcessingChain(
     $pc->processStatePassive($authProcState);
 
     $attributes = $authProcState['Attributes'];
+
+    // Remove attributes that do not require consent
+    foreach ($attributes AS $attrkey => $attrval) {
+        if (in_array($attrkey, $noconsentAttributes)) {
+            unset($attributes[$attrkey]);
+        }
+    }
 
     /*
      * Generate identifiers and hashes
@@ -79,6 +87,8 @@ if (array_key_exists('logout', $_REQUEST)) {
 }
 
 $hashAttributes = $cA_config->getValue('attributes.hash');
+
+$noconsentAttributes = $cA_config->getValue('attributes.noconsent', array());
 
 // Check if valid local session exists
 $as->requireAuth();
@@ -161,7 +171,7 @@ if ($action !== null && $sp_entityid !== null) {
 
     // Run AuthProc filters
     list($targeted_id, $attribute_hash, $attributes_new) = driveProcessingChain($idp_metadata, $source, $sp_metadata,
-        $sp_entityid, $attributes, $userid, $hashAttributes);
+        $sp_entityid, $attributes, $userid, $hashAttributes, $noconsentAttributes);
 
     // Add a consent (or update if attributes have changed and old consent for SP and IdP exists)
     if ($action == 'true') {
@@ -217,7 +227,7 @@ foreach ($all_sp_metadata as $sp_entityid => $sp_values) {
 
     // Run attribute filters
     list($targeted_id, $attribute_hash, $attributes_new) = driveProcessingChain($idp_metadata, $source, $sp_metadata,
-        $sp_entityid, $attributes, $userid, $hashAttributes);
+        $sp_entityid, $attributes, $userid, $hashAttributes, $noconsentAttributes);
 
     // Check if consent exists
     if (array_key_exists($targeted_id, $user_consent)) {


### PR DESCRIPTION
The Consent module has a (currently undocumented) noconsentattributes option that allows specified attributes to be removed from the consent hash calculation. The noconsentattribute option was introduced at simplesamlphp/simplesamlphp@1efcfa8 but no corresponding option was added to the consentAdmin module. Thus if people are using the noconsentattribute option to remove attributes, the consentAdmin module will *always* show this as attribute values having been changed.