### PR TITLE
Add missing 'required' value

### DIFF
--- a/modules/core/www/frontpage_config.php
+++ b/modules/core/www/frontpage_config.php
@@ -136,6 +136,7 @@ $funcmatrix[] = array(
 );
 
 $funcmatrix[] = array(
+    'required' => 'optional',
     'descr' => 'Memcache or Memcached Extension (required if a Memcached backend is used)',
     'enabled' => class_exists('Memcache') || class_exists('Memcached'),
 );


### PR DESCRIPTION
Fixes:

Aug  8 20:44:18 simplesamlphp-2 IDP-MOO[3845]: 3 [d01bee1f99] SimpleSAML_Error_Exception: Error 8 - Undefined index: required
Aug  8 20:44:18 simplesamlphp-2 IDP-MOO[3845]: 3 [d01bee1f99] Backtrace:
Aug  8 20:44:18 simplesamlphp-2 IDP-MOO[3845]: 3 [d01bee1f99] 4 /apps/simplesamlphp/simplesamlphp/www/_include.php:86 (SimpleSAML_error_handler)
Aug  8 20:44:18 simplesamlphp-2 IDP-MOO[3845]: 3 [d01bee1f99] 3 /apps/simplesamlphp/simplesamlphp/modules/core/templates/frontpage_config.tpl.php:91 (require)
Aug  8 20:44:18 simplesamlphp-2 IDP-MOO[3845]: 3 [d01bee1f99] 2 /apps/simplesamlphp/simplesamlphp/lib/SimpleSAML/XHTML/Template.php:405 (SimpleSAML_XHTML_Template::show)
Aug  8 20:44:18 simplesamlphp-2 IDP-MOO[3845]: 3 [d01bee1f99] 1 /apps/simplesamlphp/simplesamlphp/modules/core/www/frontpage_config.php:198 (require)
Aug  8 20:44:18 simplesamlphp-2 IDP-MOO[3845]: 3 [d01bee1f99] 0 /apps/simplesamlphp/simplesamlphp/www/module.php:135 (N/A)