### PR TITLE
Disco suggest algorithm accepts also -_() characters

### DIFF
--- a/modules/discopower/www/js/suggest.js
+++ b/modules/discopower/www/js/suggest.js
@@ -12,7 +12,7 @@ String.prototype.score = function(abbreviation,offset) {
 			suggest_cache['re'][i] = new Array();
 			// /\b<x>/ doesn't work when <x> i a non-ascii - oddly enough \s does ...
 			suggest_cache['re'][i]['initialword'] = new RegExp("^"+words[i], "i");
-			suggest_cache['re'][i]['word'] = new RegExp("\\s"+words[i], "i");
+			suggest_cache['re'][i]['word'] = new RegExp("[\\s-()_]"+words[i], "i");
 		}
 	}
 


### PR DESCRIPTION
When IdP has e.g. acronym in the name covered by () or there is dash in the name, then the current suggest algorithm doesn't split the name correctly, so disco doesn't show the name of the organization when you type the acronym or something which is in brackets.