### PR TITLE
Apache CGI support

### DIFF
--- a/lib/SimpleSAML/Utils/Config.php
+++ b/lib/SimpleSAML/Utils/Config.php
@@ -68,6 +68,11 @@ class Config
     {
         $configDir    = dirname(dirname(dirname(__DIR__))) . '/config';
         $configDirEnv = getenv('SIMPLESAMLPHP_CONFIG_DIR');
+        
+        if($configDirEnv === false) {
+            $configDirEnv = getenv('REDIRECT_SIMPLESAMLPHP_CONFIG_DIR');
+        }
+        
         if ($configDirEnv !== false) {
             if (!is_dir($configDirEnv)) {
                 throw new \InvalidArgumentException(

--- a/tests/lib/SimpleSAML/Utils/ConfigTest.php
+++ b/tests/lib/SimpleSAML/Utils/ConfigTest.php
@@ -34,6 +34,29 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($configDir, __DIR__);
     }
 
+    /**
+     * Test valid dir specified by env redirect var overrides default config dir
+     */
+    public function testEnvRedirectVariableConfigDir()
+    {
+        putenv('REDIRECT_SIMPLESAMLPHP_CONFIG_DIR=' . __DIR__);
+        $configDir = Config::getConfigDir();
+
+        $this->assertEquals($configDir, __DIR__);
+    }
+
+    /**
+     * Test which directory takes precedence
+     */
+    public function testEnvRedirectPriorityVariableConfigDir()
+    {
+        putenv('SIMPLESAMLPHP_CONFIG_DIR=' . dirname(__DIR__));
+        putenv('REDIRECT_SIMPLESAMLPHP_CONFIG_DIR=' . __DIR__);
+        $configDir = Config::getConfigDir();
+
+        $this->assertEquals($configDir, dirname(__DIR__));
+    }
+
 
     /**
      * Test invalid dir specified by env var results in a thrown exception


### PR DESCRIPTION
Option to support Apache CGI in combination with custom config directory.

When setting the environment variable via an htaccess while using PHP via Apache CGI the environment variable gets prefixed with "REDIRECT_". This pull request adds support for reading out the other pull request