### PR TITLE
facebook oauth response format changed

### DIFF
--- a/modules/authfacebook/extlibinc/base_facebook.php
+++ b/modules/authfacebook/extlibinc/base_facebook.php
@@ -790,7 +790,8 @@ abstract class BaseFacebook
     }
 
     $response_params = array();
-    parse_str($access_token_response, $response_params);
+    //parse_str($access_token_response, $response_params);
+    $response_params = json_decode($access_token_response, true);
     if (!isset($response_params['access_token'])) {
       return false;
     }


### PR DESCRIPTION
As of March 27 Facebook has deprecated their V2.2 API, and have change the response format from their access token endpoint from being URL encoded to JSON encoded.

> [Oauth Access Token] Format - The response format of https://www.facebook.com/v2.3/oauth/access_token returned when you exchange a code for an access_token now return valid JSON instead of being URL encoded. The new format of this response is {"access_token": {TOKEN}, "token_type":{TYPE}, "expires_in":{TIME}}. We made this update to be compliant with section 5.1 of RFC 6749.