### PR TITLE
Make POST template compatible with CSP

### DIFF
--- a/templates/post.php
+++ b/templates/post.php
@@ -1,34 +1,47 @@
+<?php
+$wwwlib = sprintf(
+    "//%s/%sresources/", 
+    htmlentities($_SERVER['SERVER_NAME']), 
+    htmlentities($this->data['baseurlpath'])
+);
+?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-	<title>POST data</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>POST data</title>
+    <script type="text/javascript" src="<?php echo $wwwlib;?>post.js"></script>
+    <link 
+        type="text/css" rel="stylesheet" href="<?php echo $wwwlib;?>post.css" />
 </head>
-<body onload="document.getElementsByTagName('input')[0].click();">
+<body>
 
-	<noscript>
-		<p><strong>Note:</strong> Since your browser does not support JavaScript, you must press the button below once to proceed.</p> 
-	</noscript> 
-	
-	<form method="post" action="<?php echo htmlspecialchars($this->data['destination']); ?>">
-	<!-- Need to add this element and call click method, because calling submit()
-	on the form causes failed submission if the form has another element with name or id of submit.
-	See: https://developer.mozilla.org/en/DOM/form.submit#Specification -->
-	<input type="submit" style="display:none;" />
+    <noscript>
+        <p><strong>Note:</strong> 
+        Since your browser does not support JavaScript, 
+        you must press the button below once to proceed.</p> 
+    </noscript> 
+
+    <form method="post" 
+        action="<?php echo htmlspecialchars($this->data['destination']); ?>">
+    <!-- Need to add this element and call click method, because calling 
+    submit() on the form causes failed submission if the form has another 
+    element with name or id of submit.
+    See: https://developer.mozilla.org/en/DOM/form.submit#Specification -->
+    <input type="submit" id="postLoginSubmitButton"/>
 <?php
 if (array_key_exists('post', $this->data)) {
-	$post = $this->data['post'];
+    $post = $this->data['post'];
 } else {
-	// For backwards compatibility
-	assert('array_key_exists("response", $this->data)');
-	assert('array_key_exists("RelayStateName", $this->data)');
-	assert('array_key_exists("RelayState", $this->data)');
-
-	$post = array(
-		'SAMLResponse' => $this->data['response'],
-		$this->data['RelayStateName'] => $this->data['RelayState'],
-	);
+    // For backwards compatibility
+    assert('array_key_exists("response", $this->data)');
+    assert('array_key_exists("RelayStateName", $this->data)');
+    assert('array_key_exists("RelayState", $this->data)');
+        $post = array(
+        'SAMLResponse' => $this->data['response'],
+        $this->data['RelayStateName'] => $this->data['RelayState'],
+    );
 }
 
 /**
@@ -42,29 +55,29 @@ if (array_key_exists('post', $this->data)) {
  * @param string|array $value  The value of the element.
  */
 function printItem($name, $value) {
-	assert('is_string($name)');
-	assert('is_string($value) || is_array($value)');
-
-	if (is_string($value)) {
-		echo '<input type="hidden" name="' . htmlspecialchars($name) . '" value="' . htmlspecialchars($value) . '" />';
-		return;
-	}
-
-	// This is an array...
-	foreach ($value as $index => $item) {
-		printItem($name . '[' . $index . ']', $item);
-	}
+    assert('is_string($name)');
+    assert('is_string($value) || is_array($value)');
+    if (is_string($value)) {
+        echo '<input type="hidden" name="' . 
+            htmlspecialchars($name) . '" value="' . 
+            htmlspecialchars($value) . '" />';
+        return;
+    }
+    // This is an array...
+    foreach ($value as $index => $item) {
+        printItem($name . '[' . $index . ']', $item);
+    }
 }
 
 foreach ($post as $name => $value) {
-	printItem($name, $value);
+    printItem($name, $value);
 }
 ?>
 
-		<noscript>
-			<button type="submit" class="btn">Submit</button>
-		</noscript>
-	</form>
+        <noscript>
+            <button type="submit" class="btn">Submit</button>
+        </noscript>
+    </form>
 
 </body>
 </html>

--- a/templates/post.php
+++ b/templates/post.php
@@ -1,19 +1,16 @@
 <?php
-$wwwlib = sprintf(
-    "//%s/%sresources/", 
-    htmlentities($_SERVER['SERVER_NAME']), 
-    htmlentities($this->data['baseurlpath'])
-);
+use SimpleSAML\Utils\HTTP;
 ?>
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>POST data</title>
-    <script type="text/javascript" src="<?php echo $wwwlib;?>post.js"></script>
+    <script type="text/javascript" src="<?php echo HTTP::getBaseURL();?>/resources/post.js"></script>
     <link 
-        type="text/css" rel="stylesheet" href="<?php echo $wwwlib;?>post.css" />
+        type="text/css" rel="stylesheet" href="<?php echo HTTP::getBaseURL();?>/resources/post.css" />
 </head>
 <body>
 

--- a/templates/post.php
+++ b/templates/post.php
@@ -1,16 +1,12 @@
-<?php
-use SimpleSAML\Utils\HTTP;
-?>
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>POST data</title>
-    <script type="text/javascript" src="<?php echo HTTP::getBaseURL();?>/resources/post.js"></script>
+    <script type="text/javascript" src="/<?php echo $this->data['baseurlpath']; ?>resources/post.js"></script>
     <link 
-        type="text/css" rel="stylesheet" href="<?php echo HTTP::getBaseURL();?>/resources/post.css" />
+        type="text/css" rel="stylesheet" href="/<?php echo $this->data['baseurlpath']; ?>resources/post.css" />
 </head>
 <body>
 

--- a/www/resources/post.css
+++ b/www/resources/post.css
@@ -1,0 +1,3 @@
+input#postLoginSubmitButton {
+    display:none;
+}

--- a/www/resources/post.js
+++ b/www/resources/post.js
@@ -1,0 +1,7 @@
+/**
+ * Automatically click the input button to redirect the user to
+ * the SSO
+ */
+window.onload = function(){
+    document.getElementById('postLoginSubmitButton').click();
+};


### PR DESCRIPTION
See issue #593 for a problem description.
SimpleSamlPHP makes use of unsafe inline Javascript and CSS elements.
Although most generated HTML uses SimpleSamlPHP's own headers, the
keepPost option in an authentication request uses the headers of
the PHP application it is sent from. This forces web applications
using SimpleSamlPHP to allow 'unsafe-inline' in their Content
Security Policy.

This commit fixes this issue for the keepPost page ''only'', to
allow PHP applications using SimpleSamlPHP to use a more strict
Content Security Policy. This does not take away from possible
XSS vulnerabilities in other parts of SimpleSamlPHP

In accordance with the coding standards in CONTRIBUTE.md, all tabs in templates/post.php have been replaced by four spaces as well.

One unit test fails:
 There was 1 failure:
 
 1) Test_SimpleSAML_Configuration::testLoadDefaultInstance
 Failed asserting that exception of type "\SimpleSAML\Error\CriticalConfigurationError" is thrown.

As this was already the case on the master branch, and as this seems quite a different problem, I have not taken it upon myself to fix this issue.