### PR TITLE
Flexible namespace

### DIFF
--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -70,7 +70,14 @@ class sspmod_adfs_IdP_ADFS {
 		foreach ($attributes as $name => $values) {
 			if ((!is_array($values)) || (count($values) == 0)) continue;
 			$hasValue = FALSE;
-			$r = '<saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/claims" AttributeName="' . htmlspecialchars($name) .'">';
+            $slash = strrpos($name, '/');
+            if ($slash !== false) {
+                $namespace = substr($name, 0, $slash);
+                $name = substr($name, $slash + 1);
+                $r = '<saml:Attribute AttributeNamespace="' . htmlspecialchars($namespace) . '" AttributeName="' . htmlspecialchars($name) .'">';
+            } else {
+			    $r = '<saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/claims" AttributeName="' . htmlspecialchars($name) .'">';
+            }
 			foreach ($values as $value) {
 				if ( (!isset($value)) || ($value === '')) continue;
 				$r .= '<saml:AttributeValue>' . htmlspecialchars($value) . '</saml:AttributeValue>';


### PR DESCRIPTION
It doesn't make much sense to have a hard coded AttributeNamespace used for every attribute...
It is a mandatory field in SAML1.1, so we keep the hard coded value as a fallback.

This will convert an attribute called `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddres` to:
`<saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/ws/2005/05/identity/claims" AttributeName="emailaddress">`