### PR TITLE
docs: Fix the build status buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 SimpleSAMLphp
 =============
-[![Build Status](https://travis-ci.org/simplesamlphp/simplesamlphp.svg?branch=master)]
-(https://travis-ci.org/simplesamlphp/simplesamlphp) [![Coverage Status](https://img.shields.io/coveralls/simplesamlphp/simplesamlphp.svg)] 
-(https://coveralls.io/r/simplesamlphp/simplesamlphp)
+[![Build Status](https://travis-ci.org/simplesamlphp/simplesamlphp.svg?branch=master)](https://travis-ci.org/simplesamlphp/simplesamlphp)
+[![Coverage Status](https://img.shields.io/coveralls/simplesamlphp/simplesamlphp.svg)](https://coveralls.io/r/simplesamlphp/simplesamlphp)
 
 This is the official repository of the SimpleSAMLphp software.
 


### PR DESCRIPTION
The build status buttons are broken. When clicked, they simply point to their own image. The link where the results can be checked are behind the button.

This is simply fixed by removing newlines in the button code, as GitHub markdown doesn't seem to parse it correctly.