### PR TITLE
Update PHP API change gor ldapwhoami

### DIFF
--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -733,8 +733,8 @@ class SimpleSAML_Auth_LDAP
         $authz_id = '';
 
         if (function_exists('ldap_exop_whoami')) {
-            if (ldap_exop_whoami($this->ldap, $authz_id) !== true) {
-                throw $this->getLDAPException('LDAP whoami exop failure');
+            if (($authz_id = ldap_exop_whoami($this->ldap)) === false) {
+                throw $this->makeException('LDAP whoami exop failure');
             }
         } else {
             $authz_id = $this->authz_id;
@@ -743,7 +743,7 @@ class SimpleSAML_Auth_LDAP
         $dn = $this->authzid_to_dn($searchBase, $searchAttributes, $authz_id);
 
         if (!isset($dn) || ($dn == '')) {
-            throw $this->getLDAPException('Cannot figure userID');
+            throw $this->makeException('Cannot figure userID');
         }
 
         return $dn;

--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -736,15 +736,15 @@ class SimpleSAML_Auth_LDAP
         $authz_id = '';
 
         if (function_exists('ldap_exop_whoami')) {
-	    if (version_compare(phpversion(), '7', '<')) {
+            if (version_compare(phpversion(), '7', '<')) {
                 if (ldap_exop_whoami($this->ldap, $authz_id) !== true) {
                     throw $this->makeException('LDAP whoami exop failure');
                 }
-	    } else {
+            } else {
                 if (($authz_id = ldap_exop_whoami($this->ldap)) === false) {
                     throw $this->makeException('LDAP whoami exop failure');
                 }
-	    }
+            }
         } else {
             $authz_id = $this->authz_id;
         }

--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -723,19 +723,28 @@ class SimpleSAML_Auth_LDAP
      * ldap_exop_whoami accessor, if available. Use requested authz_id
      * otherwise.
      *
-     * ldap_exop_whoami is not yet included in PHP. For reference, the
-     * feature request: http://bugs.php.net/bug.php?id=42060
-     * And the patch against lastest PHP release:
-     * http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/databases/php-ldap/files/ldap-ctrl-exop.patch
+     * ldap_exop_whoami() has been provided as a third party patch that
+     * waited several years to get its way upstream:
+     * http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/databases/php-ldap/files
+     * 
+     * When it was integrated into PHP repository, the function prototype
+     * was changed, The new prototype was used in third party patch for 
+     * PHP 7.0 and 7.1, hence the version test below.
      */
     public function whoami($searchBase, $searchAttributes)
     {
         $authz_id = '';
 
         if (function_exists('ldap_exop_whoami')) {
-            if (($authz_id = ldap_exop_whoami($this->ldap)) === false) {
-                throw $this->makeException('LDAP whoami exop failure');
-            }
+	    if (version_compare(phpversion(), '7', '<')) {
+                if (ldap_exop_whoami($this->ldap, $authz_id) !== true) {
+                    throw $this->makeException('LDAP whoami exop failure');
+                }
+	    } else {
+                if (($authz_id = ldap_exop_whoami($this->ldap)) === false) {
+                    throw $this->makeException('LDAP whoami exop failure');
+                }
+	    }
         } else {
             $authz_id = $this->authz_id;
         }


### PR DESCRIPTION
I have been maintaining the PHP LDAP EXOP patch for a few years,
which include the ldapwhoami() function. This has finally made its
way into PHP distribution and will be available in PHP 7.3, but
with a modified prototype.

This changes adapts to this API change. While there, also update
exception handling on par with recent SimpleSAMLphp code