### PR TITLE
Invalidate opcache after writing a file

### DIFF
--- a/lib/SimpleSAML/Utils/System.php
+++ b/lib/SimpleSAML/Utils/System.php
@@ -203,5 +203,9 @@ class System
                 'Error moving "'.$tmpFile.'" to "'.$filename.'": '.$error['message']
             );
         }
+
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($filename);
+        }
     }
 }


### PR DESCRIPTION
When opcache.validate_timestamps is disabled, then the new metadata will not be read after a metarefresh. This can be solved by adding the metadata file to an opcache blacklist, but calling opcache_invalidate() after writing a file is a nice out-of-the-box solution.

Hopefully, this will enable everybody that is using simplesamlphp to disable opcache.validate_timestamps without running into problems.