### PR TITLE
IDP SAML2: added 'as:Reauth'

### DIFF
--- a/lib/SimpleSAML/IdP.php
+++ b/lib/SimpleSAML/IdP.php
@@ -413,6 +413,10 @@ class SimpleSAML_IdP
                 assert('FALSE');
             } else {
                 $this->reauthenticate($state);
+                if(isset($state['as:Reauth'])) {
+                    $this->authenticate($state);
+                    assert('FALSE');
+                }
             }
             $this->postAuth($state);
         } catch (SimpleSAML_Error_Exception $e) {


### PR DESCRIPTION
Allow AuthenticationSource to decide, in reauthenticate method, if user has to forcedly reauthenticate.

I don't know it "as:" prefix is correct. If the feature is considered interesting, let's suggest the correct one.