### PR TITLE
OTP should be a password field on the form

### DIFF
--- a/modules/authYubiKey/templates/yubikeylogin.php
+++ b/modules/authYubiKey/templates/yubikeylogin.php
@@ -29,7 +29,7 @@ if ($this->data['errorcode'] !== NULL) {
 
 		<p><?php echo $this->t('{authYubiKey:yubikey:intro}'); ?></p>
 	
-		<p><input id="otp" style="border: 1px solid #ccc; background: #eee; padding: .5em; font-size: medium; width: 70%; color: #aaa" type="text" tabindex="2" name="otp" /></p>
+		<p><input id="otp" style="border: 1px solid #ccc; background: #eee; padding: .5em; font-size: medium; width: 70%; color: #aaa" type="password" tabindex="2" name="otp" /></p>
 
 
 


### PR DESCRIPTION
Colleagues commented the OTP is still a password, and really shouldn't be visible in the entry field. So this is a simple change to make the OTP a password field. It's still visible in logs for debug, etc. :-)

Thanks,

Greg