### PR TITLE
Add REMOTE_ADDR to successful auth and user name to unsuccessful log …

### DIFF
--- a/modules/core/lib/Auth/UserPassBase.php
+++ b/modules/core/lib/Auth/UserPassBase.php
@@ -256,7 +256,7 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 			throw $e;
 		}
 
-		SimpleSAML\Logger::stats('User \''.$username.'\' Successfully authenticated from '.$_SERVER['REMOTE_ADDR']);
+		SimpleSAML\Logger::stats('User \''.$username.'\' successfully authenticated from '.$_SERVER['REMOTE_ADDR']);
 
 		/* Save the attributes we received from the login-function in the $state-array. */
 		assert('is_array($attributes)');

--- a/modules/core/lib/Auth/UserPassBase.php
+++ b/modules/core/lib/Auth/UserPassBase.php
@@ -252,11 +252,11 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 		try {
 			$attributes = $source->login($username, $password);
 		} catch (Exception $e) {
-			SimpleSAML\Logger::stats('Unsuccessful login attempt from '.$_SERVER['REMOTE_ADDR'].'.');
+			SimpleSAML\Logger::stats('User \''.$username.'\' Unsuccessful login attempt from '.$_SERVER['REMOTE_ADDR']);
 			throw $e;
 		}
 
-		SimpleSAML\Logger::stats('User \''.$username.'\' has been successfully authenticated.');
+		SimpleSAML\Logger::stats('User \''.$username.'\' Successfully authenticated from '.$_SERVER['REMOTE_ADDR']);
 
 		/* Save the attributes we received from the login-function in the $state-array. */
 		assert('is_array($attributes)');

--- a/modules/core/lib/Auth/UserPassBase.php
+++ b/modules/core/lib/Auth/UserPassBase.php
@@ -252,7 +252,7 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 		try {
 			$attributes = $source->login($username, $password);
 		} catch (Exception $e) {
-			SimpleSAML\Logger::stats('User \''.$username.'\' Unsuccessful login attempt from '.$_SERVER['REMOTE_ADDR']);
+			SimpleSAML\Logger::stats('Unsuccessful login attempt from '.$_SERVER['REMOTE_ADDR'].'.');
 			throw $e;
 		}
 


### PR DESCRIPTION
Because the logging can be inconsistent on the SP side, I'd like to add the REMOTE_ADDR to the logging message of successful logins. This extra info will help administrators identify compromised accounts.
Added the username to the unsuccessful log message to help identify specific accounts that are being attacked. 