### PR TITLE
Remove long-ago deprecated code

### DIFF
--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -288,95 +288,17 @@ class SimpleSAML_Configuration
      * If no configuration file with the given instance name is found, an exception will
      * be thrown.
      *
-     * @param string $instancename The instance name of the configuration file. Deprecated.
-     *
      * @return SimpleSAML_Configuration The configuration object.
      *
      * @throws Exception If the configuration with $instancename name is not initialized.
      */
-    public static function getInstance($instancename = 'simplesaml')
+    public static function getInstance()
     {
-        assert('is_string($instancename)');
-
-        // check if the instance exists already
-        if (array_key_exists($instancename, self::$instance)) {
-            return self::$instance[$instancename];
+        try {
+            return self::getConfig();
+        } catch (SimpleSAML\Error\ConfigurationError $e) {
+            throw \SimpleSAML\Error\CriticalConfigurationError::fromException($e);
         }
-
-        if ($instancename === 'simplesaml') {
-            try {
-                return self::getConfig();
-            } catch (SimpleSAML\Error\ConfigurationError $e) {
-                throw \SimpleSAML\Error\CriticalConfigurationError::fromException($e);
-            }
-
-        }
-
-        throw new \SimpleSAML\Error\CriticalConfigurationError(
-            'Configuration with name '.$instancename.' is not initialized.'
-        );
-    }
-
-
-    /**
-     * Initialize a instance name with the given configuration file.
-     *
-     * TODO: remove.
-     *
-     * @param string $path
-     * @param string $instancename
-     * @param string $configfilename
-     *
-     * @see setConfigDir()
-     * @deprecated This function is superseeded by the setConfigDir function.
-     */
-    public static function init($path, $instancename = 'simplesaml', $configfilename = 'config.php')
-    {
-        assert('is_string($path)');
-        assert('is_string($instancename)');
-        assert('is_string($configfilename)');
-
-        if ($instancename === 'simplesaml') {
-            // for backwards compatibility
-            self::setConfigDir($path, 'simplesaml');
-        }
-
-        // check if we already have loaded the given config - return the existing instance if we have
-        if (array_key_exists($instancename, self::$instance)) {
-            return self::$instance[$instancename];
-        }
-
-        self::$instance[$instancename] = self::loadFromFile($path.'/'.$configfilename, true);
-        return self::$instance[$instancename];
-    }
-
-
-    /**
-     * Load a configuration file which is located in the same directory as this configuration file.
-     *
-     * TODO: remove.
-     *
-     * @param string $instancename
-     * @param string $filename
-     *
-     * @see getConfig()
-     * @deprecated This function is superseeded by the getConfig() function.
-     */
-    public function copyFromBase($instancename, $filename)
-    {
-        assert('is_string($instancename)');
-        assert('is_string($filename)');
-        assert('$this->filename !== NULL');
-
-        // check if we already have loaded the given config - return the existing instance if we have
-        if (array_key_exists($instancename, self::$instance)) {
-            return self::$instance[$instancename];
-        }
-
-        $dir = dirname($this->filename);
-
-        self::$instance[$instancename] = self::loadFromFile($dir.'/'.$filename, true);
-        return self::$instance[$instancename];
     }
 
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -922,9 +922,6 @@ class Test_SimpleSAML_Configuration extends PHPUnit_Framework_TestCase
         $c = array(
             'key' => 'value'
         );
-        // test loading a custom instance
-        SimpleSAML_Configuration::loadFromArray($c, '', 'dummy');
-        $this->assertEquals('value', SimpleSAML_Configuration::getInstance('dummy')->getValue('key', null));
 
         // test loading the default instance
         SimpleSAML_Configuration::loadFromArray($c, '', 'simplesaml');


### PR DESCRIPTION
I can trace deprecation back to 2009 (https://github.com/simplesamlphp/simplesamlphp/commit/1dc4bc4654b655360fee11789450fdcbb73cb5a1#diff-5b7745b258a8f6625d4dc1b014cadd37) and I can't find any code that relies on it...
I think it's safe to remove!