### PR TITLE
Added NameID Functions For SimpleSAML_Auth_Simple

### DIFF
--- a/lib/SimpleSAML/Auth/Simple.php
+++ b/lib/SimpleSAML/Auth/Simple.php
@@ -293,6 +293,46 @@ class SimpleSAML_Auth_Simple
 
 
     /**
+     * Retrieves NameID data.
+     *
+     * @param string $name The name of the parameter, e.g. 'Value', 'Format'
+     *
+     * @return string|null The value of the parameter, or null if it isn't found or we are unauthenticated.
+     */
+    public function getNameIDData($name)
+    {
+        assert('is_string($name)');
+
+        if (!$this->isAuthenticated()) {
+            return null;
+        }
+
+        $nameIdData = $this->getAuthData('saml:sp:NameID');
+
+        if (isset($nameIdData[$name])) {
+            return $nameIdData[$name];
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Retrieve all the NameID data.
+     *
+     * @return array|null All the NameID data, or null if we aren't authenticated
+     */
+    public function getNameIDDataArray()
+    {
+        if (!$this->isAuthenticated()) {
+            return null;
+        }
+
+        return $this->getAuthData('saml:sp:NameID');
+    }
+
+
+    /**
      * Retrieve a URL that can be used to log the user in.
      *
      * @param string|null $returnTo The page the user should be returned to afterwards. If this parameter is null, the

--- a/lib/SimpleSAML/Auth/Simple.php
+++ b/lib/SimpleSAML/Auth/Simple.php
@@ -291,46 +291,53 @@ class SimpleSAML_Auth_Simple
         return $session->getAuthState($this->authSource);
     }
 
-
     /**
-     * Retrieves NameID data.
+     * Retrieves the NameID Value.
      *
-     * @param string $name The name of the parameter, e.g. 'Value', 'Format'
-     *
-     * @return string|null The value of the parameter, or null if it isn't found or we are unauthenticated.
+     * @return string|null The NameID Value, or null if it isn't found or we are unauthenticated.
      */
-    public function getNameIDData($name)
+    public function getNameIDValue()
     {
-        assert('is_string($name)');
-
         if (!$this->isAuthenticated()) {
             return null;
         }
 
         $nameIdData = $this->getAuthData('saml:sp:NameID');
 
-        if (isset($nameIdData[$name])) {
-            return $nameIdData[$name];
-        }
-
-        return null;
+        return (isset($nameIdData['Value'])) ? $nameIdData['Value'] : null;
     }
 
-
     /**
-     * Retrieve all the NameID data.
+     * Retrieves the NameID Format.
      *
-     * @return array|null All the NameID data, or null if we aren't authenticated
+     * @return string|null The NameID Format, or null if it isn't found or we are unauthenticated.
      */
-    public function getNameIDDataArray()
+    public function getNameIDFormat()
     {
         if (!$this->isAuthenticated()) {
             return null;
         }
 
-        return $this->getAuthData('saml:sp:NameID');
+        $nameIdData = $this->getAuthData('saml:sp:NameID');
+
+        return (isset($nameIdData['Format'])) ? $nameIdData['Format'] : null;
     }
 
+    /**
+     * Retrieves the NameID SPNameQualifier.
+     *
+     * @return string|null The NameID SPNameQualifier, or null if it isn't found or we are unauthenticated.
+     */
+    public function getNameIDNameQualifier()
+    {
+        if (!$this->isAuthenticated()) {
+            return null;
+        }
+
+        $nameIdData = $this->getAuthData('saml:sp:NameID');
+
+        return (isset($nameIdData['SPNameQualifier'])) ? $nameIdData['SPNameQualifier'] : null;
+    }
 
     /**
      * Retrieve a URL that can be used to log the user in.

--- a/tests/lib/SimpleSAML/Auth/SimpleTest.php
+++ b/tests/lib/SimpleSAML/Auth/SimpleTest.php
@@ -6,73 +6,23 @@
 class Auth_SimpleTest extends PHPUnit_Framework_TestCase
 {
 
-    /**
-     * Test that getNameIDDataArray() returns null if the user is not authorized.
-     */
-    public function testGetNameIDDataArrayReturnsNullIfNotAuthorized()
+    public function testGetNameIDHelpersReturnsNullIfNotAuthorized()
     {
         $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
             ->disableOriginalConstructor()
             ->setMethods(array('isAuthenticated'))
             ->getMock();
 
-        $auth->expects($this->once())
+        $auth->expects($this->exactly(3))
             ->method('isAuthenticated')
             ->willReturn(false);
 
-        $this->assertNull($auth->getNameIDDataArray());
+        $this->assertNull($auth->getNameIDValue());
+        $this->assertNull($auth->getNameIDFormat());
+        $this->assertNull($auth->getNameIDNameQualifier());
     }
 
-    /**
-     * Test that getNameIDDataArray() returns an array
-     */
-    public function testGetNameIDDataArrayReturnsArray()
-    {
-        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
-            ->disableOriginalConstructor()
-            ->setMethods(array('isAuthenticated', 'getAuthData'))
-            ->getMock();
-
-        $auth->expects($this->once())
-            ->method('isAuthenticated')
-            ->willReturn(true);
-
-        $auth->expects($this->once())
-            ->method('getAuthData')
-            ->with('saml:sp:NameID')
-            ->willReturn(array(
-                'Value' => '12345',
-                'SPNameQualifier' => 'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
-                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
-            ));
-
-        $nameIDData = $auth->getNameIDDataArray();
-
-        $this->assertTrue(is_array($nameIDData));
-        $this->assertArrayHasKey('Value', $nameIDData);
-        $this->assertArrayHasKey('SPNameQualifier', $nameIDData);
-        $this->assertArrayHasKey('Format', $nameIDData);
-
-        $this->assertEquals(
-            '12345',
-            $nameIDData['Value']
-        );
-
-        $this->assertEquals(
-            'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
-            $nameIDData['SPNameQualifier']
-        );
-
-        $this->assertEquals(
-            'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-            $nameIDData['Format']
-        );
-    }
-
-    /**
-     * Test that getNameIDData() returns a value if it is set
-     */
-    public function testGetNameIDData()
+    public function testGetNameIDHelpersReturnProperValues()
     {
         $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
             ->disableOriginalConstructor()
@@ -88,66 +38,23 @@ class Auth_SimpleTest extends PHPUnit_Framework_TestCase
             ->with('saml:sp:NameID')
             ->willReturn(array(
                 'Value' => '12345',
-                'SPNameQualifier' => 'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
-                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+                'SPNameQualifier' => 'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com'
             ));
 
         $this->assertEquals(
             '12345',
-            $auth->getNameIDData('Value')
-        );
-
-        $this->assertEquals(
-            'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
-            $auth->getNameIDData('SPNameQualifier')
+            $auth->getNameIDValue()
         );
 
         $this->assertEquals(
             'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-            $auth->getNameIDData('Format')
+            $auth->getNameIDFormat()
         );
-    }
 
-    /**
-     * Test that getNameIDData() returns null if the user is not authorized.
-     */
-    public function testGetNameIDDataReturnsNullIfNotAuthorized()
-    {
-        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
-            ->disableOriginalConstructor()
-            ->setMethods(array('isAuthenticated'))
-            ->getMock();
-
-        $auth->expects($this->once())
-            ->method('isAuthenticated')
-            ->willReturn(false);
-
-        $this->assertNull($auth->getNameIDData('Value'));
-    }
-
-    /**
-     * Test that getNameIDData() returns null if the value is not set
-     */
-    public function testGetNameIDDataReturnsNullIfNotSet()
-    {
-        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
-            ->disableOriginalConstructor()
-            ->setMethods(array('isAuthenticated', 'getAuthData'))
-            ->getMock();
-
-        $auth->expects($this->once())
-            ->method('isAuthenticated')
-            ->willReturn(true);
-
-        $auth->expects($this->once())
-            ->method('getAuthData')
-            ->with('saml:sp:NameID')
-            ->willReturn(array(
-                'Value' => '12345',
-                'SPNameQualifier' => 'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
-                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
-            ));
-
-        $this->assertNull($auth->getNameIDData('DoesNotExist'));
+        $this->assertEquals(
+            'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
+            $auth->getNameIDNameQualifier()
+        );
     }
 }

--- a/tests/lib/SimpleSAML/Auth/SimpleTest.php
+++ b/tests/lib/SimpleSAML/Auth/SimpleTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Tests for SimpleSAML_Auth_Simple
+ */
+class Auth_SimpleTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test that getNameIDDataArray() returns null if the user is not authorized.
+     */
+    public function testGetNameIDDataArrayReturnsNullIfNotAuthorized()
+    {
+        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
+            ->disableOriginalConstructor()
+            ->setMethods(array('isAuthenticated'))
+            ->getMock();
+
+        $auth->expects($this->once())
+            ->method('isAuthenticated')
+            ->willReturn(false);
+
+        $this->assertNull($auth->getNameIDDataArray());
+    }
+
+    /**
+     * Test that getNameIDDataArray() returns an array
+     */
+    public function testGetNameIDDataArrayReturnsArray()
+    {
+        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
+            ->disableOriginalConstructor()
+            ->setMethods(array('isAuthenticated', 'getAuthData'))
+            ->getMock();
+
+        $auth->expects($this->once())
+            ->method('isAuthenticated')
+            ->willReturn(true);
+
+        $auth->expects($this->once())
+            ->method('getAuthData')
+            ->with('saml:sp:NameID')
+            ->willReturn(array(
+                'Value' => '12345',
+                'SPNameQualifier' => 'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+            ));
+
+        $nameIDData = $auth->getNameIDDataArray();
+
+        $this->assertTrue(is_array($nameIDData));
+        $this->assertArrayHasKey('Value', $nameIDData);
+        $this->assertArrayHasKey('SPNameQualifier', $nameIDData);
+        $this->assertArrayHasKey('Format', $nameIDData);
+
+        $this->assertEquals(
+            '12345',
+            $nameIDData['Value']
+        );
+
+        $this->assertEquals(
+            'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
+            $nameIDData['SPNameQualifier']
+        );
+
+        $this->assertEquals(
+            'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+            $nameIDData['Format']
+        );
+    }
+
+    /**
+     * Test that getNameIDData() returns a value if it is set
+     */
+    public function testGetNameIDData()
+    {
+        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
+            ->disableOriginalConstructor()
+            ->setMethods(array('isAuthenticated', 'getAuthData'))
+            ->getMock();
+
+        $auth->expects($this->exactly(3))
+            ->method('isAuthenticated')
+            ->willReturn(true);
+
+        $auth->expects($this->exactly(3))
+            ->method('getAuthData')
+            ->with('saml:sp:NameID')
+            ->willReturn(array(
+                'Value' => '12345',
+                'SPNameQualifier' => 'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+            ));
+
+        $this->assertEquals(
+            '12345',
+            $auth->getNameIDData('Value')
+        );
+
+        $this->assertEquals(
+            'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
+            $auth->getNameIDData('SPNameQualifier')
+        );
+
+        $this->assertEquals(
+            'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+            $auth->getNameIDData('Format')
+        );
+    }
+
+    /**
+     * Test that getNameIDData() returns null if the user is not authorized.
+     */
+    public function testGetNameIDDataReturnsNullIfNotAuthorized()
+    {
+        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
+            ->disableOriginalConstructor()
+            ->setMethods(array('isAuthenticated'))
+            ->getMock();
+
+        $auth->expects($this->once())
+            ->method('isAuthenticated')
+            ->willReturn(false);
+
+        $this->assertNull($auth->getNameIDData('Value'));
+    }
+
+    /**
+     * Test that getNameIDData() returns null if the value is not set
+     */
+    public function testGetNameIDDataReturnsNullIfNotSet()
+    {
+        $auth = $this->getMockBuilder('SimpleSAML_Auth_Simple')
+            ->disableOriginalConstructor()
+            ->setMethods(array('isAuthenticated', 'getAuthData'))
+            ->getMock();
+
+        $auth->expects($this->once())
+            ->method('isAuthenticated')
+            ->willReturn(true);
+
+        $auth->expects($this->once())
+            ->method('getAuthData')
+            ->with('saml:sp:NameID')
+            ->willReturn(array(
+                'Value' => '12345',
+                'SPNameQualifier' => 'http:/localhost/saml/module.php/saml/sp/metadata.php/example.com',
+                'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+            ));
+
+        $this->assertNull($auth->getNameIDData('DoesNotExist'));
+    }
+}


### PR DESCRIPTION
I've added two functions in `SimpleSAML_Auth_Simple ` to more easily gather NameID information.

```php
$auth = new SimpleSAML_Auth_Simple('some-auth-source');
$auth->getNameIDData('Value');
$auth->getNameIDDataArray();
```
These helper functions provide a shortcut to the NameID information, rather than going through `SimpleSAML_Auth_Simple::getAuthData()`.