### PR TITLE
Skip logging statistics when we have a passive request

### DIFF
--- a/modules/core/docs/authproc_statisticswithattribute.md
+++ b/modules/core/docs/authproc_statisticswithattribute.md
@@ -12,6 +12,9 @@ Parameters
 `type`
 :   The type of the statistics entry.
 
+`skipPassive`
+:   A boolean indicating whether passive requests should be skipped. Defaults to `FALSE`, in which case the type tag is prefixed with 'passive-'.
+
 
 Example
 -------

--- a/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
+++ b/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
@@ -16,6 +16,8 @@ class sspmod_core_Auth_Process_StatisticsWithAttribute extends SimpleSAML_Auth_P
 	
 	private $typeTag = 'saml20-idp-SSO';
 
+	private $skipPassive = false;
+
 
 	/**
 	 * Initialize this filter.
@@ -41,6 +43,10 @@ class sspmod_core_Auth_Process_StatisticsWithAttribute extends SimpleSAML_Auth_P
 				throw new Exception('Invalid typeTag given to core:StatisticsWithAttribute filter.');
 			}
 		}
+
+		if (array_key_exists('skipPassive', $config)) {
+			$this->skipPassive = (bool)$config['skipPassive'];
+		}
 	}
 
 
@@ -56,10 +62,14 @@ class sspmod_core_Auth_Process_StatisticsWithAttribute extends SimpleSAML_Auth_P
 		$logAttribute = 'NA';
 		$source = 'NA';
 		$dest = 'NA';
+		$isPassive = '';
 
 		if(array_key_exists('isPassive', $state) && $state['isPassive'] === true) {
-			// We have a passive request. Skip logging statistics
-			return;
+			if ($this->skipPassive === true) {
+				// We have a passive request. Skip logging statistics
+				return;
+			}
+			$isPassive = 'passive-';
 		}
 
 		if (array_key_exists($this->attribute, $state['Attributes'])) $logAttribute = $state['Attributes'][$this->attribute][0];		
@@ -81,10 +91,10 @@ class sspmod_core_Auth_Process_StatisticsWithAttribute extends SimpleSAML_Auth_P
 
 		if (!array_key_exists('PreviousSSOTimestamp', $state)) {
 			// The user hasn't authenticated with this SP earlier in this session
-			SimpleSAML\Logger::stats($this->typeTag . '-first ' . $dest . ' ' . $source . ' ' . $logAttribute);
+			SimpleSAML\Logger::stats($isPassive . $this->typeTag . '-first ' . $dest . ' ' . $source . ' ' . $logAttribute);
 		}
 
-		SimpleSAML\Logger::stats($this->typeTag . ' ' . $dest . ' ' . $source . ' ' . $logAttribute);
+		SimpleSAML\Logger::stats($isPassive . $this->typeTag . ' ' . $dest . ' ' . $source . ' ' . $logAttribute);
 	}
 
 }

--- a/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
+++ b/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
@@ -57,6 +57,11 @@ class sspmod_core_Auth_Process_StatisticsWithAttribute extends SimpleSAML_Auth_P
 		$source = 'NA';
 		$dest = 'NA';
 
+		if(array_key_exists('isPassive', $state) && $state['isPassive'] === true) {
+			// We have a passive request. Skip logging statistics
+			return;
+		}
+
 		if (array_key_exists($this->attribute, $state['Attributes'])) $logAttribute = $state['Attributes'][$this->attribute][0];		
 		if (array_key_exists('Source', $state)) {
 			if (isset($state['Source']['core:statistics-id'])) {


### PR DESCRIPTION
At the moment, the consentAdmin module generates a lot of spurious saml20-idp-SSO logs as it passes passively through the authproc filters to determine its attribute set. This has the potential to badly skew any statistics of login attempts, such as those generated by the statistics module. Because the passive state is not logged, there's no way to differentiate those generated passively from a genuine login.

This patch causes the StatisticsWithAttribute filter to be skipped when we have a passive request.