### PR TITLE
Fix XML validation failure with leading/trailing whitespace

### DIFF
--- a/www/admin/metadata-converter.php
+++ b/www/admin/metadata-converter.php
@@ -7,9 +7,9 @@ SimpleSAML\Utils\Auth::requireAdmin();
 $config = SimpleSAML_Configuration::getInstance();
 
 if (!empty($_FILES['xmlfile']['tmp_name'])) {
-    $xmldata = file_get_contents($_FILES['xmlfile']['tmp_name']);
+    $xmldata = trim(file_get_contents($_FILES['xmlfile']['tmp_name']));
 } elseif (array_key_exists('xmldata', $_POST)) {
-    $xmldata = $_POST['xmldata'];
+    $xmldata = trim($_POST['xmldata']);
 }
 
 if (!empty($xmldata)) {


### PR DESCRIPTION
Converting XML metadata to PHP on `/admin/metadata-converter.php` will fail when the XML contains leading whitespace.
Annoying some browsers seem to add an empty line when copy/pasting, so this error occurs regularly.
Trimming the xmldata fixes this.