### PR TITLE
SAML2-SP: Making the AuthnInstant available in the state array

### DIFF
--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -252,5 +252,7 @@ if (isset($state['SimpleSAML_Auth_Source.ReturnURL'])) {
 }
 $state['PersistentAuthData'][] = 'saml:sp:prevAuth';
 
+$state['AuthnInstant'] = $assertion->getAuthnInstant();
+
 $source->handleResponse($state, $idp, $attributes);
 assert('FALSE');

--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -231,6 +231,8 @@ $state['LogoutState'] = $logoutState;
 $state['saml:AuthenticatingAuthority'] = $authenticatingAuthority;
 $state['saml:AuthenticatingAuthority'][] = $idp;
 $state['PersistentAuthData'][] = 'saml:AuthenticatingAuthority';
+$state['saml:AuthnInstant'] = $assertion->getAuthnInstant();
+$state['PersistentAuthData'][] = 'saml:AuthnInstant';
 $state['saml:sp:SessionIndex'] = $sessionIndex;
 $state['PersistentAuthData'][] = 'saml:sp:SessionIndex';
 $state['saml:sp:AuthnContext'] = $assertion->getAuthnContext();
@@ -251,8 +253,6 @@ if (isset($state['SimpleSAML_Auth_Source.ReturnURL'])) {
     $state['saml:sp:prevAuth']['redirect'] = $state['saml:sp:RelayState'];
 }
 $state['PersistentAuthData'][] = 'saml:sp:prevAuth';
-
-$state['AuthnInstant'] = $assertion->getAuthnInstant();
 
 $source->handleResponse($state, $idp, $attributes);
 assert('FALSE');


### PR DESCRIPTION
The authnInstant is not being set in the saml2-acs.php. Therefore it isn't available for review or usage in auth proc filters, etc.