### PR TITLE
Flexible namespace

### DIFF
--- a/lib/SimpleSAML/Utils/Attributes.php
+++ b/lib/SimpleSAML/Utils/Attributes.php
@@ -106,4 +106,29 @@ class Attributes
 
         return $newAttrs;
     }
+
+
+    /**
+     * Extract an attribute's namespace, or revert to default.
+     *
+     * This function takes in a namespaced attribute name at splits it in a namespace/attribute name tuple.
+     * When no namespace is found in the attribute name, it will be namespaced with the default namespace.
+     * This default namespace can be overriden by supplying a second parameter to this function.
+     *
+     * @param string $name The namespaced attribute name.
+     * @param string $namespace The default namespace that should be used when no namespace is found (optional).
+     *
+     * @return array The attribute name, split to the namespace and the actual attribute name.
+     */
+    public static function getAttributeNamespace($name, $namespace = 'http://schemas.xmlsoap.org/claims')
+    {
+        $slash = strrpos($name, '/');
+        if ($slash !== false) {
+            $namespace = substr($name, 0, $slash);
+            $name = substr($name, $slash + 1);
+        }
+        $name = htmlspecialchars($name);
+        $namespace = htmlspecialchars($namespace);
+        return array($namespace, $name);
+    }
 }

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -61,7 +61,14 @@ MSG;
             if ((!is_array($values)) || (count($values) == 0)) {
                 continue;
             }
+            $namespace = "http://schemas.xmlsoap.org/claims";
+            $slash = strrpos($name, '/');
+            if ($slash !== false) {
+                $namespace = substr($name, 0, $slash);
+                $name = substr($name, $slash + 1);
+            }
             $name = htmlspecialchars($name);
+            $namespace = htmlspecialchars($namespace);
             foreach ($values as $value) {
                 if ((!isset($value)) || ($value === '')) {
                     continue;
@@ -69,7 +76,7 @@ MSG;
                 $value = htmlspecialchars($value);
 
                 $result .= <<<MSG
-                <saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/claims" AttributeName="$name">
+                <saml:Attribute AttributeNamespace="$namespace" AttributeName="$name">
                     <saml:AttributeValue>$value</saml:AttributeValue>
                 </saml:Attribute>
 MSG;

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -61,14 +61,8 @@ MSG;
             if ((!is_array($values)) || (count($values) == 0)) {
                 continue;
             }
-            $namespace = "http://schemas.xmlsoap.org/claims";
-            $slash = strrpos($name, '/');
-            if ($slash !== false) {
-                $namespace = substr($name, 0, $slash);
-                $name = substr($name, $slash + 1);
-            }
-            $name = htmlspecialchars($name);
-            $namespace = htmlspecialchars($namespace);
+
+            list($namespace, $name) = SimpleSAML\Utils\Attributes::getAttributeNamespace($name);
             foreach ($values as $value) {
                 if ((!isset($value)) || ($value === '')) {
                     continue;

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -62,7 +62,7 @@ MSG;
                 continue;
             }
 
-            list($namespace, $name) = SimpleSAML\Utils\Attributes::getAttributeNamespace($name);
+            list($namespace, $name) = SimpleSAML\Utils\Attributes::getAttributeNamespace($name, 'http://schemas.xmlsoap.org/claims');
             foreach ($values as $value) {
                 if ((!isset($value)) || ($value === '')) {
                     continue;


### PR DESCRIPTION
It doesn't make much sense to have a hard coded AttributeNamespace used for every attribute...
It is a mandatory field in SAML1.1, so we keep the hard coded value as a fallback.

This will convert an attribute called http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress to:
<saml:Attribute AttributeNamespace="http://schemas.xmlsoap.org/ws/2005/05/identity/claims" AttributeName="emailaddress">