### PR TITLE
Raise exception when memcache-server is down

### DIFF
--- a/lib/SimpleSAML/Memcache.php
+++ b/lib/SimpleSAML/Memcache.php
@@ -439,8 +439,10 @@ class SimpleSAML_Memcache
 
         foreach (self::getMemcacheServers() as $sg) {
             $stats = $sg->getExtendedStats();
-            if ($stats === false) {
-                throw new Exception('Failed to get memcache server status.');
+            foreach ($stats as $server => $data) {
+                if ($data === false) {
+                    throw new Exception('Failed to get memcache server status.');
+                }
             }
 
             $stats = SimpleSAML\Utils\Arrays::transpose($stats);


### PR DESCRIPTION
The exception was never raised because $stats will be array('server' => false) on failure instead of just false.
This eventually led to $ret being NULL when one of the servers is down..

Because of this NULL-value, it also led to an empty memcacheMonitor screen.