### PR TITLE
feature: AttributeCopy can take array for an attribute

### DIFF
--- a/modules/core/docs/authproc_attributecopy.md
+++ b/modules/core/docs/authproc_attributecopy.md
@@ -1,13 +1,13 @@
 `core:AttributeCopy`
 ===================
 
-Filter that renames attributes.
+Filter that copies attributes.
 
 
 Examples
 --------
 
-Copy a single attribute (user's uid will be copied to the user's username):
+Copy a single attribute (user's `uid` will be copied to the user's `username`):
 
     'authproc' => array(
         50 => array(
@@ -16,3 +16,11 @@ Copy a single attribute (user's uid will be copied to the user's username):
         ),
     ),
 
+Copy a single attribute to more then one attribute (user's `uid` will be copied to the user's `username` and to `urn:mace:dir:attribute-def:uid`)
+
+    'authproc' => array(
+        50 => array(
+            'class' => 'core:AttributeCopy',
+            'uid' => array('username', 'urn:mace:dir:attribute-def:uid'),
+        ),
+    ),

--- a/modules/core/lib/Auth/Process/AttributeCopy.php
+++ b/modules/core/lib/Auth/Process/AttributeCopy.php
@@ -40,7 +40,7 @@ class sspmod_core_Auth_Process_AttributeCopy extends SimpleSAML_Auth_ProcessingF
 				throw new Exception('Invalid source attribute name: ' . var_export($source, TRUE));
 			}
 
-			if(!is_string($destination)) {
+			if(!is_string($destination) && !is_array($destination)) {
 				throw new Exception('Invalid destination attribute name: ' . var_export($destination, TRUE));
 			}
 
@@ -62,7 +62,13 @@ class sspmod_core_Auth_Process_AttributeCopy extends SimpleSAML_Auth_ProcessingF
 
 		foreach($attributes as $name => $values) {
 			if (array_key_exists($name,$this->map)){
-				$attributes[$this->map[$name]] = $values;
+				if (!is_array($this->map[$name])) {
+					$attributes[$this->map[$name]] = $values;
+				} else {
+					foreach ($this->map[$name] as $to_map) {
+						$attributes[$to_map] = $values;
+					}
+				}
 			}
 		}
 

--- a/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
@@ -132,7 +132,7 @@ class Test_Core_Auth_Process_AttributeCopy extends PHPUnit_Framework_TestCase
         );
         $request = array(
             'Attributes' => array(
-                'test' => array('value1'),
+                'test' => 100,
             ),
         );
         $result = self::processFilter($config, $request);

--- a/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
@@ -39,6 +39,26 @@ class Test_Core_Auth_Process_AttributeCopy extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test the most basic functionality.
+     */
+    public function testArray()
+    {
+        $config = array(
+            'test' => array('new1','new2'),
+        );
+        $request = array(
+            'Attributes' => array('test' => array('AAP')),
+        );
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey('test', $attributes);
+        $this->assertArrayHasKey('new1', $attributes);
+        $this->assertArrayHasKey('new2', $attributes);
+        $this->assertEquals($attributes['new1'], array('AAP'));
+        $this->assertEquals($attributes['new2'], array('AAP'));
+    }
+
+    /**
      * Test that existing attributes are left unmodified.
      */
     public function testExistingNotModified()

--- a/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
@@ -128,11 +128,11 @@ class Test_Core_Auth_Process_AttributeCopy extends PHPUnit_Framework_TestCase
     public function testWrongAttributeValue()
     {
         $config = array(
-            'test' => array('test2'),
+            'test' => 100,
         );
         $request = array(
             'Attributes' => array(
-                'test' => 100,
+                'test' => array('value1'),
             ),
         );
         $result = self::processFilter($config, $request);


### PR DESCRIPTION
Just like with AttributeMap you can specify a string or array as the destination:
```
50 => array(
   'class' => 'core:AttributeCopy',
   'sn' => 'urn:mace:dir:attribute-def:sn',
   'cn' => array('urn:mace:dir:attribute-def:cn','urn:mace:dir:attribute-def:diplayName')
),
```