### PR TITLE
Class name typo causes fatals on some pages

### DIFF
--- a/modules/authX509/www/expirywarning.php
+++ b/modules/authX509/www/expirywarning.php
@@ -27,5 +27,5 @@ $t->data['target'] = SimpleSAML\Module::getModuleURL('authX509/expirywarning.php
 $t->data['data'] = array('StateId' => $id);
 $t->data['daysleft'] = $state['daysleft'];
 $t->data['renewurl'] = $state['renewurl'];
-$t->data['errorcodes'] = SimpleSAML\Error\Errorcodes::getAllErrorCodeMessages();
+$t->data['errorcodes'] = SimpleSAML\Error\ErrorCodes::getAllErrorCodeMessages();
 $t->show();

--- a/modules/authYubiKey/www/yubikeylogin.php
+++ b/modules/authYubiKey/www/yubikeylogin.php
@@ -31,7 +31,7 @@ $globalConfig = SimpleSAML_Configuration::getInstance();
 $t = new SimpleSAML_XHTML_Template($globalConfig, 'authYubiKey:yubikeylogin.php');
 $t->data['stateparams'] = array('AuthState' => $authStateId);
 $t->data['errorcode'] = $errorCode;
-$t->data['errorcodes'] = SimpleSAML\Error\Errorcodes::getAllErrorCodeMessages();
+$t->data['errorcodes'] = SimpleSAML\Error\ErrorCodes::getAllErrorCodeMessages();
 $t->data['logo_url'] = SimpleSAML\Module::getModuleURL('authYubiKey/resources/logo.jpg');
 $t->data['devicepic_url'] = SimpleSAML\Module::getModuleURL('authYubiKey/resources/yubikey.jpg');
 $t->show();


### PR DESCRIPTION
Hi,

I was trying out YubiKey Auth with master when I hit this bug caused by a typo in the core ErrorCodes classname. Grepping the codebase I found another incidence in authX509 where it checks cert expiry. This PR fixes these typos.

Thanks,

Greg