### PR TITLE
Allow the language cookie to be secured

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -656,6 +656,8 @@ $config = array(
     'language.cookie.name' => 'language',
     'language.cookie.domain' => null,
     'language.cookie.path' => '/',
+    'language.cookie.secure' => false,
+    'language.cookie.httponly' => false,
     'language.cookie.lifetime' => (60 * 60 * 24 * 900),
 
     /*

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -412,7 +412,8 @@ class Language
             'lifetime' => ($config->getInteger('language.cookie.lifetime', 60 * 60 * 24 * 900)),
             'domain'   => ($config->getString('language.cookie.domain', null)),
             'path'     => ($config->getString('language.cookie.path', '/')),
-            'httponly' => false,
+            'secure'   => ($config->getBoolean('language.cookie.secure', false)),
+            'httponly' => ($config->getBoolean('language.cookie.httponly', false)),
         );
 
         HTTP::setCookie($name, $language, $params, false);


### PR DESCRIPTION
There are config options that allow the session cookie to be secured, but there are no equivalent options for the language cookie. As a result it is not possible to secure the language cookie.

Whilst it might be desirable to have a cookie containing language preference more widely accessible, some people may wish to lock down the cookie -- particularly where they are implementing policies like HSTS. Having an insecure cookie triggers a flag in audits of HSTS.

This change adds two additional config options allowing the language cookie to be secured. The default of serving an insecure cookie remains unchanged, meaning the change should not affect existing installs.