### PR TITLE
Sort attribute values for consent

### DIFF
--- a/modules/consent/lib/Auth/Process/Consent.php
+++ b/modules/consent/lib/Auth/Process/Consent.php
@@ -374,6 +374,9 @@ class sspmod_consent_Auth_Process_Consent extends SimpleSAML_Auth_ProcessingFilt
     {
         $hashBase = null;
         if ($includeValues) {
+            foreach ($attributes as &$values) {
+                sort($values);
+            }
             ksort($attributes);
             $hashBase = serialize($attributes);
         } else {

--- a/tests/modules/consent/lib/Auth/Process/ConsentTest.php
+++ b/tests/modules/consent/lib/Auth/Process/ConsentTest.php
@@ -113,4 +113,21 @@ class ConsentTest extends \PHPUnit_Framework_TestCase
         // the state should NOT have changed because NO consent should be necessary (match)
         $this->assertEquals($request, $result);
     }
+
+    public function testAttributeHastIsConsistentWhenOrderOfValuesChange()
+    {
+        $attributes1 = [
+            'attribute1' => ['val1', 'val2'],
+            'attribute2' => ['val1', 'val2']
+        ];
+        $attributeHash1 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes1, true);
+
+        $attributes2 = [
+            'attribute1' => ['val2', 'val1'],
+            'attribute2' => ['val1', 'val2']
+        ];
+        $attributeHash2 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes2, true);
+
+        $this->assertEquals($attributeHash1, $attributeHash2, "Hash is not the same when the order of values changes");
+    }
 }

--- a/tests/modules/consent/lib/Auth/Process/ConsentTest.php
+++ b/tests/modules/consent/lib/Auth/Process/ConsentTest.php
@@ -114,7 +114,7 @@ class ConsentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($request, $result);
     }
 
-    public function testAttributeHastIsConsistentWhenOrderOfValuesChange()
+    public function testAttributeHashIsConsistentWhenOrderOfValuesChange()
     {
         $attributes1 = array(
             'attribute1' => array('val1', 'val2'),

--- a/tests/modules/consent/lib/Auth/Process/ConsentTest.php
+++ b/tests/modules/consent/lib/Auth/Process/ConsentTest.php
@@ -116,16 +116,16 @@ class ConsentTest extends \PHPUnit_Framework_TestCase
 
     public function testAttributeHastIsConsistentWhenOrderOfValuesChange()
     {
-        $attributes1 = [
-            'attribute1' => ['val1', 'val2'],
-            'attribute2' => ['val1', 'val2']
-        ];
+        $attributes1 = array(
+            'attribute1' => array('val1', 'val2'),
+            'attribute2' => array('val1', 'val2')
+        );
         $attributeHash1 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes1, true);
 
-        $attributes2 = [
-            'attribute1' => ['val2', 'val1'],
-            'attribute2' => ['val1', 'val2']
-        ];
+        $attributes2 = array(
+            'attribute1' => array('val1', 'val2'),
+            'attribute2' => array('val2', 'val1')
+        );
         $attributeHash2 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes2, true);
 
         $this->assertEquals($attributeHash1, $attributeHash2, "Hash is not the same when the order of values changes");

--- a/tests/modules/consent/lib/Auth/Process/ConsentTest.php
+++ b/tests/modules/consent/lib/Auth/Process/ConsentTest.php
@@ -147,4 +147,25 @@ class ConsentTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($attributeHash1, $attributeHash2, "Hash is not the same when the order of values changes");
     }
+
+    public function testAttributeHashIsConsistentWithoutValuesWhenOrderOfAttributesChange()
+    {
+        $attributes1 = array(
+            'attribute2' => array('val1', 'val2'),
+            'attribute1' => array('val1', 'val2')
+        );
+        $attributeHash1 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes1);
+
+        $attributes2 = array(
+            'attribute1' => array('val1', 'val2'),
+            'attribute2' => array('val1', 'val2')
+        );
+        $attributeHash2 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes2);
+
+        $this->assertEquals(
+            $attributeHash1,
+            $attributeHash2,
+            "Hash is not the same when the order of the attributs changes and the values are not included"
+        );
+    }
 }

--- a/tests/modules/consent/lib/Auth/Process/ConsentTest.php
+++ b/tests/modules/consent/lib/Auth/Process/ConsentTest.php
@@ -145,7 +145,11 @@ class ConsentTest extends \PHPUnit_Framework_TestCase
         );
         $attributeHash2 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes2, true);
 
-        $this->assertEquals($attributeHash1, $attributeHash2, "Hash is not the same when the order of values changes");
+        $this->assertEquals(
+            $attributeHash1,
+            $attributeHash2,
+            "Hash is not the same when the order of the attributs changes"
+        );
     }
 
     public function testAttributeHashIsConsistentWithoutValuesWhenOrderOfAttributesChange()

--- a/tests/modules/consent/lib/Auth/Process/ConsentTest.php
+++ b/tests/modules/consent/lib/Auth/Process/ConsentTest.php
@@ -130,4 +130,21 @@ class ConsentTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($attributeHash1, $attributeHash2, "Hash is not the same when the order of values changes");
     }
+
+    public function testAttributeHashIsConsistentWhenOrderOfAttributesChange()
+    {
+        $attributes1 = array(
+            'attribute2' => array('val1', 'val2'),
+            'attribute1' => array('val1', 'val2')
+        );
+        $attributeHash1 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes1, true);
+
+        $attributes2 = array(
+            'attribute1' => array('val1', 'val2'),
+            'attribute2' => array('val1', 'val2')
+        );
+        $attributeHash2 = \sspmod_consent_Auth_Process_Consent::getAttributeHash($attributes2, true);
+
+        $this->assertEquals($attributeHash1, $attributeHash2, "Hash is not the same when the order of values changes");
+    }
 }


### PR DESCRIPTION
Fixes simplesamlphp/simplesamlphp#39

This ensures that the attribute hash is the same if the order of the attribute values changes. A user
givers consent to the values, not the order.