### PR TITLE
Show AuthData on authentication status page

### DIFF
--- a/dictionaries/status.definition.json
+++ b/dictionaries/status.definition.json
@@ -38,10 +38,10 @@
 	"logout": {
 		"en": "Logout"
 	},
-        "authData_header": {
-                "en": "AuthData"
-        },
-        "authData_summary": {
-                "en": "Click to view AuthData"
-        }
+	"authData_header": {
+		"en": "AuthData"
+	},
+	"authData_summary": {
+		"en": "Click to view AuthData"
+	}
 }

--- a/dictionaries/status.definition.json
+++ b/dictionaries/status.definition.json
@@ -37,5 +37,11 @@
 	},
 	"logout": {
 		"en": "Logout"
-	}
+	},
+        "authData_header": {
+                "en": "AuthData"
+        },
+        "authData_summary": {
+                "en": "Click to view AuthData"
+        }
 }

--- a/modules/core/www/authenticate.php
+++ b/modules/core/www/authenticate.php
@@ -37,11 +37,13 @@ if (!$as->isAuthenticated()) {
 }
 
 $attributes = $as->getAttributes();
+$authData = $as->getAuthDataArray();
 
 $t = new SimpleSAML_XHTML_Template($config, 'status.php', 'attributes');
 
 $t->data['header'] = '{status:header_saml20_sp}';
 $t->data['attributes'] = $attributes;
+$t->data['authData'] = $authData;
 $t->data['nameid'] = !is_null($as->getAuthData('saml:sp:NameID')) ? $as->getAuthData('saml:sp:NameID') : false;
 $t->data['logouturl'] = \SimpleSAML\Utils\HTTP::getSelfURLNoQuery().'?as='.urlencode($asId).'&logout';
 $t->show();

--- a/templates/status.php
+++ b/templates/status.php
@@ -60,6 +60,13 @@ if ($nameid !== false) {
     echo(present_attributes($this, $list, ''));
 }
 
+$authData = $this->data['authData'];
+if (isset($authData)) {
+    echo "<h2>".$this->t('{status:authData_header}')."</h2>";
+    echo '<details><summary>' . $this->t('{status:authData_summary}') . '</summary>'; 
+    echo('<pre>' . htmlspecialchars(json_encode($this->data['authData'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) . '</pre>');
+    echo '</details>';
+}
 if (isset($this->data['logout'])) {
     echo('<h2>'.$this->t('{status:logout}').'</h2>');
     echo('<p>'.$this->data['logout'].'</p>');

--- a/templates/status.php
+++ b/templates/status.php
@@ -61,7 +61,7 @@ if ($nameid !== false) {
 }
 
 $authData = $this->data['authData'];
-if (isset($authData)) {
+if (!empty($authData)) {
     echo "<h2>".$this->t('{status:authData_header}')."</h2>";
     echo '<details><summary>' . $this->t('{status:authData_summary}') . '</summary>'; 
     echo('<pre>' . htmlspecialchars(json_encode($this->data['authData'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) . '</pre>');


### PR DESCRIPTION
It can be useful to see the AuthData when testing an authentication source.

Since the AuthData can be a hierarchy of data of various depths it is converted
into a pretty printed JSON structure and put inside &lt;pre>

Since the amount of AuthData can vary greatly, the data is displayed in side
a &lt;details> element which requires clicking to view.