### PR TITLE
Implement "Remember my Organization" in multiple-ldap

### DIFF
--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -355,8 +355,8 @@ $config = array(
         //'remember.username.checked' => FALSE,
 
         // Give the user an option to save their organization choice for future login
-		// attempts. And when enabled, what should the default be, checked or not.
-		//'remember.organization.enabled' => false,
+        // attempts. And when enabled, what should the default be, checked or not.
+        //'remember.organization.enabled' => false,
         //'remember.organization.checked' => false,
 
         // The way the organization as part of the username should be handled.

--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -354,6 +354,11 @@ $config = array(
         //'remember.username.enabled' => FALSE,
         //'remember.username.checked' => FALSE,
 
+        // Give the user an option to save their organization choice for future login
+		// attempts. And when enabled, what should the default be, checked or not.
+		//'remember.organization.enabled' => false,
+        //'remember.organization.checked' => false,
+
         // The way the organization as part of the username should be handled.
         // Three possible values:
         // - 'none':   No handling of the organization. Allows '@' to be part

--- a/dictionaries/login.definition.json
+++ b/dictionaries/login.definition.json
@@ -62,9 +62,9 @@
 	"remember_username": {
 		"en": "Remember my username"
 	},
-    "remember_me": {
-        "en": "Remember me"
-    },
+	"remember_me": {
+		"en": "Remember me"
+	},
 	"remember_organization": {
 		"en": "Remember my organization"
 	}

--- a/dictionaries/login.definition.json
+++ b/dictionaries/login.definition.json
@@ -64,5 +64,8 @@
 	},
     "remember_me": {
         "en": "Remember me"
-    }
+    },
+	"remember_organization": {
+		"en": "Remember my organization"
+	}
 }

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -780,12 +780,14 @@ class HTTP
              * It doesn't matter which one of those cases we have. We just know we can't apply our base URL to the
              * current URI, so we need to build it back from the PHP environment.
              */
+            $https = self::getServerHTTPS();
             $protocol = 'http';
-            $protocol .= (self::getServerHTTPS()) ? 's' : '';
+            $protocol .= $https ? 's' : '';
             $protocol .= '://';
 
             $hostname = self::getServerHost();
             $port = self::getServerPort();
+            $port = ($https && $port !== ':443') || (!$https && $port !== ':80') ? $port : '';
             return $protocol.$hostname.$port.$_SERVER['REQUEST_URI'];
         }
 

--- a/modules/core/lib/Auth/UserPassOrgBase.php
+++ b/modules/core/lib/Auth/UserPassOrgBase.php
@@ -57,12 +57,12 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 */
 	protected $rememberUsernameChecked = FALSE;
 
-    /**
-     * Storage for authsource config option remember.organization.enabled
-     * loginuserpassorg.php page/template use this option to present users
-     * with a checkbox to save their organization choice for the next login request.
-     * @var bool
-     */
+	/**
+	 * Storage for authsource config option remember.organization.enabled
+	 * loginuserpassorg.php page/template use this option to present users	
+	 * with a checkbox to save their organization choice for the next login request.
+	 * @var bool
+ 	*/
 	protected $rememberOrganizationEnabled = false;
 
 	/**
@@ -99,10 +99,10 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 			$this->rememberUsernameChecked = (bool) $config['remember.username.checked'];
 			unset($config['remember.username.checked']);
 		}
-        // Get the remember organization config options
-        if (isset($config['remember.organization.enabled'])) {
-            $this->rememberOrganizationEnabled = (bool) $config['remember.organization.enabled'];
-            unset($config['remember.organization.enabled']);
+		// Get the remember organization config options
+		if (isset($config['remember.organization.enabled'])) {
+			$this->rememberOrganizationEnabled = (bool) $config['remember.organization.enabled'];
+			unset($config['remember.organization.enabled']);
 		}
 		if (isset($config['remember.organization.checked'])) {
 			$this->rememberOrganizationChecked = (bool) $config['remember.organization.checked'];
@@ -159,16 +159,16 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 * @return bool
 	 */
 	public function getRememberUsernameChecked()
