### PR TITLE
FQDN can be up to 255 chars according to RFC1035 3.1

### DIFF
--- a/modules/saml/lib/SP/LogoutStore.php
+++ b/modules/saml/lib/SP/LogoutStore.php
@@ -14,12 +14,24 @@ class sspmod_saml_SP_LogoutStore {
 	 */
 	private static function createLogoutTable(\SimpleSAML\Store\SQL $store) {
 
-		if ($store->getTableVersion('saml_LogoutStore') === 1) {
+		$tableVer = $store->getTableVersion('saml_LogoutStore');
+		if ($tableVer === 2) {
+			return;
+		} elseif ($tableVer === 1) {
+			/* TableVersion 2 increased the column size to 255 which is the maximum length of a FQDN. */
+			$query = 'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore MODIFY _authSource VARCHAR(255) NOT NULL';
+			try {
+				$ret = $store->pdo->exec($query);
+			} catch (Exception $e) {
+				SimpleSAML\Logger::warning($store->pdo->errorInfo());
+				return;
+			}
+			$store->setTableVersion('saml_LogoutStore', 2);
 			return;
 		}
 
 		$query = 'CREATE TABLE ' . $store->prefix . '_saml_LogoutStore (
-			_authSource VARCHAR(30) NOT NULL,
+			_authSource VARCHAR(255) NOT NULL,
 			_nameId VARCHAR(40) NOT NULL,
 			_sessionIndex VARCHAR(50) NOT NULL,
 			_expire TIMESTAMP NOT NULL,
@@ -34,7 +46,7 @@ class sspmod_saml_SP_LogoutStore {
 		$query = 'CREATE INDEX ' . $store->prefix . '_saml_LogoutStore_nameId ON '  . $store->prefix . '_saml_LogoutStore (_authSource, _nameId)';
 		$store->pdo->exec($query);
 
-		$store->setTableVersion('saml_LogoutStore', 1);
+		$store->setTableVersion('saml_LogoutStore', 2);
 	}
 
 


### PR DESCRIPTION
Fixes #579.

According to [RFC1035 3.1](https://tools.ietf.org/html/rfc1035#section-3.1) and [RFC 2181 11](https://tools.ietf.org/html/rfc2181#section-11), domain names can be up to 255 in size.