### PR TITLE
SAMLBuilder AttributeAuthorityDescriptor empty protocolSupportEnumeration

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -646,7 +646,7 @@ class SimpleSAML_Metadata_SAMLBuilder
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
 
         $e = new \SAML2\XML\md\AttributeAuthorityDescriptor();
-        $e->protocolSupportEnumeration = $metadata->getArray('protocols', array());
+        $e->protocolSupportEnumeration = $metadata->getArray('protocols', array('urn:oasis:names:tc:SAML:2.0:protocol'));
 
         $this->addExtensions($metadata, $e);
         $this->addCertificate($e, $metadata);

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -646,7 +646,7 @@ class SimpleSAML_Metadata_SAMLBuilder
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
 
         $e = new \SAML2\XML\md\AttributeAuthorityDescriptor();
-        $e->protocolSupportEnumeration = $metadata->getArray('protocols', array('urn:oasis:names:tc:SAML:2.0:protocol'));
+        $e->protocolSupportEnumeration = $metadata->getArray('protocols', array(\SAML2\Constants::NS_SAMLP));
 
         $this->addExtensions($metadata, $e);
         $this->addCertificate($e, $metadata);

--- a/tests/lib/SimpleSAML/Metadata/SAMLBuilderTest.php
+++ b/tests/lib/SimpleSAML/Metadata/SAMLBuilderTest.php
@@ -134,4 +134,52 @@ class SimpleSAML_Metadata_SAMLBuilderTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($keys[$c], $curAttribute->getAttribute("FriendlyName"));
         }
     }
+
+    /**
+     * Test the required protocolSupportEnumeration in AttributeAuthorityDescriptor
+     */
+    public function testProtocolSupportEnumeration()
+    {
+        $entityId = 'https://entity.example.com/id';
+        $set = 'attributeauthority-remote';
+
+        // without protocolSupportEnumeration fallback to default: urn:oasis:names:tc:SAML:2.0:protocol
+        $metadata = array(
+            'entityid'     => $entityId,
+            'name'         => array('en' => 'Test AA'),
+            'metadata-set' => $set,
+            'AttributeService' =>
+                array (
+                    0 =>
+                        array (
+                            'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP',
+                            'Location' => 'https://entity.example.com:8443/idp/profile/SAML2/SOAP/AttributeQuery',
+                        ),
+                ),
+            );
+
+        $samlBuilder = new SimpleSAML_Metadata_SAMLBuilder($entityId);
+        $samlBuilder->addMetadata($set, $metadata);
+        $entityDescriptorXml = $samlBuilder->getEntityDescriptorText();
+
+        $this->assertRegExp(
+            '/<md:AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">/',
+            $entityDescriptorXml
+        );
+
+        // explicit protocols
+        $metadata['protocols'] =
+            array(
+                0 => 'urn:oasis:names:tc:SAML:1.1:protocol',
+                1 => 'urn:oasis:names:tc:SAML:2.0:protocol',
+            );
+        $samlBuilder = new SimpleSAML_Metadata_SAMLBuilder($entityId);
+        $samlBuilder->addMetadata($set, $metadata);
+        $entityDescriptorXml = $samlBuilder->getEntityDescriptorText();
+
+        $this->assertRegExp(
+            '/<md:AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:2.0:protocol">/',
+            $entityDescriptorXml
+        );
+    }
 }


### PR DESCRIPTION
When there is no `protocols` in `attributeauthority-remote` metadata, the generated xml by SAMLBuilder contains `AttributeAuthorityDescriptor` tag with protocolSupportEnumeration attribute with empty string. 

Shibboleth SPs ignore these entities.
