### PR TITLE
Fix non-standard LDAP ports (assume LDAP URIs in authsources.php)

### DIFF
--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -75,11 +75,18 @@ class SimpleSAML_Auth_LDAP
                 SimpleSAML\Logger::warning('Library - LDAP __construct(): Unable to set debug level (LDAP_OPT_DEBUG_LEVEL) to 7');
         }
 
+        // Port must be specified in LDAP URI
+        $hostname = explode(' ', $hostname);
+        $hostname = array_map(function ($host) use ($port) {
+            return "{$host}:{$port}";
+        }, $hostname);
+        $hostname = implode(' ', $hostname);
+
         /*
          * Prepare a connection for to this LDAP server. Note that this function
          * doesn't actually connect to the server.
          */
-        $this->ldap = @ldap_connect($hostname, $port);
+        $this->ldap = @ldap_connect($hostname);
         if ($this->ldap === false) {
             throw $this->makeException('Library - LDAP __construct(): Unable to connect to \'' . $hostname . '\'', ERR_INTERNAL);
         }


### PR DESCRIPTION
We fixed an issue we were experiencing where non-standard LDAP ports did not work correctly. This was due to the fact that we were specifying LDAP URIs in `authsources.php` (to support multiple servers, as noted in #425) which causes the `$port` param of [`ldap_connect()`](https://secure.php.net/ldap_connect) to be ignored.

However, there are tradeoffs to this solution: On the plus side, the interface for configuring authsources doesn't change; on the negative side, this only works if you define your `authsources.php` with LDAP URIs, and breaks otherwise.

This is also a little odd because if you were to define your `authsources.php` with LDAP URIs, you could just as simply add the port number into the LDAP URI itself.

I don't really expect this to be merged, but I figured I would put it up for discussion.