### PR TITLE
Using null as memcache prefix in default config causes fatal error.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -608,7 +608,7 @@ $config = array(
      * than one instance is using memcache, you probably want to assign
      * a unique value per instance to this setting to avoid data collision.
      */
-    'memcache_store.prefix' => null,
+    'memcache_store.prefix' => '',
 
     /*
      * This value is the duration data should be stored in memcache. Data


### PR DESCRIPTION
Hi,

I just cloned SimpleSAMLphp and configured it right out of the box to use memcached for sessions, but as soon as I set store type to 'memcache' I got this error:

> Fatal error: Uncaught Exception: /vagrant/www/libraries/simplesamlphp/config/config.php: The option 'memcache_store.prefix' is not a valid string value. in /vagrant/www/libraries/simplesamlphp/lib/SimpleSAML/Configuration.php on line 604

If this is just an empty string in the default config instead of null then there's no out of the box error for novice users to try and figure out if they set the application to use memcache. :-)

Thanks,

Greg