### PR TITLE
Added metadata configuration options for 'index' and 'isDefault' attributes in AttributeConsumingService element

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -403,7 +403,11 @@ class SimpleSAML_Metadata_SAMLBuilder
          */
         $attributeconsumer = new \SAML2\XML\md\AttributeConsumingService();
 
-        $attributeconsumer->index = 0;
+        $attributeconsumer->index = $metadata->getInteger('attributes.index', 0);
+
+        if ($metadata->hasValue('attributes.isDefault')) {
+            $attributeconsumer->isDefault = $metadata->getBoolean('attributes.isDefault', false);
+        }
 
         $attributeconsumer->ServiceName = $name;
         $attributeconsumer->ServiceDescription = $metadata->getLocalizedString('description', array());

--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -708,6 +708,12 @@ class SimpleSAML_Metadata_SAMLParser
         if (array_key_exists('attributes.NameFormat', $spd)) {
             $ret['attributes.NameFormat'] = $spd['attributes.NameFormat'];
         }
+        if (array_key_exists('attributes.index', $spd)) {
+            $ret['attributes.index'] = $spd['attributes.index'];
+        }
+        if (array_key_exists('attributes.isDefault', $spd)) {
+            $ret['attributes.isDefault'] = $spd['attributes.isDefault'];
+        }
 
         // add name & description
         if (array_key_exists('name', $spd)) {

--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -125,6 +125,12 @@ Options
 `attributes.NameFormat`
 :   The `NameFormat` for the requested attributes.
 
+`attributes.index`
+:   The `index` attribute that is set in the md:AttributeConsumingService element. Integer value that defaults to `0`.
+
+`attributes.isDefault`
+:   If present, sets the `isDefault` attribute in the md:AttributeConsumingService element. Boolean value that defaults to `false`.
+
 `attributes.required`
 : If you have attributes added you can here specify which should be marked as required.
 : The attributes should still be present in `attributes`.

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -148,6 +148,14 @@ if ($name !== null && !empty($attributes)) {
     if ($nameFormat !== null) {
         $metaArray20['attributes.NameFormat'] = $nameFormat;
     }
+
+    if ($spconfig->hasValue('attributes.index')) {
+        $metaArray20['attributes.index'] = $spconfig->getInteger('attributes.index', 0);
+    }
+
+    if ($spconfig->hasValue('attributes.isDefault')) {
+        $metaArray20['attributes.isDefault'] = $spconfig->getBoolean('attributes.isDefault', false);
+    }
 }
 
 // add organization info


### PR DESCRIPTION
This patch adds two metadata configuration options for 'index' and 'isDefault' attributes. We had to be able to output the isDefault attribute in the AttributeConsumingService element.
I don't know if 'attributes.index' and 'attributes.isDefault' is the best and correct names for the options, so please feel free to comment on this if needed.