### PR TITLE
ADFS-module: Set enctype on post-form

### DIFF
--- a/modules/adfs/docs/adfs.md
+++ b/modules/adfs/docs/adfs.md
@@ -45,7 +45,7 @@ The recommended settings for /metadata/adfs-idp-hosted.php is:
 The minimal configuration for /metadata/adfs-sp-remote.php is:
 
 $metadata['urn:federation:localhost'] = array(
-        prp' => 'https://localhost/adfs/ls/',
+        'prp' => 'https://localhost/adfs/ls/',
 );
 
 7. Creating a SSL self signed certificate

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -113,7 +113,7 @@ class sspmod_adfs_IdP_ADFS {
 
 	public static function ADFS_PostResponse($url, $wresult, $wctx) {
 		print '
-<body onload="document.forms[0].submit()"><form method="post" action="' . $url . '">
+<body onload="document.forms[0].submit()"><form method="post" action="' . $url . '" enctype="multipart/form-data">
 	<input type="hidden" name="wa" value="wsignin1.0">
 	<input type="hidden" name="wresult" value="' . htmlspecialchars($wresult) . '">
 	<input type="hidden" name="wctx" value="' . htmlspecialchars($wctx) . '">


### PR DESCRIPTION
Without proper enctype, every space in $wresult will be converted to a +
I really wonder if this ever worked at all..

![no_enctype](https://user-images.githubusercontent.com/841045/29252813-5f7c8ea4-806e-11e7-8052-da6d2ebe2e15.png)