-    {
+	{
 		return $this->rememberUsernameChecked;
 	}
 
-    /**
-     * Getter for the authsource config option remember.organization.enabled
-     * @return bool
-     */
+	/**
+	 * Getter for the authsource config option remember.organization.enabled
+	 * @return bool
+	 */
 	public function getRememberOrganizationEnabled()
-    {
+	{
 		return $this->rememberOrganizationEnabled;
 	}
 

--- a/modules/core/lib/Auth/UserPassOrgBase.php
+++ b/modules/core/lib/Auth/UserPassOrgBase.php
@@ -158,7 +158,8 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 * Getter for the authsource config option remember.username.checked
 	 * @return bool
 	 */
-	public function getRememberUsernameChecked() {
+	public function getRememberUsernameChecked()
+    {
 		return $this->rememberUsernameChecked;
 	}
 
@@ -166,7 +167,8 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
      * Getter for the authsource config option remember.organization.enabled
      * @return bool
      */
-	public function getRememberOrganizationEnabled() {
+	public function getRememberOrganizationEnabled()
+    {
 		return $this->rememberOrganizationEnabled;
 	}
 

--- a/modules/core/lib/Auth/UserPassOrgBase.php
+++ b/modules/core/lib/Auth/UserPassOrgBase.php
@@ -57,6 +57,22 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 */
 	protected $rememberUsernameChecked = FALSE;
 
+    /**
+     * Storage for authsource config option remember.organization.enabled
+     * loginuserpassorg.php page/template use this option to present users
+     * with a checkbox to save their organization choice for the next login request.
+     * @var bool
+     */
+	protected $rememberOrganizationEnabled = false;
+
+	/**
+	 * Storage for authsource config option remember.organization.checked
+	 * loginuserpassorg.php page/template use this option to
+	 * default the remember organization checkbox to checked or not.
+	 * @var bool
+	 */
+	protected $rememberOrganizationChecked = false;
+
 
 	/**
 	 * Constructor for this authentication source.
@@ -82,6 +98,15 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 		if (isset($config['remember.username.checked'])) {
 			$this->rememberUsernameChecked = (bool) $config['remember.username.checked'];
 			unset($config['remember.username.checked']);
+		}
+        // Get the remember organization config options
+        if (isset($config['remember.organization.enabled'])) {
+            $this->rememberOrganizationEnabled = (bool) $config['remember.organization.enabled'];
+            unset($config['remember.organization.enabled']);
+		}
+		if (isset($config['remember.organization.checked'])) {
+			$this->rememberOrganizationChecked = (bool) $config['remember.organization.checked'];
+			unset($config['remember.organization.checked']);
 		}
 
 		$this->usernameOrgMethod = 'none';
@@ -137,6 +162,21 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 		return $this->rememberUsernameChecked;
 	}
 
+    /**
+     * Getter for the authsource config option remember.organization.enabled
+     * @return bool
+     */
+	public function getRememberOrganizationEnabled() {
+		return $this->rememberOrganizationEnabled;
+	}
+
+	/**
+	 * Getter for the authsource config option remember.organization.checked
+	 * @return bool
+	 */
+	public function getRememberOrganizationChecked() {
+		return $this->rememberOrganizationChecked;
+	}
 
 	/**
 	 * Initialize login.

--- a/modules/core/templates/loginuserpass.php
+++ b/modules/core/templates/loginuserpass.php
@@ -142,6 +142,16 @@ if ($this->data['errorcode'] !== null) {
                             }
                             ?>
                         </select></td>
+                    <td style="padding: .4em;">
+                        <?php
+                            if ($this->data['rememberOrganizationEnabled']) {
+                            	echo str_repeat("\t", 4);
+	                            echo '<input type="checkbox" id="remember_organization" tabindex="5" name="remember_organization" value="Yes" ';
+                                echo ($this->data['rememberOrganizationChecked'] ? 'checked="Yes" /> ' : '/> ');
+                            	echo $this->t('{login:remember_organization}');
+                            }
+                        ?>
+                    </td>
                 </tr>
                 <?php
             }

--- a/modules/core/www/loginuserpassorg.php
+++ b/modules/core/www/loginuserpassorg.php
@@ -59,7 +59,7 @@ if ($organizations === NULL || !empty($organization)) {
 			$params = $sessionHandler->getCookieParams();
 			$params['expire'] = time();
 			$params['expire'] += (isset($_REQUEST['remember_username']) && $_REQUEST['remember_username'] == 'Yes' ? 31536000 : -300);
-            \SimpleSAML\Utils\HTTP::setCookie($source->getAuthId() . '-username', $username, $params, FALSE);
+			\SimpleSAML\Utils\HTTP::setCookie($source->getAuthId() . '-username', $username, $params, false);
 		}
 
         if ($source->getRememberOrganizationEnabled()) {

--- a/tests/modules/core/lib/Auth/UserPassOrgBaseTest.php
+++ b/tests/modules/core/lib/Auth/UserPassOrgBaseTest.php
@@ -1,41 +1,41 @@
 <?php
-    /**
-     * Created by PhpStorm.
-     * User: agustin
-     * Date: 16.10.2017
-     * Time: 12:17
-     */
+/**
+ * Created by PhpStorm.
+ * User: agustin
+ * Date: 16.10.2017
+ * Time: 12:17
+ */
 
-    namespace SimpleSAML\Test\Module\core\Auth;
+namespace SimpleSAML\Test\Module\core\Auth;
 
-    use SimpleSAML\Module\core\Auth\UserPassOrgBase;
+use SimpleSAML\Module\core\Auth\UserPassOrgBase;
 
-    class UserPassOrgBaseTest extends \PHPUnit_Framework_TestCase
+class UserPassOrgBaseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRememberOrganizationEnabled()
     {
-        public function testRememberOrganizationEnabled()
-        {
-            $config = array(
-                'ldap:LDAPMulti',
+        $config = array(
+            'ldap:LDAPMulti',
 
-                'remember.organization.enabled' => true,
-                'remember.organization.checked' => false,
+            'remember.organization.enabled' => true,
+            'remember.organization.checked' => false,
 
-                'my-org' => array(
-                    'description' => 'My organization',
-                    // The rest of the options are the same as those available for
-                    // the LDAP authentication source.
-                    'hostname' => 'ldap://ldap.myorg.com',
-                    'dnpattern' => 'uid=%username%,ou=employees,dc=example,dc=org',
-                    // Whether SSL/TLS should be used when contacting the LDAP server.
-                    'enable_tls' => false,
-                )
-            );
+            'my-org' => array(
+                'description' => 'My organization',
+                // The rest of the options are the same as those available for
+                // the LDAP authentication source.
+                'hostname' => 'ldap://ldap.myorg.com',
+                'dnpattern' => 'uid=%username%,ou=employees,dc=example,dc=org',
+                // Whether SSL/TLS should be used when contacting the LDAP server.
+                'enable_tls' => false,
+            )
+        );
 
-            $mockUserPassOrgBase = $this->getMockBuilder('\sspmod_core_Auth_UserPassOrgBase')
-                ->setConstructorArgs(array(array('AuthId' => 'my-org'), &$config))
-                ->setMethods(array())
-                ->getMockForAbstractClass();
+        $mockUserPassOrgBase = $this->getMockBuilder('\sspmod_core_Auth_UserPassOrgBase')
+            ->setConstructorArgs(array(array('AuthId' => 'my-org'), &$config))
+            ->setMethods(array())
+            ->getMockForAbstractClass();
 
-            $this->assertTrue($mockUserPassOrgBase->getRememberOrganizationEnabled());
-        }
+        $this->assertTrue($mockUserPassOrgBase->getRememberOrganizationEnabled());
     }
+}

--- a/tests/modules/core/lib/Auth/UserPassOrgBaseTest.php
+++ b/tests/modules/core/lib/Auth/UserPassOrgBaseTest.php
@@ -1,0 +1,41 @@
+<?php
+    /**
+     * Created by PhpStorm.
+     * User: agustin
+     * Date: 16.10.2017
+     * Time: 12:17
+     */
+
+    namespace SimpleSAML\Test\Module\core\Auth;
+
+    use SimpleSAML\Module\core\Auth\UserPassOrgBase;
+
+    class UserPassOrgBaseTest extends \PHPUnit_Framework_TestCase
+    {
+        public function testRememberOrganizationEnabled()
+        {
+            $config = array(
+                'ldap:LDAPMulti',
+
+                'remember.organization.enabled' => true,
+                'remember.organization.checked' => false,
+
+                'my-org' => array(
+                    'description' => 'My organization',
+                    // The rest of the options are the same as those available for
+                    // the LDAP authentication source.
+                    'hostname' => 'ldap://ldap.myorg.com',
+                    'dnpattern' => 'uid=%username%,ou=employees,dc=example,dc=org',
+                    // Whether SSL/TLS should be used when contacting the LDAP server.
+                    'enable_tls' => false,
+                )
+            );
+
+            $mockUserPassOrgBase = $this->getMockBuilder('\sspmod_core_Auth_UserPassOrgBase')
+                ->setConstructorArgs(array(array('AuthId' => 'my-org'), &$config))
+                ->setMethods(array())
+                ->getMockForAbstractClass();
+
+            $this->assertTrue($mockUserPassOrgBase->getRememberOrganizationEnabled());
+        }
+    }


### PR DESCRIPTION
This new feature allows the users to have a checkbox in the login form
which works in the same way than "Remember my username" but for the
organization selected in the dropdown
Implements feature requested in issue: Allow "Remember organization" for multiple-ldap authsource #703 