### PR TITLE
Remove sensitive data from logs during LDAP filters

### DIFF
--- a/modules/ldap/lib/Auth/Process/BaseFilter.php
+++ b/modules/ldap/lib/Auth/Process/BaseFilter.php
@@ -280,7 +280,7 @@ abstract class sspmod_ldap_Auth_Process_BaseFilter extends SimpleSAML_Auth_Proce
             ' Referrals: ' . ($referrals ? 'Yes' : 'No') .
             ' Timeout: ' . $timeout .
             ' Username: ' . $username .
-            ' Password: ' . str_repeat('*', strlen($password))
+            ' Password: ' . (empty($password) ? '' : '********')
         );
 
         // Connect to the LDAP server to be queried during processing
@@ -300,8 +300,16 @@ abstract class sspmod_ldap_Auth_Process_BaseFilter extends SimpleSAML_Auth_Proce
      * @param mixed $value
      * @return string
      */
-    protected function var_export($value)
+    public function var_export($value)
     {
+        // Remove sensitive data
+        foreach ($value as $key => &$val) {
+            if ($key === 'ldap.password') {
+                $val = empty($val) ? '' : '********';
+            }
+        }
+        unset($val);
+
         $export = var_export($value, true);
         $lines = explode("\n", $export);
         foreach ($lines as &$line) {

--- a/tests/modules/ldap/lib/Auth/Process/BaseFilterTest.php
+++ b/tests/modules/ldap/lib/Auth/Process/BaseFilterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class sspmod_ldap_Auth_Process_BaseFilter_Test extends PHPUnit_Framework_TestCase
+{
+    public function testVarExportHidesLdapPassword()
+    {
+        $stub = $this->getMockBuilder('sspmod_ldap_Auth_Process_BaseFilter')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->assertEquals(
+            "array ( 'ldap.hostname' => 'ldap://172.17.101.32', 'ldap.port' => 389, 'ldap.password' => '********', )",
+            $stub->var_export(array(
+                'ldap.hostname' => 'ldap://172.17.101.32',
+                'ldap.port' => 389,
+                'ldap.password' => 'password',
+            ))
+        );
+    }
+}


### PR DESCRIPTION
Remove `ldap.password` from being logged, and hide the length of the password in all instances.