### PR TITLE
Add "isDefault=true" to the AttributeConsumingService

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -404,6 +404,7 @@ class SimpleSAML_Metadata_SAMLBuilder
         $attributeconsumer = new \SAML2\XML\md\AttributeConsumingService();
 
         $attributeconsumer->index = 0;
+        $attributeconsumer->isDefault = true;
 
         $attributeconsumer->ServiceName = $name;
         $attributeconsumer->ServiceDescription = $metadata->getLocalizedString('description', array());


### PR DESCRIPTION
Add "isDefault=true" to the AttributeConsumingService element of the generated SP metadata since some IdPs would not release attributes otherwise.