### PR TITLE
Remove PHP 5.3 support from composer configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "files": ["lib/_autoload_modules.php"]
     },
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.4",
         "ext-SPL": "*",
         "ext-zlib": "*",
         "ext-pcre": "*",


### PR DESCRIPTION
Looks like PHP 5.3 support was finally dropped! However it also looks like a spot was missed in the update :)