### PR TITLE
Fix duplicate assertion error using Redis Store

### DIFF
--- a/lib/SimpleSAML/Store/Redis.php
+++ b/lib/SimpleSAML/Store/Redis.php
@@ -70,7 +70,7 @@ class Redis extends Store
 
         $result = $this->redis->get("{$type}.{$key}");
 
-        if ($result === false) {
+        if ($result === false || $result === null) {
             return null;
         }
 

--- a/tests/lib/SimpleSAML/Store/RedisTest.php
+++ b/tests/lib/SimpleSAML/Store/RedisTest.php
@@ -48,7 +48,7 @@ class RedisTest extends \PHPUnit_Framework_TestCase
 
     public function getMocked($key)
     {
-        return array_key_exists($key, $this->config) ? $this->config[$key] : false;
+        return array_key_exists($key, $this->config) ? $this->config[$key] : null;
     }
 
     public function setMocked($key, $value)


### PR DESCRIPTION
Fixes the following error when using the Redis Store:

```SimpleSAML_Error_Error: UNHANDLEDEXCEPTION
Backtrace:
1 www/_include.php:45 (SimpleSAML_exception_handler)
0 [builtin] (N/A)
Caused by: SimpleSAML_Error_Exception: Received duplicate assertion.
Backtrace:
1 modules/saml/www/sp/saml2-acs.php:150 (require)
0 www/module.php:135 (N/A)
```