### PR TITLE
Deprecate assert with string

### DIFF
--- a/lib/SimpleSAML/Auth/Default.php
+++ b/lib/SimpleSAML/Auth/Default.php
@@ -47,8 +47,8 @@ class SimpleSAML_Auth_Default {
 	 * @deprecated This method will be removed in SSP 2.0.
 	 */
 	public static function initLogoutReturn($returnURL, $authority) {
-		assert('is_string($returnURL)');
-		assert('is_string($authority)');
+		assert(is_string($returnURL));
+		assert(is_string($authority));
 
 		$session = SimpleSAML_Session::getSessionFromRequest();
 
@@ -72,8 +72,8 @@ class SimpleSAML_Auth_Default {
 	 * @deprecated This method will be removed in SSP 2.0.
 	 */
 	public static function initLogout($returnURL, $authority) {
-		assert('is_string($returnURL)');
-		assert('is_string($authority)');
+		assert(is_string($returnURL));
+		assert(is_string($authority));
 
 		self::initLogoutReturn($returnURL, $authority);
 
@@ -85,8 +85,8 @@ class SimpleSAML_Auth_Default {
 	 * @deprecated This method will be removed in SSP 2.0.
 	 */
 	public static function logoutCompleted($state) {
-		assert('is_array($state)');
-		assert('array_key_exists("SimpleSAML_Auth_Default.ReturnURL", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('SimpleSAML_Auth_Default.ReturnURL', $state));
 
 		\SimpleSAML\Utils\HTTP::redirectTrustedURL($state['SimpleSAML_Auth_Default.ReturnURL']);
 	}

--- a/lib/SimpleSAML/Auth/ProcessingChain.php
+++ b/lib/SimpleSAML/Auth/ProcessingChain.php
@@ -46,8 +46,8 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @param array $spMetadata  The metadata for the SP.
 	 */
 	public function __construct($idpMetadata, $spMetadata, $mode = 'idp') {
-		assert('is_array($idpMetadata)');
-		assert('is_array($spMetadata)');
+		assert(is_array($idpMetadata));
+		assert(is_array($spMetadata));
 
 		$this->filters = array();
 		
@@ -85,8 +85,8 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @param array $src  Source filters. May be unsorted.
 	 */
 	private static function addFilters(&$target, $src) {
-		assert('is_array($target)');
-		assert('is_array($src)');
+		assert(is_array($target));
+		assert(is_array($src));
 
 		foreach ($src as $filter) {
 			$fp = $filter->priority;
@@ -112,7 +112,7 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @return array  Array of SimpleSAML_Auth_ProcessingFilter objects.
 	 */
 	private static function parseFilterList($filterSrc) {
-		assert('is_array($filterSrc)');
+		assert(is_array($filterSrc));
 
 		$parsedFilters = array();
 
@@ -143,7 +143,7 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @return SimpleSAML_Auth_ProcessingFilter  The parsed filter.
 	 */
 	private static function parseFilter($config, $priority) {
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (!array_key_exists('class', $config)) 
 			throw new Exception('Authentication processing filter without name given.');
@@ -176,9 +176,9 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @param array &$state  The state we are processing.
 	 */
 	public function processState(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("ReturnURL", $state) || array_key_exists("ReturnCall", $state)');
-		assert('!array_key_exists("ReturnURL", $state) || !array_key_exists("ReturnCall", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('ReturnURL', $state) || array_key_exists('ReturnCall', $state));
+		assert(!array_key_exists('ReturnURL', $state) || !array_key_exists('ReturnCall', $state));
 
 		$state[self::FILTERS_INDEX] = $this->filters;
 
@@ -222,7 +222,7 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @param array $state  The state we are processing.
 	 */
 	public static function resumeProcessing($state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		while (count($state[self::FILTERS_INDEX]) > 0) {
 			$filter = array_shift($state[self::FILTERS_INDEX]);
@@ -238,8 +238,8 @@ class SimpleSAML_Auth_ProcessingChain {
 
 		// Completed
 
-		assert('array_key_exists("ReturnURL", $state) || array_key_exists("ReturnCall", $state)');
-		assert('!array_key_exists("ReturnURL", $state) || !array_key_exists("ReturnCall", $state)');
+		assert(array_key_exists('ReturnURL', $state) || array_key_exists('ReturnCall', $state));
+		assert(!array_key_exists('ReturnURL', $state) || !array_key_exists('ReturnCall', $state));
 
 
 		if (array_key_exists('ReturnURL', $state)) {
@@ -256,7 +256,7 @@ class SimpleSAML_Auth_ProcessingChain {
 			SimpleSAML_Auth_State::deleteState($state);
 
 			$func = $state['ReturnCall'];
-			assert('is_callable($func)');
+			assert(is_callable($func));
 
 			call_user_func($func, $state);
 			assert(FALSE);
@@ -275,9 +275,9 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @param array &$state  The state we are processing.
 	 */
 	public function processStatePassive(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 		// Should not be set when calling this method
-		assert('!array_key_exists("ReturnURL", $state)');
+		assert(!array_key_exists('ReturnURL', $state));
 
 		// Notify filters about passive request
 		$state['isPassive'] = TRUE;
@@ -308,7 +308,7 @@ class SimpleSAML_Auth_ProcessingChain {
      * @return Array The state referenced by the $id parameter.
 	 */
 	public static function fetchProcessedState($id) {
-		assert('is_string($id)');
+		assert(is_string($id));
 
 		return SimpleSAML_Auth_State::loadState($id, self::COMPLETED_STAGE);
 	}
@@ -318,8 +318,8 @@ class SimpleSAML_Auth_ProcessingChain {
 	 * @deprecated This method will be removed in SSP 2.0.
 	 */
 	private static function addUserID(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("Attributes", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('Attributes', $state));
 
 		if (isset($state['Destination']['userid.attribute'])) {
 			$attributeName = $state['Destination']['userid.attribute'];

--- a/lib/SimpleSAML/Auth/ProcessingFilter.php
+++ b/lib/SimpleSAML/Auth/ProcessingFilter.php
@@ -42,7 +42,7 @@ abstract class SimpleSAML_Auth_ProcessingFilter {
 	 * @param mixed $reserved  For future use.
 	 */
 	public function __construct(&$config, $reserved) {
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if(array_key_exists('%priority', $config)) {
 			$this->priority = $config['%priority'];

--- a/lib/SimpleSAML/Auth/Simple.php
+++ b/lib/SimpleSAML/Auth/Simple.php
@@ -37,7 +37,7 @@ class Simple
      */
     public function __construct($authSource)
     {
-        assert('is_string($authSource)');
+        assert(is_string($authSource));
 
         $this->authSource = $authSource;
         $this->app_config = Configuration::getInstance()->getConfigItem('application', null);
@@ -159,7 +159,7 @@ class Simple
 
         $as = $this->getAuthSource();
         $as->initLogin($returnTo, $errorURL, $params);
-        assert('false');
+        assert(false);
     }
 
 
@@ -180,7 +180,7 @@ class Simple
      */
     public function logout($params = null)
     {
-        assert('is_array($params) || is_string($params) || is_null($params)');
+        assert(is_array($params) || is_string($params) || $params === null);
 
         if ($params === null) {
             $params = HTTP::getSelfURL();
@@ -192,11 +192,11 @@ class Simple
             );
         }
 
-        assert('is_array($params)');
-        assert('isset($params["ReturnTo"]) || isset($params["ReturnCallback"])');
+        assert(is_array($params));
+        assert(isset($params['ReturnTo']) || isset($params['ReturnCallback']));
 
         if (isset($params['ReturnStateParam']) || isset($params['ReturnStateStage'])) {
-            assert('isset($params["ReturnStateParam"]) && isset($params["ReturnStateStage"])');
+            assert(isset($params['ReturnStateParam'], $params['ReturnStateStage']));
         }
 
         $session = Session::getSessionFromRequest();
@@ -229,16 +229,16 @@ class Simple
      */
     public static function logoutCompleted($state)
     {
-        assert('is_array($state)');
-        assert('isset($state["ReturnTo"]) || isset($state["ReturnCallback"])');
+        assert(is_array($state));
+        assert(isset($state['ReturnTo']) || isset($state['ReturnCallback']));
 
         if (isset($state['ReturnCallback'])) {
             call_user_func($state['ReturnCallback'], $state);
-            assert('false');
+            assert(false);
         } else {
             $params = array();
             if (isset($state['ReturnStateParam']) || isset($state['ReturnStateStage'])) {
-                assert('isset($state["ReturnStateParam"]) && isset($state["ReturnStateStage"])');
+                assert(isset($state['ReturnStateParam'], $state['ReturnStateStage']));
                 $stateID = State::saveState($state, $state['ReturnStateStage']);
                 $params[$state['ReturnStateParam']] = $stateID;
             }
@@ -278,7 +278,7 @@ class Simple
      */
     public function getAuthData($name)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         if (!$this->isAuthenticated()) {
             return null;
@@ -316,7 +316,7 @@ class Simple
      */
     public function getLoginURL($returnTo = null)
     {
-        assert('is_null($returnTo) || is_string($returnTo)');
+        assert($returnTo === null || is_string($returnTo));
 
         if ($returnTo === null) {
             $returnTo = HTTP::getSelfURL();
@@ -341,7 +341,7 @@ class Simple
      */
     public function getLogoutURL($returnTo = null)
     {
-        assert('is_null($returnTo) || is_string($returnTo)');
+        assert($returnTo === null || is_string($returnTo));
 
         if ($returnTo === null) {
             $returnTo = HTTP::getSelfURL();

--- a/lib/SimpleSAML/Auth/Source.php
+++ b/lib/SimpleSAML/Auth/Source.php
@@ -33,10 +33,10 @@ abstract class SimpleSAML_Auth_Source
      */
     public function __construct($info, &$config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
-        assert('array_key_exists("AuthId", $info)');
+        assert(array_key_exists('AuthId', $info));
         $this->authId = $info['AuthId'];
     }
 
@@ -51,7 +51,7 @@ abstract class SimpleSAML_Auth_Source
      */
     public static function getSourcesOfType($type)
     {
-        assert('is_string($type)');
+        assert(is_string($type));
 
         $config = SimpleSAML_Configuration::getConfig('authsources.php');
 
@@ -112,7 +112,7 @@ abstract class SimpleSAML_Auth_Source
      */
     public function reauthenticate(array &$state)
     {
-        assert('isset($state["ReturnCallback"])');
+        assert(isset($state['ReturnCallback']));
 
         // the default implementation just copies over the previous authentication data
         $session = SimpleSAML_Session::getSessionFromRequest();
@@ -134,13 +134,13 @@ abstract class SimpleSAML_Auth_Source
      */
     public static function completeAuth(&$state)
     {
-        assert('is_array($state)');
-        assert('array_key_exists("LoginCompletedHandler", $state)');
+        assert(is_array($state));
+        assert(array_key_exists('LoginCompletedHandler', $state));
 
         SimpleSAML_Auth_State::deleteState($state);
 
         $func = $state['LoginCompletedHandler'];
-        assert('is_callable($func)');
+        assert(is_callable($func));
 
         call_user_func($func, $state);
         assert(false);
@@ -162,8 +162,8 @@ abstract class SimpleSAML_Auth_Source
      */
     public function initLogin($return, $errorURL = null, array $params = array())
     {
-        assert('is_string($return) || is_array($return)');
-        assert('is_string($errorURL) || is_null($errorURL)');
+        assert(is_string($return) || is_array($return));
+        assert(is_string($errorURL) || $errorURL === null);
 
         $state = array_merge($params, array(
             'SimpleSAML_Auth_Default.id' => $this->authId, // TODO: remove in 2.0
@@ -210,11 +210,11 @@ abstract class SimpleSAML_Auth_Source
      */
     public static function loginCompleted($state)
     {
-        assert('is_array($state)');
-        assert('array_key_exists("SimpleSAML_Auth_Source.Return", $state)');
-        assert('array_key_exists("SimpleSAML_Auth_Source.id", $state)');
-        assert('array_key_exists("Attributes", $state)');
-        assert('!array_key_exists("LogoutState", $state) || is_array($state["LogoutState"])');
+        assert(is_array($state));
+        assert(array_key_exists('SimpleSAML_Auth_Source.Return', $state));
+        assert(array_key_exists('SimpleSAML_Auth_Source.id', $state));
+        assert(array_key_exists('Attributes', $state));
+        assert(!array_key_exists('LogoutState', $state) || is_array($state['LogoutState']));
 
         $return = $state['SimpleSAML_Auth_Source.Return'];
 
@@ -228,7 +228,7 @@ abstract class SimpleSAML_Auth_Source
         } else {
             call_user_func($return, $state);
         }
-        assert('false');
+        assert(false);
     }
 
 
@@ -247,7 +247,7 @@ abstract class SimpleSAML_Auth_Source
      */
     public function logout(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
         // default logout handler which doesn't do anything
     }
 
@@ -263,13 +263,13 @@ abstract class SimpleSAML_Auth_Source
      */
     public static function completeLogout(&$state)
     {
-        assert('is_array($state)');
-        assert('array_key_exists("LogoutCompletedHandler", $state)');
+        assert(is_array($state));
+        assert(array_key_exists('LogoutCompletedHandler', $state));
 
         SimpleSAML_Auth_State::deleteState($state);
 
         $func = $state['LogoutCompletedHandler'];
-        assert('is_callable($func)');
+        assert(is_callable($func));
 
         call_user_func($func, $state);
         assert(false);
@@ -290,8 +290,8 @@ abstract class SimpleSAML_Auth_Source
      */
     private static function parseAuthSource($authId, $config)
     {
-        assert('is_string($authId)');
-        assert('is_array($config)');
+        assert(is_string($authId));
+        assert(is_array($config));
 
         self::validateSource($config, $authId);
 
@@ -323,8 +323,8 @@ abstract class SimpleSAML_Auth_Source
      */
     public static function getById($authId, $type = null)
     {
-        assert('is_string($authId)');
-        assert('is_null($type) || is_string($type)');
+        assert(is_string($authId));
+        assert($type === null || is_string($type));
 
         // for now - load and parse config file
         $config = SimpleSAML_Configuration::getConfig('authsources.php');
@@ -362,8 +362,8 @@ abstract class SimpleSAML_Auth_Source
      */
     public static function logoutCallback($state)
     {
-        assert('is_array($state)');
-        assert('array_key_exists("SimpleSAML_Auth_Source.logoutSource", $state)');
+        assert(is_array($state));
+        assert(array_key_exists('SimpleSAML_Auth_Source.logoutSource', $state));
 
         $source = $state['SimpleSAML_Auth_Source.logoutSource'];
 
@@ -394,8 +394,8 @@ abstract class SimpleSAML_Auth_Source
      */
     protected function addLogoutCallback($assoc, $state)
     {
-        assert('is_string($assoc)');
-        assert('is_array($state)');
+        assert(is_string($assoc));
+        assert(is_array($state));
 
         if (!array_key_exists('LogoutCallback', $state)) {
             // the authentication requester doesn't have a logout callback
@@ -438,7 +438,7 @@ abstract class SimpleSAML_Auth_Source
      */
     protected function callLogoutCallback($assoc)
     {
-        assert('is_string($assoc)');
+        assert(is_string($assoc));
 
         $id = strlen($this->authId).':'.$this->authId.$assoc;
 
@@ -452,9 +452,9 @@ abstract class SimpleSAML_Auth_Source
             return;
         }
 
-        assert('is_array($data)');
-        assert('array_key_exists("callback", $data)');
-        assert('array_key_exists("state", $data)');
+        assert(is_array($data));
+        assert(array_key_exists('callback', $data));
+        assert(array_key_exists('state', $data));
 
         $callback = $data['callback'];
         $callbackState = $data['state'];

--- a/lib/SimpleSAML/Auth/State.php
+++ b/lib/SimpleSAML/Auth/State.php
@@ -144,8 +144,8 @@ class SimpleSAML_Auth_State
      */
     public static function getStateId(&$state, $rawId = false)
     {
-        assert('is_array($state)');
-        assert('is_bool($rawId)');
+        assert(is_array($state));
+        assert(is_bool($rawId));
 
         if (!array_key_exists(self::ID, $state)) {
             $state[self::ID] = SimpleSAML\Utils\Random::generateID();
@@ -193,9 +193,9 @@ class SimpleSAML_Auth_State
      */
     public static function saveState(&$state, $stage, $rawId = false)
     {
-        assert('is_array($state)');
-        assert('is_string($stage)');
-        assert('is_bool($rawId)');
+        assert(is_array($state));
+        assert(is_string($stage));
+        assert(is_bool($rawId));
 
         $return = self::getStateId($state, $rawId);
         $id = $state[self::ID];
@@ -258,9 +258,9 @@ class SimpleSAML_Auth_State
      */
     public static function loadState($id, $stage, $allowMissing = false)
     {
-        assert('is_string($id)');
-        assert('is_string($stage)');
-        assert('is_bool($allowMissing)');
+        assert(is_string($id));
+        assert(is_string($stage));
+        assert(is_bool($allowMissing));
         SimpleSAML\Logger::debug('Loading state: '.var_export($id, true));
 
         $sid = self::parseStateID($id);
@@ -282,9 +282,9 @@ class SimpleSAML_Auth_State
         }
 
         $state = unserialize($state);
-        assert('is_array($state)');
-        assert('array_key_exists(self::ID, $state)');
-        assert('array_key_exists(self::STAGE, $state)');
+        assert(is_array($state));
+        assert(array_key_exists(self::ID, $state));
+        assert(array_key_exists(self::STAGE, $state));
 
         // Verify stage
         if ($state[self::STAGE] !== $stage) {
@@ -318,7 +318,7 @@ class SimpleSAML_Auth_State
      */
     public static function deleteState(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         if (!array_key_exists(self::ID, $state)) {
             // This state hasn't been saved
@@ -342,7 +342,7 @@ class SimpleSAML_Auth_State
      */
     public static function throwException($state, SimpleSAML_Error_Exception $exception)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         if (array_key_exists(self::EXCEPTION_HANDLER_URL, $state)) {
 
@@ -358,7 +358,7 @@ class SimpleSAML_Auth_State
         } elseif (array_key_exists(self::EXCEPTION_HANDLER_FUNC, $state)) {
             // Call the exception handler
             $func = $state[self::EXCEPTION_HANDLER_FUNC];
-            assert('is_callable($func)');
+            assert(is_callable($func));
 
             call_user_func($func, $exception, $state);
             assert(false);
@@ -380,7 +380,7 @@ class SimpleSAML_Auth_State
      */
     public static function loadExceptionState($id = null)
     {
-        assert('is_string($id) || is_null($id)');
+        assert(is_string($id) || $id === null);
 
         if ($id === null) {
             if (!array_key_exists(self::EXCEPTION_PARAM, $_REQUEST)) {
@@ -391,7 +391,7 @@ class SimpleSAML_Auth_State
         }
 
         $state = self::loadState($id, self::EXCEPTION_STAGE);
-        assert('array_key_exists(self::EXCEPTION_DATA, $state)');
+        assert(array_key_exists(self::EXCEPTION_DATA, $state));
 
         return $state;
     }

--- a/lib/SimpleSAML/Bindings/Shib13/Artifact.php
+++ b/lib/SimpleSAML/Bindings/Shib13/Artifact.php
@@ -29,7 +29,7 @@ class Artifact
      */
     private static function getArtifacts()
     {
-        assert('array_key_exists("QUERY_STRING", $_SERVER)');
+        assert(array_key_exists('QUERY_STRING', $_SERVER));
 
         // We need to process the query string manually, to capture all SAMLart parameters
 
@@ -87,7 +87,7 @@ class Artifact
      */
     private static function extractResponse($soapResponse)
     {
-        assert('is_string($soapResponse)');
+        assert(is_string($soapResponse));
 
         try {
             $doc = DOMDocumentFactory::fromString($soapResponse);

--- a/lib/SimpleSAML/Bindings/Shib13/HTTPPost.php
+++ b/lib/SimpleSAML/Bindings/Shib13/HTTPPost.php
@@ -103,7 +103,7 @@ class HTTPPost
             // sign the response - this must be done after encrypting the assertion
             // we insert the signature before the saml2p:Status element
             $statusElements = XML::getDOMChildren($responseroot, 'Status', '@saml1p');
-            assert('count($statusElements) === 1');
+            assert(count($statusElements) === 1);
             $signer->sign($responseroot, $responseroot, $statusElements[0]);
         } else {
             // Sign the assertion
@@ -130,7 +130,7 @@ class HTTPPost
      */
     public function decodeResponse($post)
     {
-        assert('is_array($post)');
+        assert(is_array($post));
 
         if (!array_key_exists('SAMLResponse', $post)) {
             throw new \Exception('Missing required SAMLResponse parameter.');

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -87,8 +87,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function __construct($config, $location)
     {
-        assert('is_array($config)');
-        assert('is_string($location)');
+        assert(is_array($config));
+        assert(is_string($location));
 
         $this->configuration = $config;
         $this->location = $location;
@@ -108,8 +108,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     private static function loadFromFile($filename, $required)
     {
-        assert('is_string($filename)');
-        assert('is_bool($required)');
+        assert(is_string($filename));
+        assert(is_bool($required));
 
         if (array_key_exists($filename, self::$loadedConfigs)) {
             return self::$loadedConfigs[$filename];
@@ -190,8 +190,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public static function setConfigDir($path, $configSet = 'simplesaml')
     {
-        assert('is_string($path)');
-        assert('is_string($configSet)');
+        assert(is_string($path));
+        assert(is_string($configSet));
 
         self::$configDirs[$configSet] = $path;
     }
@@ -208,8 +208,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public static function getConfig($filename = 'config.php', $configSet = 'simplesaml')
     {
-        assert('is_string($filename)');
-        assert('is_string($configSet)');
+        assert(is_string($filename));
+        assert(is_string($configSet));
 
         if (!array_key_exists($configSet, self::$configDirs)) {
             if ($configSet !== 'simplesaml') {
@@ -238,8 +238,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public static function getOptionalConfig($filename = 'config.php', $configSet = 'simplesaml')
     {
-        assert('is_string($filename)');
-        assert('is_string($configSet)');
+        assert(is_string($filename));
+        assert(is_string($configSet));
 
         if (!array_key_exists($configSet, self::$configDirs)) {
             if ($configSet !== 'simplesaml') {
@@ -268,8 +268,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public static function loadFromArray($config, $location = '[ARRAY]', $instance = null)
     {
-        assert('is_array($config)');
-        assert('is_string($location)');
+        assert(is_array($config));
+        assert(is_string($location));
 
         $c = new SimpleSAML_Configuration($config, $location);
         if ($instance !== null) {
@@ -296,7 +296,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public static function getInstance($instancename = 'simplesaml')
     {
-        assert('is_string($instancename)');
+        assert(is_string($instancename));
 
         // check if the instance exists already
         if (array_key_exists($instancename, self::$instance)) {
@@ -331,9 +331,9 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public static function init($path, $instancename = 'simplesaml', $configfilename = 'config.php')
     {
-        assert('is_string($path)');
-        assert('is_string($instancename)');
-        assert('is_string($configfilename)');
+        assert(is_string($path));
+        assert(is_string($instancename));
+        assert(is_string($configfilename));
 
         if ($instancename === 'simplesaml') {
             // for backwards compatibility
@@ -363,9 +363,9 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function copyFromBase($instancename, $filename)
     {
-        assert('is_string($instancename)');
-        assert('is_string($filename)');
-        assert('$this->filename !== NULL');
+        assert(is_string($instancename));
+        assert(is_string($filename));
+        assert($this->filename !== null);
 
         // check if we already have loaded the given config - return the existing instance if we have
         if (array_key_exists($instancename, self::$instance)) {
@@ -539,7 +539,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
             return null;
         }
 
-        assert('is_string($path)');
+        assert(is_string($path));
 
         /* Prepend path with basedir if it doesn't start with a slash or a Windows drive letter (e.g. "C:\"). We assume
          * getBaseDir ends with a slash.
@@ -612,13 +612,13 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
 
         // the directory wasn't set in the configuration file, path is <base directory>/lib/SimpleSAML/Configuration.php
         $dir = __FILE__;
-        assert('basename($dir) === "Configuration.php"');
+        assert(basename($dir) === 'Configuration.php');
 
         $dir = dirname($dir);
-        assert('basename($dir) === "SimpleSAML"');
+        assert(basename($dir) === 'SimpleSAML');
 
         $dir = dirname($dir);
-        assert('basename($dir) === "lib"');
+        assert(basename($dir) === 'lib');
 
         $dir = dirname($dir);
 
@@ -647,7 +647,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getBoolean($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
 
@@ -685,7 +685,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getString($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
 
@@ -723,7 +723,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getInteger($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
 
@@ -765,9 +765,9 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getIntegerRange($name, $minimum, $maximum, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
-        assert('is_int($minimum)');
-        assert('is_int($maximum)');
+        assert(is_string($name));
+        assert(is_int($minimum));
+        assert(is_int($maximum));
 
         $ret = $this->getInteger($name, $default);
 
@@ -811,8 +811,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getValueValidate($name, $allowedValues, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
-        assert('is_array($allowedValues)');
+        assert(is_string($name));
+        assert(is_array($allowedValues));
 
         $ret = $this->getValue($name, $default);
         if ($ret === $default) {
@@ -856,7 +856,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getArray($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
 
@@ -887,7 +887,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getArrayize($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
 
@@ -920,7 +920,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getArrayizeString($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getArrayize($name, $default);
 
@@ -962,7 +962,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getConfigItem($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
 
@@ -1003,7 +1003,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getConfigList($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
 
@@ -1072,7 +1072,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     private function getDefaultBinding($endpointType)
     {
-        assert('is_string($endpointType)');
+        assert(is_string($endpointType));
 
         $set = $this->getString('metadata-set');
         switch ($set.':'.$endpointType) {
@@ -1105,7 +1105,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getEndpoints($endpointType)
     {
-        assert('is_string($endpointType)');
+        assert(is_string($endpointType));
 
         $loc = $this->location.'['.var_export($endpointType, true).']:';
 
@@ -1186,7 +1186,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getEndpointPrioritizedByBinding($endpointType, array $bindings, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($endpointType)');
+        assert(is_string($endpointType));
 
         $endpoints = $this->getEndpoints($endpointType);
 
@@ -1221,7 +1221,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getDefaultEndpoint($endpointType, array $bindings = null, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($endpointType)');
+        assert(is_string($endpointType));
 
         $endpoints = $this->getEndpoints($endpointType);
 
@@ -1254,7 +1254,7 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getLocalizedString($name, $default = self::REQUIRED_OPTION)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $ret = $this->getValue($name, $default);
         if ($ret === $default) {
@@ -1302,8 +1302,8 @@ class SimpleSAML_Configuration implements \SimpleSAML\Utils\ClearableState
      */
     public function getPublicKeys($use = null, $required = false, $prefix = '')
     {
-        assert('is_bool($required)');
-        assert('is_string($prefix)');
+        assert(is_bool($required));
+        assert(is_string($prefix));
 
         if ($this->hasValue($prefix.'keys')) {
             $ret = array();

--- a/lib/SimpleSAML/Database.php
+++ b/lib/SimpleSAML/Database.php
@@ -198,9 +198,9 @@ class Database
      */
     private function query($db, $stmt, $params)
     {
-        assert('is_object($db)');
-        assert('is_string($stmt)');
-        assert('is_array($params)');
+        assert(is_object($db));
+        assert(is_string($stmt));
+        assert(is_array($params));
 
         try {
             $query = $db->prepare($stmt);
@@ -234,8 +234,8 @@ class Database
      */
     private function exec($db, $stmt)
     {
-        assert('is_object($db)');
-        assert('is_string($stmt)');
+        assert(is_object($db));
+        assert(is_string($stmt));
 
         try {
             return $db->exec($stmt);

--- a/lib/SimpleSAML/Error/Assertion.php
+++ b/lib/SimpleSAML/Error/Assertion.php
@@ -25,7 +25,7 @@ class SimpleSAML_Error_Assertion extends SimpleSAML_Error_Exception {
 	 *                                given an expression.
 	 */
 	public function __construct($assertion = NULL) {
-		assert('is_null($assertion) || is_string($assertion)');
+		assert($assertion === null || is_string($assertion));
 
 		$msg = 'Assertion failed: ' . var_export($assertion, TRUE);
 		parent::__construct($msg);

--- a/lib/SimpleSAML/Error/AuthSource.php
+++ b/lib/SimpleSAML/Error/AuthSource.php
@@ -27,8 +27,8 @@ class SimpleSAML_Error_AuthSource extends SimpleSAML_Error_Error {
 	 * @param string $reason  Description of the error.
 	 */
 	public function __construct($authsource, $reason, $cause = NULL) {
-		assert('is_string($authsource)');
-		assert('is_string($reason)');
+		assert(is_string($authsource));
+		assert(is_string($reason));
 
 		$this->authsource = $authsource;
 		$this->reason = $reason;

--- a/lib/SimpleSAML/Error/BadRequest.php
+++ b/lib/SimpleSAML/Error/BadRequest.php
@@ -24,7 +24,7 @@ class SimpleSAML_Error_BadRequest extends SimpleSAML_Error_Error {
 	 * @param string $reason  Description of why the request was unacceptable.
 	 */
 	public function __construct($reason) {
-		assert('is_string($reason)');
+		assert(is_string($reason));
 
 		$this->reason = $reason;
 		parent::__construct(array('BADREQUEST', '%REASON%' => $this->reason));

--- a/lib/SimpleSAML/Error/Error.php
+++ b/lib/SimpleSAML/Error/Error.php
@@ -79,7 +79,7 @@ class SimpleSAML_Error_Error extends SimpleSAML_Error_Exception
      */
     public function __construct($errorCode, Exception $cause = null, $httpCode = null)
     {
-        assert('is_string($errorCode) || is_array($errorCode)');
+        assert(is_string($errorCode) || is_array($errorCode));
 
         if (is_array($errorCode)) {
             $this->parameters = $errorCode;
@@ -289,9 +289,9 @@ class SimpleSAML_Error_Error extends SimpleSAML_Error_Exception
 
         $show_function = $config->getArray('errors.show_function', null);
         if (isset($show_function)) {
-            assert('is_callable($show_function)');
+            assert(is_callable($show_function));
             call_user_func($show_function, $config, $data);
-            assert('FALSE');
+            assert(false);
         } else {
             $t = new SimpleSAML_XHTML_Template($config, 'error.php', 'errors');
             $t->data = array_merge($t->data, $data);

--- a/lib/SimpleSAML/Error/Exception.php
+++ b/lib/SimpleSAML/Error/Exception.php
@@ -43,8 +43,8 @@ class SimpleSAML_Error_Exception extends Exception
      */
     public function __construct($message, $code = 0, Exception $cause = null)
     {
-        assert('is_string($message)');
-        assert('is_int($code)');
+        assert(is_string($message));
+        assert(is_int($code));
 
         parent::__construct($message, $code);
 

--- a/lib/SimpleSAML/Error/MetadataNotFound.php
+++ b/lib/SimpleSAML/Error/MetadataNotFound.php
@@ -14,7 +14,7 @@ class SimpleSAML_Error_MetadataNotFound extends SimpleSAML_Error_Error {
 	 * @param string $entityId  The entityID we were unable to locate.
 	 */
 	public function __construct($entityId) {
-		assert('is_string($entityId)');
+		assert(is_string($entityId));
 
 		$this->includeTemplate = 'core:no_metadata.tpl.php';
 		parent::__construct(array(

--- a/lib/SimpleSAML/Error/NotFound.php
+++ b/lib/SimpleSAML/Error/NotFound.php
@@ -25,7 +25,7 @@ class SimpleSAML_Error_NotFound extends SimpleSAML_Error_Error {
 	 */
 	public function __construct($reason = NULL) {
 
-		assert('is_null($reason) || is_string($reason)');
+		assert($reason === null || is_string($reason));
 
 		$url = \SimpleSAML\Utils\HTTP::getSelfURL();
 

--- a/lib/SimpleSAML/IdP.php
+++ b/lib/SimpleSAML/IdP.php
@@ -63,7 +63,7 @@ class SimpleSAML_IdP
      */
     private function __construct($id)
     {
-        assert('is_string($id)');
+        assert(is_string($id));
 
         $this->id = $id;
 
@@ -130,7 +130,7 @@ class SimpleSAML_IdP
      */
     public static function getById($id)
     {
-        assert('is_string($id)');
+        assert(is_string($id));
 
         if (isset(self::$idpCache[$id])) {
             return self::$idpCache[$id];
@@ -151,7 +151,7 @@ class SimpleSAML_IdP
      */
     public static function getByState(array &$state)
     {
-        assert('isset($state["core:IdP"])');
+        assert(isset($state['core:IdP']));
 
         return self::getById($state['core:IdP']);
     }
@@ -177,7 +177,7 @@ class SimpleSAML_IdP
      */
     public function getSPName($assocId)
     {
-        assert('is_string($assocId)');
+        assert(is_string($assocId));
 
         $prefix = substr($assocId, 0, 4);
         $spEntityId = substr($assocId, strlen($prefix) + 1);
@@ -218,8 +218,8 @@ class SimpleSAML_IdP
      */
     public function addAssociation(array $association)
     {
-        assert('isset($association["id"])');
-        assert('isset($association["Handler"])');
+        assert(isset($association['id']));
+        assert(isset($association['Handler']));
 
         $association['core:IdP'] = $this->id;
 
@@ -247,7 +247,7 @@ class SimpleSAML_IdP
      */
     public function terminateAssociation($assocId)
     {
-        assert('is_string($assocId)');
+        assert(is_string($assocId));
 
         $session = SimpleSAML_Session::getSessionFromRequest();
         $session->terminateAssociation($this->associationGroup, $assocId);
@@ -272,7 +272,7 @@ class SimpleSAML_IdP
      */
     public static function postAuthProc(array $state)
     {
-        assert('is_callable($state["Responder"])');
+        assert(is_callable($state['Responder']));
 
         if (isset($state['core:SP'])) {
             $session = SimpleSAML_Session::getSessionFromRequest();
@@ -285,7 +285,7 @@ class SimpleSAML_IdP
         }
 
         call_user_func($state['Responder'], $state);
-        assert('FALSE');
+        assert(false);
     }
 
 
@@ -383,7 +383,7 @@ class SimpleSAML_IdP
      */
     public function handleAuthenticationRequest(array &$state)
     {
-        assert('isset($state["Responder"])');
+        assert(isset($state['Responder']));
 
         $state['core:IdP'] = $this->id;
 
@@ -410,7 +410,7 @@ class SimpleSAML_IdP
         try {
             if ($needAuth) {
                 $this->authenticate($state);
-                assert('FALSE');
+                assert(false);
             } else {
                 $this->reauthenticate($state);
             }
@@ -459,11 +459,11 @@ class SimpleSAML_IdP
      */
     public function finishLogout(array &$state)
     {
-        assert('isset($state["Responder"])');
+        assert(isset($state['Responder']));
 
         $idp = SimpleSAML_IdP::getByState($state);
         call_user_func($state['Responder'], $idp, $state);
-        assert('false');
+        assert(false);
     }
 
 
@@ -478,8 +478,8 @@ class SimpleSAML_IdP
      */
     public function handleLogoutRequest(array &$state, $assocId)
     {
-        assert('isset($state["Responder"])');
-        assert('is_string($assocId) || is_null($assocId)');
+        assert(isset($state['Responder']));
+        assert(is_string($assocId) || $assocId === null);
 
         $state['core:IdP'] = $this->id;
         $state['core:TerminatedAssocId'] = $assocId;
@@ -498,7 +498,7 @@ class SimpleSAML_IdP
 
         $handler = $this->getLogoutHandler();
         $handler->startLogout($state, $assocId);
-        assert('false');
+        assert(false);
     }
 
 
@@ -513,8 +513,8 @@ class SimpleSAML_IdP
      */
     public function handleLogoutResponse($assocId, $relayState, SimpleSAML_Error_Exception $error = null)
     {
-        assert('is_string($assocId)');
-        assert('is_string($relayState) || is_null($relayState)');
+        assert(is_string($assocId));
+        assert(is_string($relayState) || $relayState === null);
 
         $session = SimpleSAML_Session::getSessionFromRequest();
         $session->deleteData('core:idp-ssotime', $this->id.';'.substr($assocId, strpos($assocId, ':') + 1));
@@ -522,7 +522,7 @@ class SimpleSAML_IdP
         $handler = $this->getLogoutHandler();
         $handler->onResponse($assocId, $relayState, $error);
 
-        assert('false');
+        assert(false);
     }
 
 
@@ -535,7 +535,7 @@ class SimpleSAML_IdP
      */
     public function doLogoutRedirect($url)
     {
-        assert('is_string($url)');
+        assert(is_string($url));
 
         $state = array(
             'Responder'       => array('SimpleSAML_IdP', 'finishLogoutRedirect'),
@@ -543,7 +543,7 @@ class SimpleSAML_IdP
         );
 
         $this->handleLogoutRequest($state, null);
-        assert('false');
+        assert(false);
     }
 
 
@@ -557,9 +557,9 @@ class SimpleSAML_IdP
      */
     public static function finishLogoutRedirect(SimpleSAML_IdP $idp, array $state)
     {
-        assert('isset($state["core:Logout:URL"])');
+        assert(isset($state['core:Logout:URL']));
 
         \SimpleSAML\Utils\HTTP::redirectTrustedURL($state['core:Logout:URL']);
-        assert('false');
+        assert(false);
     }
 }

--- a/lib/SimpleSAML/IdP/IFrameLogoutHandler.php
+++ b/lib/SimpleSAML/IdP/IFrameLogoutHandler.php
@@ -40,7 +40,7 @@ class IFrameLogoutHandler implements LogoutHandlerInterface
      */
     public function startLogout(array &$state, $assocId)
     {
-        assert('is_string($assocId) || is_null($assocId)');
+        assert(is_string($assocId) || $assocId === null);
 
         $associations = $this->idp->getAssociations();
 
@@ -89,7 +89,7 @@ class IFrameLogoutHandler implements LogoutHandlerInterface
      */
     public function onResponse($assocId, $relayState, \SimpleSAML_Error_Exception $error = null)
     {
-        assert('is_string($assocId)');
+        assert(is_string($assocId));
 
         $spId = sha1($assocId);
         $this->idp->terminateAssociation($assocId);

--- a/lib/SimpleSAML/IdP/TraditionalLogoutHandler.php
+++ b/lib/SimpleSAML/IdP/TraditionalLogoutHandler.php
@@ -63,7 +63,7 @@ class TraditionalLogoutHandler implements LogoutHandlerInterface
 
             // Try the next SP
             $this->logoutNextSP($state);
-            assert('FALSE');
+            assert(false);
         }
     }
 
@@ -97,8 +97,8 @@ class TraditionalLogoutHandler implements LogoutHandlerInterface
      */
     public function onResponse($assocId, $relayState, \SimpleSAML_Error_Exception $error = null)
     {
-        assert('is_string($assocId)');
-        assert('is_string($relayState) || is_null($relayState)');
+        assert(is_string($assocId));
+        assert(is_string($relayState) || $relayState === null);
 
         if ($relayState === null) {
             throw new \SimpleSAML_Error_Exception('RelayState lost during logout.');

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -399,7 +399,7 @@ class Language
      */
     public static function setLanguageCookie($language)
     {
-        assert('is_string($language)');
+        assert(is_string($language));
 
         $language = strtolower($language);
         $config = \SimpleSAML_Configuration::getInstance();

--- a/lib/SimpleSAML/Locale/Translate.php
+++ b/lib/SimpleSAML/Locale/Translate.php
@@ -89,7 +89,7 @@ class Translate
      */
     private function getDictionary($name)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         if (!array_key_exists($name, $this->dictionaries)) {
             $sepPos = strpos($name, ':');
@@ -119,7 +119,7 @@ class Translate
      */
     public function getTag($tag)
     {
-        assert('is_string($tag)');
+        assert(is_string($tag));
 
         // first check translations loaded by the includeInlineTranslation and includeLanguageFile methods
         if (array_key_exists($tag, $this->langtext)) {
@@ -158,7 +158,7 @@ class Translate
      */
     public function getPreferredTranslation($translations)
     {
-        assert('is_array($translations)');
+        assert(is_array($translations));
 
         // look up translation of tag in the selected language
         $selected_language = $this->language->getLanguage();
@@ -395,7 +395,7 @@ class Translate
     private function readDictionaryJSON($filename)
     {
         $definitionFile = $filename.'.definition.json';
-        assert('file_exists($definitionFile)');
+        assert(file_exists($definitionFile));
 
         $fileContent = file_get_contents($definitionFile);
         $lang = json_decode($fileContent, true);
@@ -428,7 +428,7 @@ class Translate
     private function readDictionaryPHP($filename)
     {
         $phpFile = $filename.'.php';
-        assert('file_exists($phpFile)');
+        assert(file_exists($phpFile));
 
         $lang = null;
         include($phpFile);
@@ -449,7 +449,7 @@ class Translate
      */
     private function readDictionaryFile($filename)
     {
-        assert('is_string($filename)');
+        assert(is_string($filename));
 
         \SimpleSAML\Logger::debug('Template: Reading ['.$filename.']');
 

--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -305,7 +305,7 @@ class Logger
      */
     public static function maskErrors($mask)
     {
-        assert('is_int($mask)');
+        assert(is_int($mask));
 
         $currentEnabled = error_reporting();
         self::$logLevelStack[] = array($currentEnabled, self::$logMask);

--- a/lib/SimpleSAML/Memcache.php
+++ b/lib/SimpleSAML/Memcache.php
@@ -179,7 +179,7 @@ class SimpleSAML_Memcache
      */
     public static function delete($key)
     {
-        assert('is_string($key)');
+        assert(is_string($key));
         SimpleSAML\Logger::debug("deleting key $key from memcache");
 
         // store this object to all groups of memcache servers

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandler.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandler.php
@@ -138,7 +138,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandler
      */
     public function getList($set = 'saml20-idp-remote')
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         $result = array();
 
@@ -193,7 +193,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandler
      */
     public function getMetaDataCurrentEntityID($set, $type = 'entityid')
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         // first we look for the hostname/path combination
         $currenthostwithpath = \SimpleSAML\Utils\HTTP::getSelfHostWithPath(); // sp.example.org/university
@@ -268,13 +268,13 @@ class SimpleSAML_Metadata_MetaDataStorageHandler
      */
     public function getMetaData($index, $set)
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         if ($index === null) {
             $index = $this->getMetaDataCurrentEntityID($set, 'metaindex');
         }
 
-        assert('is_string($index)');
+        assert(is_string($index));
 
         foreach ($this->sources as $source) {
             $metadata = $source->getMetaData($index, $set);
@@ -292,7 +292,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandler
 
                 $metadata['metadata-index'] = $index;
                 $metadata['metadata-set'] = $set;
-                assert('array_key_exists("entityid", $metadata)');
+                assert(array_key_exists('entityid', $metadata));
                 return $metadata;
             }
         }
@@ -314,8 +314,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandler
      */
     public function getMetaDataConfig($entityId, $set)
     {
-        assert('is_string($entityId)');
-        assert('is_string($set)');
+        assert(is_string($entityId));
+        assert(is_string($set));
 
         $metadata = $this->getMetaData($entityId, $set);
         return SimpleSAML_Configuration::loadFromArray($metadata, $set.'/'.var_export($entityId, true));
@@ -333,8 +333,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandler
      */
     public function getMetaDataConfigForSha1($sha1, $set)
     {
-        assert('is_string($sha1)');
-        assert('is_string($set)');
+        assert(is_string($sha1));
+        assert(is_string($set));
 
         $result = array();
 

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
@@ -40,7 +40,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerFlatFile extends SimpleSAML_Meta
      */
     protected function __construct($config)
     {
-        assert('is_array($config)');
+        assert(is_array($config));
 
         // get the configuration
         $globalConfig = SimpleSAML_Configuration::getInstance();

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -60,7 +60,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
      */
     public function __construct($config)
     {
-        assert('is_array($config)');
+        assert(is_array($config));
 
         $this->db = SimpleSAML\Database::getInstance();
     }
@@ -80,7 +80,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
      */
     private function load($set)
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         $tableName = $this->getTableName($set);
 
@@ -119,7 +119,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
      */
     public function getMetadataSet($set)
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         if (array_key_exists($set, $this->cachedMetadata)) {
             return $this->cachedMetadata[$set];
@@ -145,7 +145,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
 
     private function generateDynamicHostedEntityID($set)
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         // get the configuration
         $baseurl = \SimpleSAML\Utils\HTTP::getBaseURL();
@@ -179,9 +179,9 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
      */
     public function addEntry($index, $set, $entityData)
     {
-        assert('is_string($index)');
-        assert('is_string($set)');
-        assert('is_array($entityData)');
+        assert(is_string($index));
+        assert(is_string($set));
+        assert(is_array($entityData));
 
         if (!in_array($set, $this->supportedSets)) {
             return false;
@@ -229,7 +229,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
      */
     private function getTableName($table)
     {
-        assert('is_string($table)');
+        assert(is_string($table));
 
         return $this->db->applyPrefix(str_replace("-", "_", $this->tablePrefix.$table));
     }

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
@@ -34,7 +34,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerSerialize extends SimpleSAML_Met
      */
     public function __construct($config)
     {
-        assert('is_array($config)');
+        assert(is_array($config));
 
         $globalConfig = SimpleSAML_Configuration::getInstance();
 
@@ -59,8 +59,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerSerialize extends SimpleSAML_Met
      */
     private function getMetadataPath($entityId, $set)
     {
-        assert('is_string($entityId)');
-        assert('is_string($set)');
+        assert(is_string($entityId));
+        assert(is_string($set));
 
         return $this->directory.'/'.rawurlencode($set).'/'.rawurlencode($entityId).self::EXTENSION;
     }
@@ -118,7 +118,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerSerialize extends SimpleSAML_Met
      */
     public function getMetadataSet($set)
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         $ret = array();
 
@@ -171,8 +171,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerSerialize extends SimpleSAML_Met
      */
     public function getMetaData($entityId, $set)
     {
-        assert('is_string($entityId)');
-        assert('is_string($set)');
+        assert(is_string($entityId));
+        assert(is_string($set));
 
         $filePath = $this->getMetadataPath($entityId, $set);
 
@@ -214,9 +214,9 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerSerialize extends SimpleSAML_Met
      */
     public function saveMetadata($entityId, $set, $metadata)
     {
-        assert('is_string($entityId)');
-        assert('is_string($set)');
-        assert('is_array($metadata)');
+        assert(is_string($entityId));
+        assert(is_string($set));
+        assert(is_array($metadata));
 
         $filePath = $this->getMetadataPath($entityId, $set);
         $newPath = $filePath.'.new';
@@ -262,8 +262,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerSerialize extends SimpleSAML_Met
      */
     public function deleteMetadata($entityId, $set)
     {
-        assert('is_string($entityId)');
-        assert('is_string($set)');
+        assert(is_string($entityId));
+        assert(is_string($set));
 
         $filePath = $this->getMetadataPath($entityId, $set);
 

--- a/lib/SimpleSAML/Metadata/MetaDataStorageSource.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageSource.php
@@ -30,7 +30,7 @@ abstract class SimpleSAML_Metadata_MetaDataStorageSource
      */
     public static function parseSources($sourcesConfig)
     {
-        assert('is_array($sourcesConfig)');
+        assert(is_array($sourcesConfig));
 
         $sources = array();
 
@@ -206,8 +206,8 @@ abstract class SimpleSAML_Metadata_MetaDataStorageSource
      */
     private function lookupIndexFromEntityId($entityId, $set)
     {
-        assert('is_string($entityId)');
-        assert('isset($set)');
+        assert(is_string($entityId));
+        assert(isset($set));
 
         $metadataSet = $this->getMetadataSet($set);
 
@@ -246,8 +246,8 @@ abstract class SimpleSAML_Metadata_MetaDataStorageSource
     public function getMetaData($index, $set)
     {
 
-        assert('is_string($index)');
-        assert('isset($set)');
+        assert(is_string($index));
+        assert(isset($set));
 
         $metadataSet = $this->getMetadataSet($set);
 

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -46,7 +46,7 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function __construct($entityId, $maxCache = null, $maxDuration = null)
     {
-        assert('is_string($entityId)');
+        assert(is_string($entityId));
 
         $this->maxCache = $maxCache;
         $this->maxDuration = $maxDuration;
@@ -98,7 +98,7 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function getEntityDescriptorText($formatted = true)
     {
-        assert('is_bool($formatted)');
+        assert(is_bool($formatted));
 
         $xml = $this->getEntityDescriptor();
         if ($formatted) {
@@ -116,9 +116,9 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addSecurityTokenServiceType($metadata)
     {
-        assert('is_array($metadata)');
-        assert('isset($metadata["entityid"])');
-        assert('isset($metadata["metadata-set"])');
+        assert(is_array($metadata));
+        assert(isset($metadata['entityid']));
+        assert(isset($metadata['metadata-set']));
 
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
         $defaultEndpoint = $metadata->getDefaultEndpoint('SingleSignOnService');
@@ -326,7 +326,7 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     private static function createEndpoints(array $endpoints, $indexed)
     {
-        assert('is_bool($indexed)');
+        assert(is_bool($indexed));
 
         $ret = array();
 
@@ -436,8 +436,8 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addMetadata($set, $metadata)
     {
-        assert('is_string($set)');
-        assert('is_array($metadata)');
+        assert(is_string($set));
+        assert(is_array($metadata));
 
         $this->setExpiration($metadata);
 
@@ -471,10 +471,10 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addMetadataSP20($metadata, $protocols = array(\SAML2\Constants::NS_SAMLP))
     {
-        assert('is_array($metadata)');
-        assert('is_array($protocols)');
-        assert('isset($metadata["entityid"])');
-        assert('isset($metadata["metadata-set"])');
+        assert(is_array($metadata));
+        assert(is_array($protocols));
+        assert(isset($metadata['entityid']));
+        assert(isset($metadata['metadata-set']));
 
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
 
@@ -527,9 +527,9 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addMetadataIdP20($metadata)
     {
-        assert('is_array($metadata)');
-        assert('isset($metadata["entityid"])');
-        assert('isset($metadata["metadata-set"])');
+        assert(is_array($metadata));
+        assert(isset($metadata['entityid']));
+        assert(isset($metadata['metadata-set']));
 
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
 
@@ -576,9 +576,9 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addMetadataSP11($metadata)
     {
-        assert('is_array($metadata)');
-        assert('isset($metadata["entityid"])');
-        assert('isset($metadata["metadata-set"])');
+        assert(is_array($metadata));
+        assert(isset($metadata['entityid']));
+        assert(isset($metadata['metadata-set']));
 
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
 
@@ -611,9 +611,9 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addMetadataIdP11($metadata)
     {
-        assert('is_array($metadata)');
-        assert('isset($metadata["entityid"])');
-        assert('isset($metadata["metadata-set"])');
+        assert(is_array($metadata));
+        assert(isset($metadata['entityid']));
+        assert(isset($metadata['metadata-set']));
 
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
 
@@ -639,9 +639,9 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addAttributeAuthority(array $metadata)
     {
-        assert('is_array($metadata)');
-        assert('isset($metadata["entityid"])');
-        assert('isset($metadata["metadata-set"])');
+        assert(is_array($metadata));
+        assert(isset($metadata['entityid']));
+        assert(isset($metadata['metadata-set']));
 
         $metadata = SimpleSAML_Configuration::loadFromArray($metadata, $metadata['entityid']);
 
@@ -678,9 +678,9 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     public function addContact($type, $details)
     {
-        assert('is_string($type)');
-        assert('is_array($details)');
-        assert('in_array($type, array("technical", "support", "administrative", "billing", "other"), TRUE)');
+        assert(is_string($type));
+        assert(is_array($details));
+        assert(in_array($type, array('technical', 'support', 'administrative', 'billing', 'other'), true));
 
         // TODO: remove this check as soon as getContact() is called always before calling this function
         $details = \SimpleSAML\Utils\Config\Metadata::getContact($details);
@@ -735,8 +735,8 @@ class SimpleSAML_Metadata_SAMLBuilder
      */
     private function addX509KeyDescriptor(\SAML2\XML\md\RoleDescriptor $rd, $use, $x509data)
     {
-        assert('in_array($use, array("encryption", "signing"), TRUE)');
-        assert('is_string($x509data)');
+        assert(in_array($use, array('encryption', 'signing'), true));
+        assert(is_string($x509data));
 
         $keyDescriptor = \SAML2\Utils::createKeyDescriptor($x509data);
         $keyDescriptor->use = $use;

--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -167,7 +167,7 @@ class SimpleSAML_Metadata_SAMLParser
         array $validators = array(),
         array $parentExtensions = null
     ) {
-        assert('is_null($maxExpireTime) || is_int($maxExpireTime)');
+        assert($maxExpireTime === null || is_int($maxExpireTime));
 
         $this->spDescriptors = array();
         $this->idpDescriptors = array();
@@ -264,7 +264,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     public static function parseDocument($document)
     {
-        assert('$document instanceof DOMDocument');
+        assert($document instanceof DOMDocument);
 
         $entityElement = self::findEntityDescriptor($document);
 
@@ -282,7 +282,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     public static function parseElement($entityElement)
     {
-        assert('$entityElement instanceof \SAML2\XML\md\EntityDescriptor');
+        assert($entityElement instanceof \SAML2\XML\md\EntityDescriptor);
 
         return new SimpleSAML_Metadata_SAMLParser($entityElement, null);
     }
@@ -390,7 +390,7 @@ class SimpleSAML_Metadata_SAMLParser
         array $validators = array(),
         array $parentExtensions = array()
     ) {
-        assert('is_null($maxExpireTime) || is_int($maxExpireTime)');
+        assert($maxExpireTime === null || is_int($maxExpireTime));
 
         if ($element instanceof \SAML2\XML\md\EntityDescriptor) {
             $ret = new SimpleSAML_Metadata_SAMLParser($element, $maxExpireTime, $validators, $parentExtensions);
@@ -399,7 +399,7 @@ class SimpleSAML_Metadata_SAMLParser
             return $ret;
         }
 
-        assert('$element instanceof \SAML2\XML\md\EntitiesDescriptor');
+        assert($element instanceof \SAML2\XML\md\EntitiesDescriptor);
 
         $extensions = self::processExtensions($element, $parentExtensions);
         $expTime = self::getExpireTime($element, $maxExpireTime);
@@ -486,8 +486,8 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private function addExtensions(array &$metadata, array $roleDescriptor)
     {
-        assert('array_key_exists("scope", $roleDescriptor)');
-        assert('array_key_exists("tags", $roleDescriptor)');
+        assert(array_key_exists('scope', $roleDescriptor));
+        assert(array_key_exists('tags', $roleDescriptor));
 
         $scopes = array_merge($this->scopes, array_diff($roleDescriptor['scope'], $this->scopes));
         if (!empty($scopes)) {
@@ -842,7 +842,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private static function parseRoleDescriptorType(\SAML2\XML\md\RoleDescriptor $element, $expireTime)
     {
-        assert('is_null($expireTime) || is_int($expireTime)');
+        assert($expireTime === null || is_int($expireTime));
 
         $ret = array();
 
@@ -893,7 +893,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private static function parseSSODescriptor(\SAML2\XML\md\SSODescriptorType $element, $expireTime)
     {
-        assert('is_null($expireTime) || is_int($expireTime)');
+        assert($expireTime === null || is_int($expireTime));
 
         $sd = self::parseRoleDescriptorType($element, $expireTime);
 
@@ -920,7 +920,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private function processSPSSODescriptor(\SAML2\XML\md\SPSSODescriptor $element, $expireTime)
     {
-        assert('is_null($expireTime) || is_int($expireTime)');
+        assert($expireTime === null || is_int($expireTime));
 
         $sp = self::parseSSODescriptor($element, $expireTime);
 
@@ -956,7 +956,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private function processIDPSSODescriptor(\SAML2\XML\md\IDPSSODescriptor $element, $expireTime)
     {
-        assert('is_null($expireTime) || is_int($expireTime)');
+        assert($expireTime === null || is_int($expireTime));
 
         $idp = self::parseSSODescriptor($element, $expireTime);
 
@@ -984,7 +984,7 @@ class SimpleSAML_Metadata_SAMLParser
         \SAML2\XML\md\AttributeAuthorityDescriptor $element,
         $expireTime
     ) {
-        assert('is_null($expireTime) || is_int($expireTime)');
+        assert($expireTime === null || is_int($expireTime));
 
         $aad = self::parseRoleDescriptorType($element, $expireTime);
         $aad['entityid'] = $this->entityId;
@@ -1203,7 +1203,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private static function parseAttributeConsumerService(\SAML2\XML\md\AttributeConsumingService $element, &$sp)
     {
-        assert('is_array($sp)');
+        assert(is_array($sp));
 
         $sp['name'] = $element->ServiceName;
         $sp['description'] = $element->ServiceDescription;
@@ -1357,7 +1357,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private function getSPDescriptors($protocols)
     {
-        assert('is_array($protocols)');
+        assert(is_array($protocols));
 
         $ret = array();
 
@@ -1381,7 +1381,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private function getIdPDescriptors($protocols)
     {
-        assert('is_array($protocols)');
+        assert(is_array($protocols));
 
         $ret = array();
 
@@ -1409,7 +1409,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     private static function findEntityDescriptor($doc)
     {
-        assert('$doc instanceof DOMDocument');
+        assert($doc instanceof DOMDocument);
 
         // find the EntityDescriptor DOMElement. This should be the first (and only) child of the DOMDocument
         $ed = $doc->documentElement;
@@ -1438,7 +1438,7 @@ class SimpleSAML_Metadata_SAMLParser
     public function validateSignature($certificates)
     {
         foreach ($certificates as $cert) {
-            assert('is_string($cert)');
+            assert(is_string($cert));
             $certFile = \SimpleSAML\Utils\Config::getCertPath($cert);
             if (!file_exists($certFile)) {
                 throw new Exception(
@@ -1475,7 +1475,7 @@ class SimpleSAML_Metadata_SAMLParser
      */
     public function validateFingerprint($fingerprint)
     {
-        assert('is_string($fingerprint)');
+        assert(is_string($fingerprint));
 
         $fingerprint = strtolower(str_replace(":", "", $fingerprint));
 

--- a/lib/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/lib/SimpleSAML/Metadata/Sources/MDQ.php
@@ -65,7 +65,7 @@ class MDQ extends \SimpleSAML_Metadata_MetaDataStorageSource
      */
     protected function __construct($config)
     {
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (!array_key_exists('server', $config)) {
             throw new \Exception(__CLASS__.": the 'server' configuration option is not set.");
@@ -118,8 +118,8 @@ class MDQ extends \SimpleSAML_Metadata_MetaDataStorageSource
      */
     private function getCacheFilename($set, $entityId)
     {
-        assert('is_string($set)');
-        assert('is_string($entityId)');
+        assert(is_string($set));
+        assert(is_string($entityId));
 
         $cachekey = sha1($entityId);
         return $this->cacheDir.'/'.$set.'-'.$cachekey.'.cached.xml';
@@ -138,8 +138,8 @@ class MDQ extends \SimpleSAML_Metadata_MetaDataStorageSource
      */
     private function getFromCache($set, $entityId)
     {
-        assert('is_string($set)');
-        assert('is_string($entityId)');
+        assert(is_string($set));
+        assert(is_string($entityId));
 
         if (empty($this->cacheDir)) {
             return null;
@@ -196,9 +196,9 @@ class MDQ extends \SimpleSAML_Metadata_MetaDataStorageSource
      */
     private function writeToCache($set, $entityId, $data)
     {
-        assert('is_string($set)');
-        assert('is_string($entityId)');
-        assert('is_array($data)');
+        assert(is_string($set));
+        assert(is_string($entityId));
+        assert(is_array($data));
 
         if (empty($this->cacheDir)) {
             return;
@@ -224,7 +224,7 @@ class MDQ extends \SimpleSAML_Metadata_MetaDataStorageSource
      */
     private static function getParsedSet(\SimpleSAML_Metadata_SAMLParser $entity, $set)
     {
-        assert('is_string($set)');
+        assert(is_string($set));
 
         switch ($set) {
             case 'saml20-idp-remote':
@@ -266,8 +266,8 @@ class MDQ extends \SimpleSAML_Metadata_MetaDataStorageSource
      */
     public function getMetaData($index, $set)
     {
-        assert('is_string($index)');
-        assert('is_string($set)');
+        assert(is_string($index));
+        assert(is_string($set));
 
         Logger::info(__CLASS__.': loading metadata entity ['.$index.'] from ['.$set.']');
 

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -251,9 +251,9 @@ class Module
      */
     public static function resolveClass($id, $type, $subclass = null)
     {
-        assert('is_string($id)');
-        assert('is_string($type)');
-        assert('is_string($subclass) || is_null($subclass)');
+        assert(is_string($id));
+        assert(is_string($type));
+        assert(is_string($subclass) || $subclass === null);
 
         $tmp = explode(':', $id, 2);
         if (count($tmp) === 1) { // no module involved
@@ -302,8 +302,8 @@ class Module
      */
     public static function getModuleURL($resource, array $parameters = array())
     {
-        assert('is_string($resource)');
-        assert('$resource[0] !== "/"');
+        assert(is_string($resource));
+        assert($resource[0] !== '/');
 
         $url = Utils\HTTP::getBaseURL().'module.php/'.$resource;
         if (!empty($parameters)) {
@@ -363,7 +363,7 @@ class Module
      */
     public static function callHooks($hook, &$data = null)
     {
-        assert('is_string($hook)');
+        assert(is_string($hook));
 
         $modules = self::getModules();
         $config = \SimpleSAML_Configuration::getOptionalConfig()->getArray('module.enable', array());

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -180,7 +180,7 @@ class SimpleSAML_Session implements Serializable
             $globalConfig = SimpleSAML_Configuration::getInstance();
             $checkFunction = $globalConfig->getArray('session.check_function', null);
             if (isset($checkFunction)) {
-                assert('is_callable($checkFunction)');
+                assert(is_callable($checkFunction));
                 call_user_func($checkFunction, $this, true);
             }
         }
@@ -316,7 +316,7 @@ class SimpleSAML_Session implements Serializable
      */
     public static function getSession($sessionId = null)
     {
-        assert('is_string($sessionId) || is_null($sessionId)');
+        assert(is_string($sessionId) || $sessionId === null);
 
         $sh = \SimpleSAML\SessionHandler::getSessionHandler();
 
@@ -339,7 +339,7 @@ class SimpleSAML_Session implements Serializable
             return null;
         }
 
-        assert('$session instanceof self');
+        assert($session instanceof self);
 
         if ($checkToken) {
             $globalConfig = SimpleSAML_Configuration::getInstance();
@@ -362,7 +362,7 @@ class SimpleSAML_Session implements Serializable
             // run session check function if defined
             $checkFunction = $globalConfig->getArray('session.check_function', null);
             if (isset($checkFunction)) {
-                assert('is_callable($checkFunction)');
+                assert(is_callable($checkFunction));
                 $check = call_user_func($checkFunction, $session);
                 if ($check !== true) {
                     SimpleSAML\Logger::warning('Session did not pass check function.');
@@ -417,7 +417,7 @@ class SimpleSAML_Session implements Serializable
      */
     public static function createSession($sessionId)
     {
-        assert('is_string($sessionId)');
+        assert(is_string($sessionId));
         self::$sessions[$sessionId] = null;
     }
 
@@ -554,7 +554,7 @@ class SimpleSAML_Session implements Serializable
      */
     public function setRememberMeExpire($expire = null)
     {
-        assert('is_int($expire) || is_null($expire)');
+        assert(is_int($expire) || $expire === null);
 
         if ($expire === null) {
             $globalConfig = SimpleSAML_Configuration::getInstance();
@@ -578,8 +578,8 @@ class SimpleSAML_Session implements Serializable
      */
     public function doLogin($authority, array $data = null)
     {
-        assert('is_string($authority)');
-        assert('is_array($data) || is_null($data)');
+        assert(is_string($authority));
+        assert(is_array($data) || $data === null);
 
         SimpleSAML\Logger::debug('Session: doLogin("'.$authority.'")');
 
@@ -697,8 +697,8 @@ class SimpleSAML_Session implements Serializable
      */
     private function callLogoutHandlers($authority)
     {
-        assert('is_string($authority)');
-        assert('isset($this->authData[$authority])');
+        assert(is_string($authority));
+        assert(isset($this->authData[$authority]));
 
         if (empty($this->authData[$authority]['LogoutHandlers'])) {
             return;
@@ -733,7 +733,7 @@ class SimpleSAML_Session implements Serializable
      */
     public function isValid($authority)
     {
-        assert('is_string($authority)');
+        assert(is_string($authority));
 
         if (!isset($this->authData[$authority])) {
             SimpleSAML\Logger::debug(
@@ -784,8 +784,8 @@ class SimpleSAML_Session implements Serializable
      */
     public function setAuthorityExpire($authority, $expire = null)
     {
-        assert('isset($this->authData[$authority])');
-        assert('is_int($expire) || is_null($expire)');
+        assert(isset($this->authData[$authority]));
+        assert(is_int($expire) || $expire === null);
 
         $this->markDirty();
 
@@ -808,7 +808,7 @@ class SimpleSAML_Session implements Serializable
      */
     public function registerLogoutHandler($authority, $classname, $functionname)
     {
-        assert('isset($this->authData[$authority])');
+        assert(isset($this->authData[$authority]));
 
         $logout_handler = array($classname, $functionname);
 
@@ -833,8 +833,8 @@ class SimpleSAML_Session implements Serializable
      */
     public function deleteData($type, $id)
     {
-        assert('is_string($type)');
-        assert('is_string($id)');
+        assert(is_string($type));
+        assert(is_string($id));
 
         if (!is_array($this->dataStore)) {
             return;
@@ -866,9 +866,9 @@ class SimpleSAML_Session implements Serializable
      */
     public function setData($type, $id, $data, $timeout = null)
     {
-        assert('is_string($type)');
-        assert('is_string($id)');
-        assert('is_int($timeout) || is_null($timeout) || $timeout === self::DATA_TIMEOUT_SESSION_END');
+        assert(is_string($type));
+        assert(is_string($id));
+        assert(is_int($timeout) || $timeout === null || $timeout === self::DATA_TIMEOUT_SESSION_END);
 
         // clean out old data
         $this->expireData();
@@ -955,8 +955,8 @@ class SimpleSAML_Session implements Serializable
      */
     public function getData($type, $id)
     {
-        assert('is_string($type)');
-        assert('$id === null || is_string($id)');
+        assert(is_string($type));
+        assert($id === null || is_string($id));
 
         if ($id === null) {
             return null;
@@ -994,7 +994,7 @@ class SimpleSAML_Session implements Serializable
      */
     public function getDataOfType($type)
     {
-        assert('is_string($type)');
+        assert(is_string($type));
 
         if (!is_array($this->dataStore)) {
             return array();
@@ -1021,7 +1021,7 @@ class SimpleSAML_Session implements Serializable
      */
     public function getAuthState($authority)
     {
-        assert('is_string($authority)');
+        assert(is_string($authority));
 
         if (!isset($this->authData[$authority])) {
             return null;
@@ -1055,9 +1055,9 @@ class SimpleSAML_Session implements Serializable
      */
     public function addAssociation($idp, array $association)
     {
-        assert('is_string($idp)');
-        assert('isset($association["id"])');
-        assert('isset($association["Handler"])');
+        assert(is_string($idp));
+        assert(isset($association['id']));
+        assert(isset($association['Handler']));
 
         if (!isset($this->associations)) {
             $this->associations = array();
@@ -1084,7 +1084,7 @@ class SimpleSAML_Session implements Serializable
      */
     public function getAssociations($idp)
     {
-        assert('is_string($idp)');
+        assert(is_string($idp));
 
         if (!isset($this->associations)) {
             $this->associations = array();
@@ -1119,8 +1119,8 @@ class SimpleSAML_Session implements Serializable
      */
     public function terminateAssociation($idp, $associationId)
     {
-        assert('is_string($idp)');
-        assert('is_string($associationId)');
+        assert(is_string($idp));
+        assert(is_string($associationId));
 
         if (!isset($this->associations)) {
             return;
@@ -1146,8 +1146,8 @@ class SimpleSAML_Session implements Serializable
      */
     public function getAuthData($authority, $name)
     {
-        assert('is_string($authority)');
-        assert('is_string($name)');
+        assert(is_string($authority));
+        assert(is_string($name));
 
         if (!isset($this->authData[$authority][$name])) {
             return null;

--- a/lib/SimpleSAML/SessionHandlerCookie.php
+++ b/lib/SimpleSAML/SessionHandlerCookie.php
@@ -159,8 +159,8 @@ abstract class SessionHandlerCookie extends SessionHandler
      */
     public function setCookie($sessionName, $sessionID, array $cookieParams = null)
     {
-        assert('is_string($sessionName)');
-        assert('is_string($sessionID) || is_null($sessionID)');
+        assert(is_string($sessionName));
+        assert(is_string($sessionID) || $sessionID === null);
 
         if ($cookieParams !== null) {
             $params = array_merge($this->getCookieParams(), $cookieParams);

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -239,7 +239,7 @@ class SessionHandlerPHP extends SessionHandler
      */
     public function loadSession($sessionId = null)
     {
-        assert('is_string($sessionId) || is_null($sessionId)');
+        assert(is_string($sessionId) || $sessionId === null);
 
         if ($sessionId !== null) {
             if (session_id() === '') {
@@ -263,7 +263,7 @@ class SessionHandlerPHP extends SessionHandler
         }
 
         $session = $_SESSION['SimpleSAMLphp_SESSION'];
-        assert('is_string($session)');
+        assert(is_string($session));
 
         $session = unserialize($session);
 

--- a/lib/SimpleSAML/SessionHandlerStore.php
+++ b/lib/SimpleSAML/SessionHandlerStore.php
@@ -42,7 +42,7 @@ class SessionHandlerStore extends SessionHandlerCookie
      */
     public function loadSession($sessionId = null)
     {
-        assert('is_string($sessionId) || is_null($sessionId)');
+        assert(is_string($sessionId) || $sessionId === null);
 
         if ($sessionId === null) {
             $sessionId = $this->getCookieSessionId();
@@ -54,7 +54,7 @@ class SessionHandlerStore extends SessionHandlerCookie
 
         $session = $this->store->get('session', $sessionId);
         if ($session !== null) {
-            assert('$session instanceof SimpleSAML_Session');
+            assert($session instanceof SimpleSAML_Session);
             return $session;
         }
 

--- a/lib/SimpleSAML/Stats.php
+++ b/lib/SimpleSAML/Stats.php
@@ -70,10 +70,10 @@ class SimpleSAML_Stats
      */
     public static function log($event, array $data = array())
     {
-        assert('is_string($event)');
-        assert('!isset($data["op"])');
-        assert('!isset($data["time"])');
-        assert('!isset($data["_id"])');
+        assert(is_string($event));
+        assert(!isset($data['op']));
+        assert(!isset($data['time']));
+        assert(!isset($data['_id']));
 
         if (!self::$initialized) {
             self::initOutputs();

--- a/lib/SimpleSAML/Store/Memcache.php
+++ b/lib/SimpleSAML/Store/Memcache.php
@@ -39,8 +39,8 @@ class Memcache extends Store
      */
     public function get($type, $key)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
+        assert(is_string($type));
+        assert(is_string($key));
 
         return \SimpleSAML_Memcache::get($this->prefix . '.' . $type . '.' . $key);
     }
@@ -56,9 +56,9 @@ class Memcache extends Store
      */
     public function set($type, $key, $value, $expire = null)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
-        assert('is_null($expire) || (is_int($expire) && $expire > 2592000)');
+        assert(is_string($type));
+        assert(is_string($key));
+        assert($expire === null || (is_int($expire) && $expire > 2592000));
 
         if ($expire === null) {
             $expire = 0;
@@ -76,8 +76,8 @@ class Memcache extends Store
      */
     public function delete($type, $key)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
+        assert(is_string($type));
+        assert(is_string($key));
 
         \SimpleSAML_Memcache::delete($this->prefix . '.' . $type . '.' . $key);
     }

--- a/lib/SimpleSAML/Store/Redis.php
+++ b/lib/SimpleSAML/Store/Redis.php
@@ -17,13 +17,13 @@ class Redis extends Store
      */
     public function __construct($redis = null)
     {
-        assert('is_null($redis) || is_subclass_of($redis, "Predis\\Client")');
+        assert($redis === null || is_subclass_of($redis, 'Predis\\Client'));
 
         if (!class_exists('\Predis\Client')) {
             throw new \SimpleSAML\Error\CriticalConfigurationError('predis/predis is not available.');
         }
 
-        if (is_null($redis)) {
+        if ($redis === null) {
             $config = Configuration::getInstance();
 
             $host = $config->getString('store.redis.host', 'localhost');
@@ -65,8 +65,8 @@ class Redis extends Store
      */
     public function get($type, $key)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
+        assert(is_string($type));
+        assert(is_string($key));
 
         $result = $this->redis->get("{$type}.{$key}");
 
@@ -87,13 +87,13 @@ class Redis extends Store
      */
     public function set($type, $key, $value, $expire = null)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
-        assert('is_null($expire) || (is_int($expire) && $expire > 2592000)');
+        assert(is_string($type));
+        assert(is_string($key));
+        assert($expire === null || (is_int($expire) && $expire > 2592000));
 
         $serialized = serialize($value);
 
-        if (is_null($expire)) {
+        if ($expire === null) {
             $this->redis->set("{$type}.{$key}", $serialized);
         } else {
             $this->redis->setex("{$type}.{$key}", $expire, $serialized);
@@ -108,8 +108,8 @@ class Redis extends Store
      */
     public function delete($type, $key)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
+        assert(is_string($type));
+        assert(is_string($key));
 
         $this->redis->del("{$type}.{$key}");
     }

--- a/lib/SimpleSAML/Store/Redis.php
+++ b/lib/SimpleSAML/Store/Redis.php
@@ -12,6 +12,8 @@ use \SimpleSAML\Store;
  */
 class Redis extends Store
 {
+    public $redis;
+
     /**
      * Initialize the Redis data store.
      */

--- a/lib/SimpleSAML/Store/SQL.php
+++ b/lib/SimpleSAML/Store/SQL.php
@@ -130,7 +130,7 @@ class SQL extends Store
      */
     public function getTableVersion($name)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         if (!isset($this->tableVersions[$name])) {
             return 0;
@@ -148,8 +148,8 @@ class SQL extends Store
      */
     public function setTableVersion($name, $version)
     {
-        assert('is_string($name)');
-        assert('is_int($version)');
+        assert(is_string($name));
+        assert(is_int($version));
 
         $this->insertOrUpdate(
             $this->prefix.'_tableVersion',
@@ -171,7 +171,7 @@ class SQL extends Store
      */
     public function insertOrUpdate($table, array $keys, array $data)
     {
-        assert('is_string($table)');
+        assert(is_string($table));
 
         $colNames = '('.implode(', ', array_keys($data)).')';
         $values = 'VALUES(:'.implode(', :', array_keys($data)).')';
@@ -249,8 +249,8 @@ class SQL extends Store
      */
     public function get($type, $key)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
+        assert(is_string($type));
+        assert(is_string($key));
 
         if (strlen($key) > 50) {
             $key = sha1($key);
@@ -292,9 +292,9 @@ class SQL extends Store
      */
     public function set($type, $key, $value, $expire = null)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
-        assert('is_null($expire) || (is_int($expire) && $expire > 2592000)');
+        assert(is_string($type));
+        assert(is_string($key));
+        assert($expire === null || (is_int($expire) && $expire > 2592000));
 
         if (rand(0, 1000) < 10) {
             $this->cleanKVStore();
@@ -330,8 +330,8 @@ class SQL extends Store
      */
     public function delete($type, $key)
     {
-        assert('is_string($type)');
-        assert('is_string($key)');
+        assert(is_string($type));
+        assert(is_string($key));
 
         if (strlen($key) > 50) {
             $key = sha1($key);

--- a/lib/SimpleSAML/Utilities.php
+++ b/lib/SimpleSAML/Utilities.php
@@ -192,9 +192,9 @@ class SimpleSAML_Utilities
 
     private static function _doRedirect($url, $parameters = array())
     {
-        assert('is_string($url)');
-        assert('!empty($url)');
-        assert('is_array($parameters)');
+        assert(is_string($url));
+        assert(!empty($url));
+        assert(is_array($parameters));
 
         if (!empty($parameters)) {
             $url = self::addURLparameter($url, $parameters);
@@ -254,9 +254,9 @@ class SimpleSAML_Utilities
      */
     public static function redirect($url, $parameters = array(), $allowed_redirect_hosts = null)
     {
-        assert('is_string($url)');
-        assert('strlen($url) > 0');
-        assert('is_array($parameters)');
+        assert(is_string($url));
+        assert(strlen($url) > 0);
+        assert(is_array($parameters));
 
         if ($allowed_redirect_hosts !== null) {
             $url = self::checkURLAllowed($url, $allowed_redirect_hosts);
@@ -358,7 +358,7 @@ class SimpleSAML_Utilities
      */
     public static function generateRandomBytes($length)
     {
-        assert('is_int($length)');
+        assert(is_int($length));
 
         return openssl_random_pseudo_bytes($length);
     }
@@ -557,8 +557,8 @@ class SimpleSAML_Utilities
      */
     public static function createHttpPostRedirectLink($destination, $post)
     {
-        assert('is_string($destination)');
-        assert('is_array($post)');
+        assert(is_string($destination));
+        assert(is_array($post));
 
         $postId = SimpleSAML\Utils\Random::generateID();
         $postData = array(

--- a/lib/SimpleSAML/Utils/Crypto.php
+++ b/lib/SimpleSAML/Utils/Crypto.php
@@ -296,7 +296,7 @@ class Crypto
 
             // normalize fingerprint(s) - lowercase and no colons
             foreach ($fps as &$fp) {
-                assert('is_string($fp)');
+                assert(is_string($fp));
                 $fp = strtolower(str_replace(':', '', $fp));
             }
 

--- a/lib/SimpleSAML/XHTML/IdPDisco.php
+++ b/lib/SimpleSAML/XHTML/IdPDisco.php
@@ -115,7 +115,7 @@ class SimpleSAML_XHTML_IdPDisco
      */
     public function __construct(array $metadataSets, $instance)
     {
-        assert('is_string($instance)');
+        assert(is_string($instance));
 
         // initialize standard classes
         $this->config = SimpleSAML_Configuration::getInstance();
@@ -388,7 +388,7 @@ class SimpleSAML_XHTML_IdPDisco
      */
     protected function setPreviousIdP($idp)
     {
-        assert('is_string($idp)');
+        assert(is_string($idp));
 
         $this->log('Choice made ['.$idp.'] Setting cookie.');
         $this->setCookie('lastidp', $idp);

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -451,7 +451,7 @@ class SimpleSAML_XHTML_Template
      */
     private function findTemplatePath($template, $throw_exception = true)
     {
-        assert('is_string($template)');
+        assert(is_string($template));
 
         list($templateModule, $templateName) = $this->findModuleAndTemplateName($template);
         $templateModule = ($templateModule !== null) ? $templateModule : 'default';

--- a/lib/SimpleSAML/XML/Errors.php
+++ b/lib/SimpleSAML/XML/Errors.php
@@ -108,7 +108,7 @@ class Errors
      */
     public static function formatError($error)
     {
-        assert('$error instanceof LibXMLError');
+        assert($error instanceof LibXMLError);
         return 'level=' . $error->level . ',code='  . $error->code . ',line=' . $error->line . ',col=' . $error->column .
             ',msg=' . trim($error->message);
     }
@@ -126,7 +126,7 @@ class Errors
      */
     public static function formatErrors($errors)
     {
-        assert('is_array($errors)');
+        assert(is_array($errors));
 
         $ret = '';
         foreach ($errors as $error) {

--- a/lib/SimpleSAML/XML/Errors.php
+++ b/lib/SimpleSAML/XML/Errors.php
@@ -12,6 +12,8 @@
 
 namespace SimpleSAML\XML;
 
+use LibXMLError;
+
 class Errors
 {
 

--- a/lib/SimpleSAML/XML/Shib13/AuthnResponse.php
+++ b/lib/SimpleSAML/XML/Shib13/AuthnResponse.php
@@ -9,6 +9,8 @@
 
 namespace SimpleSAML\XML\Shib13;
 
+use DOMDocument;
+use DOMNode;
 use SAML2\DOMDocumentFactory;
 use SAML2\Utils;
 use SimpleSAML\Utils\Config;
@@ -53,7 +55,7 @@ class AuthnResponse
      */
     public function setMessageValidated($messageValidated)
     {
-        assert('is_bool($messageValidated)');
+        assert(is_bool($messageValidated));
 
         $this->messageValidated = $messageValidated;
     }
@@ -61,7 +63,7 @@ class AuthnResponse
 
     public function setXML($xml)
     {
-        assert('is_string($xml)');
+        assert(is_string($xml));
 
         try {
             $this->dom = DOMDocumentFactory::fromString(str_replace("\r", "", $xml));
@@ -82,7 +84,7 @@ class AuthnResponse
 
     public function validate()
     {
-        assert('$this->dom instanceof DOMDocument');
+        assert($this->dom instanceof DOMDocument);
 
         if ($this->messageValidated) {
             // This message was validated externally
@@ -147,7 +149,7 @@ class AuthnResponse
             $node = dom_import_simplexml($node);
         }
 
-        assert('$node instanceof DOMNode');
+        assert($node instanceof DOMNode);
 
         return $this->validator->isNodeValidated($node);
     }
@@ -163,14 +165,14 @@ class AuthnResponse
      */
     private function doXPathQuery($query, $node = null)
     {
-        assert('is_string($query)');
-        assert('$this->dom instanceof DOMDocument');
+        assert(is_string($query));
+        assert($this->dom instanceof DOMDocument);
 
         if ($node === null) {
             $node = $this->dom->documentElement;
         }
 
-        assert('$node instanceof DOMNode');
+        assert($node instanceof DOMNode);
 
         $xPath = new \DOMXpath($this->dom);
         $xPath->registerNamespace('shibp', self::SHIB_PROTOCOL_NS);
@@ -186,7 +188,7 @@ class AuthnResponse
      */
     public function getSessionIndex()
     {
-        assert('$this->dom instanceof DOMDocument');
+        assert($this->dom instanceof DOMDocument);
 
         $query = '/shibp:Response/shib:Assertion/shib:AuthnStatement';
         $nodelist = $this->doXPathQuery($query);
@@ -306,8 +308,8 @@ class AuthnResponse
      */
     public function generate(\SimpleSAML_Configuration $idp, \SimpleSAML_Configuration $sp, $shire, $attributes)
     {
-        assert('is_string($shire)');
-        assert('$attributes === NULL || is_array($attributes)');
+        assert(is_string($shire));
+        assert($attributes === null || is_array($attributes));
 
         if ($sp->hasValue('scopedattributes')) {
             $scopedAttributes = $sp->getArray('scopedattributes');
@@ -406,10 +408,10 @@ class AuthnResponse
      */
     private function enc_attribute($name, $values, $base64, $scopedAttributes)
     {
-        assert('is_string($name)');
-        assert('is_array($values)');
-        assert('is_bool($base64)');
-        assert('is_array($scopedAttributes)');
+        assert(is_string($name));
+        assert(is_array($values));
+        assert(is_bool($base64));
+        assert(is_array($scopedAttributes));
 
         if (in_array($name, $scopedAttributes, true)) {
             $scoped = true;

--- a/lib/SimpleSAML/XML/Signer.php
+++ b/lib/SimpleSAML/XML/Signer.php
@@ -11,6 +11,9 @@
 
 namespace SimpleSAML\XML;
 
+use DOMComment;
+use DOMElement;
+use DOMText;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SimpleSAML\Utils\Config;
@@ -59,7 +62,7 @@ class Signer
      */
     public function __construct($options = array())
     {
-        assert('is_array($options)');
+        assert(is_array($options));
 
         $this->idAttrName = false;
         $this->privateKey = false;
@@ -103,8 +106,8 @@ class Signer
      */
     public function loadPrivateKeyArray($privatekey)
     {
-        assert('is_array($privatekey)');
-        assert('array_key_exists("PEM", $privatekey)');
+        assert(is_array($privatekey));
+        assert(array_key_exists('PEM', $privatekey));
 
         $this->privateKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'private'));
         if (array_key_exists('password', $privatekey)) {
@@ -129,9 +132,9 @@ class Signer
      */
     public function loadPrivateKey($file, $pass = null, $full_path = false)
     {
-        assert('is_string($file)');
-        assert('is_string($pass) || is_null($pass)');
-        assert('is_bool($full_path)');
+        assert(is_string($file));
+        assert(is_string($pass) || $pass === null);
+        assert(is_bool($full_path));
 
         if (!$full_path) {
             $keyFile = Config::getCertPath($file);
@@ -166,7 +169,7 @@ class Signer
      */
     public function loadPublicKeyArray($publickey)
     {
-        assert('is_array($publickey)');
+        assert(is_array($publickey));
 
         if (!array_key_exists('PEM', $publickey)) {
             // We have a public key with only a fingerprint
@@ -192,8 +195,8 @@ class Signer
      */
     public function loadCertificate($file, $full_path = false)
     {
-        assert('is_string($file)');
-        assert('is_bool($full_path)');
+        assert(is_string($file));
+        assert(is_bool($full_path));
 
         if (!$full_path) {
             $certFile = Config::getCertPath($file);
@@ -219,7 +222,7 @@ class Signer
      */
     public function setIDAttribute($idAttrName)
     {
-        assert('is_string($idAttrName)');
+        assert(is_string($idAttrName));
 
         $this->idAttrName = $idAttrName;
     }
@@ -238,8 +241,8 @@ class Signer
      */
     public function addCertificate($file, $full_path = false)
     {
-        assert('is_string($file)');
-        assert('is_bool($full_path)');
+        assert(is_string($file));
+        assert(is_bool($full_path));
 
         if (!$full_path) {
             $certFile = Config::getCertPath($file);
@@ -274,10 +277,10 @@ class Signer
      */
     public function sign($node, $insertInto, $insertBefore = null)
     {
-        assert('$node instanceof DOMElement');
-        assert('$insertInto instanceof DOMElement');
-        assert('is_null($insertBefore) || $insertBefore instanceof DOMElement ' .
-            '|| $insertBefore instanceof DOMComment || $insertBefore instanceof DOMText');
+        assert($node instanceof DOMElement);
+        assert($insertInto instanceof DOMElement);
+        assert($insertBefore === null || $insertBefore instanceof DOMElement ||
+            $insertBefore instanceof DOMComment || $insertBefore instanceof DOMText);
 
         if ($this->privateKey === false) {
             throw new \Exception('Private key not set.');

--- a/lib/SimpleSAML/XML/Validator.php
+++ b/lib/SimpleSAML/XML/Validator.php
@@ -48,7 +48,7 @@ class Validator
      */
     public function __construct($xmlNode, $idAttribute = null, $publickey = false)
     {
-        assert('$xmlNode instanceof \DOMNode');
+        assert($xmlNode instanceof \DOMNode);
 
         if ($publickey === null) {
             $publickey = false;
@@ -57,7 +57,7 @@ class Validator
                 'PEM' => $publickey,
             );
         } else {
-            assert('$publickey === FALSE || is_array($publickey)');
+            assert($publickey === false || is_array($publickey));
         }
 
         // Create an XML security object
@@ -111,7 +111,7 @@ class Validator
                  * Check that the response contains a certificate with a matching
                  * fingerprint.
                  */
-                assert('is_array($publickey["certFingerprint"])');
+                assert(is_array($publickey['certFingerprint']));
 
                 $certificate = $objKey->getX509Certificate();
                 if ($certificate === null) {
@@ -162,7 +162,7 @@ class Validator
      */
     private static function calculateX509Fingerprint($x509cert)
     {
-        assert('is_string($x509cert)');
+        assert(is_string($x509cert));
 
         $lines = explode("\n", $x509cert);
 
@@ -205,8 +205,8 @@ class Validator
      */
     private static function validateCertificateFingerprint($certificate, $fingerprints)
     {
-        assert('is_string($certificate)');
-        assert('is_array($fingerprints)');
+        assert(is_string($certificate));
+        assert(is_array($fingerprints));
 
         $certFingerprint = self::calculateX509Fingerprint($certificate);
         if ($certFingerprint === null) {
@@ -216,7 +216,7 @@ class Validator
         }
 
         foreach ($fingerprints as $fp) {
-            assert('is_string($fp)');
+            assert(is_string($fp));
 
             if ($fp === $certFingerprint) {
                 // The fingerprints matched
@@ -243,7 +243,7 @@ class Validator
      */
     public function validateFingerprint($fingerprints)
     {
-        assert('is_string($fingerprints) || is_array($fingerprints)');
+        assert(is_string($fingerprints) || is_array($fingerprints));
 
         if ($this->x509Certificate === null) {
             throw new \Exception('Key used to sign the message was not an X509 certificate.');
@@ -255,7 +255,7 @@ class Validator
 
         // Normalize the fingerprints
         foreach ($fingerprints as &$fp) {
-            assert('is_string($fp)');
+            assert(is_string($fp));
 
             // Make sure that the fingerprint is in the correct format
             $fp = strtolower(str_replace(":", "", $fp));
@@ -274,7 +274,7 @@ class Validator
      */
     public function isNodeValidated($node)
     {
-        assert('$node instanceof \DOMNode');
+        assert($node instanceof \DOMNode);
 
         while ($node !== null) {
             if (in_array($node, $this->validNodes)) {
@@ -301,7 +301,7 @@ class Validator
      */
     public function validateCA($caFile)
     {
-        assert('is_string($caFile)');
+        assert(is_string($caFile));
 
         if ($this->x509Certificate === null) {
             throw new \Exception('Key used to sign the message was not an X509 certificate.');
@@ -321,8 +321,8 @@ class Validator
      */
     private static function validateCABuiltIn($certificate, $caFile)
     {
-        assert('is_string($certificate)');
-        assert('is_string($caFile)');
+        assert(is_string($certificate));
+        assert(is_string($caFile));
 
         // Clear openssl errors
         while (openssl_error_string() !== false);
@@ -358,8 +358,8 @@ class Validator
      */
     private static function validateCAExec($certificate, $caFile)
     {
-        assert('is_string($certificate)');
-        assert('is_string($caFile)');
+        assert(is_string($certificate));
+        assert(is_string($caFile));
 
         $command = array(
             'openssl', 'verify',
@@ -417,8 +417,8 @@ class Validator
      */
     public static function validateCertificate($certificate, $caFile)
     {
-        assert('is_string($certificate)');
-        assert('is_string($caFile)');
+        assert(is_string($certificate));
+        assert(is_string($caFile));
 
         if (!file_exists($caFile)) {
             throw new \Exception('Could not load CA file: ' . $caFile);

--- a/modules/adfs/lib/IdP/ADFS.php
+++ b/modules/adfs/lib/IdP/ADFS.php
@@ -192,7 +192,7 @@ MSG;
         // this implies an override to normal sp notification
         if (isset($_GET['wreply']) && !empty($_GET['wreply'])) {
             $idp->doLogoutRedirect(\SimpleSAML\Utils\HTTP::checkURLAllowed($_GET['wreply']));
-            assert('false');
+            assert(false);
         }
 
         $state = array(

--- a/modules/adfs/lib/SAML2/XML/fed/Endpoint.php
+++ b/modules/adfs/lib/SAML2/XML/fed/Endpoint.php
@@ -14,8 +14,8 @@ class sspmod_adfs_SAML2_XML_fed_Endpoint
      */
     public static function appendXML(DOMElement $parent, $name, $address)
     {
-        assert('is_string($name)');
-        assert('is_string($address)');
+        assert(is_string($name));
+        assert(is_string($address));
 
         $e = $parent->ownerDocument->createElement($name);
         $parent->appendChild($e);

--- a/modules/adfs/lib/SAML2/XML/fed/SecurityTokenServiceType.php
+++ b/modules/adfs/lib/SAML2/XML/fed/SecurityTokenServiceType.php
@@ -41,7 +41,7 @@ class sspmod_adfs_SAML2_XML_fed_SecurityTokenServiceType extends SAML2_XML_md_Ro
      */
     public function toXML(DOMElement $parent)
     {
-        assert('is_string($this->Location)');
+        assert(is_string($this->Location));
 
         $e = parent::toXML($parent);
         $e->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:fed', sspmod_adfs_SAML2_XML_fed_Const::NS_FED);

--- a/modules/adfs/www/idp/metadata.php
+++ b/modules/adfs/www/idp/metadata.php
@@ -47,7 +47,7 @@ try {
 
     if ($idpmeta->hasValue('https.certificate')) {
         $httpsCert = SimpleSAML\Utils\Crypto::loadPublicKey($idpmeta, true, 'https.');
-        assert('isset($httpsCert["certData"])');
+        assert(isset($httpsCert['certData']));
         $availableCerts['https.crt'] = $httpsCert;
         $keys[] = array(
             'type'            => 'X509Certificate',

--- a/modules/adfs/www/idp/prp.php
+++ b/modules/adfs/www/idp/prp.php
@@ -18,7 +18,7 @@ if (isset($_GET['wa'])) {
     } else if ($_GET['wa'] === 'wsignin1.0') {
         sspmod_adfs_IdP_ADFS::receiveAuthnRequest($idp);
     }
-    assert('false');		
+    assert(false);
 } elseif (isset($_GET['assocId'])) {
     // logout response from ADFS SP
     $assocId = $_GET['assocId']; // Association ID of the SP that sent the logout response

--- a/modules/authX509/lib/Auth/Process/ExpiryWarning.php
+++ b/modules/authX509/lib/Auth/Process/ExpiryWarning.php
@@ -30,7 +30,7 @@ class sspmod_authX509_Auth_Process_ExpiryWarning extends SimpleSAML_Auth_Process
     {
         parent::__construct($config, $reserved);
 
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (array_key_exists('warndaysbefore', $config)) {
             $this->warndaysbefore = $config['warndaysbefore'];
@@ -57,7 +57,7 @@ class sspmod_authX509_Auth_Process_ExpiryWarning extends SimpleSAML_Auth_Process
      */
     public function process(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         if (isset($state['isPassive']) && $state['isPassive'] === true) {
             // We have a passive request. Skip the warning

--- a/modules/authX509/lib/Auth/Source/X509userCert.php
+++ b/modules/authX509/lib/Auth/Source/X509userCert.php
@@ -37,8 +37,8 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
      */
     public function __construct($info, &$config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         if (isset($config['authX509:x509attributes'])) {
             $this->x509attributes = $config['authX509:x509attributes'];
@@ -88,7 +88,7 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
      */
     public function authenticate(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
         $ldapcf = $this->ldapcf;
 
         if (!isset($_SERVER['SSL_CLIENT_CERT']) ||
@@ -96,7 +96,7 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
             $state['authX509.error'] = "NOCERT";
             $this->authFailed($state);
 
-            assert('false'); // should never be reached
+            assert(false); // should never be reached
             return;
         }
 
@@ -107,7 +107,7 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
             $state['authX509.error'] = "INVALIDCERT";
             $this->authFailed($state);
 
-            assert('false'); // should never be reached
+            assert(false); // should never be reached
             return;
         }
 
@@ -129,17 +129,17 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
             $state['authX509.error'] = "UNKNOWNCERT";
             $this->authFailed($state);
 
-            assert('false'); // should never be reached
+            assert(false); // should never be reached
             return;
         }
 
         if ($this->ldapusercert === null) { // do not check for certificate match
             $attributes = $ldapcf->getAttributes($dn);
-            assert('is_array($attributes)');
+            assert(is_array($attributes));
             $state['Attributes'] = $attributes;
             $this->authSuccesful($state);
 
-            assert('false'); // should never be reached
+            assert(false); // should never be reached
             return;
         }
 
@@ -149,7 +149,7 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
             $state['authX509.error'] = "UNKNOWNCERT";
             $this->authFailed($state);
 
-            assert('false'); // should never be reached
+            assert(false); // should never be reached
             return;
         }
 
@@ -170,11 +170,11 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
 
             if ($ldap_cert_data === $client_cert_data) {
                 $attributes = $ldapcf->getAttributes($dn);
-                assert('is_array($attributes)');
+                assert(is_array($attributes));
                 $state['Attributes'] = $attributes;
                 $this->authSuccesful($state);
 
-                assert('false'); // should never be reached
+                assert(false); // should never be reached
                 return;
             }
         }
@@ -183,7 +183,7 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
         $state['authX509.error'] = "UNKNOWNCERT";
         $this->authFailed($state);
 
-        assert('false'); // should never be reached
+        assert(false); // should never be reached
         return;
     }
 
@@ -199,7 +199,7 @@ class sspmod_authX509_Auth_Source_X509userCert extends SimpleSAML_Auth_Source
     {
         SimpleSAML_Auth_Source::completeAuth($state);
 
-        assert('false'); // should never be reached
+        assert(false); // should never be reached
         return;
     }
 }

--- a/modules/authYubiKey/lib/Auth/Process/OTP2YubiPrefix.php
+++ b/modules/authYubiKey/lib/Auth/Process/OTP2YubiPrefix.php
@@ -52,8 +52,8 @@ class sspmod_authYubiKey_Auth_Process_OTP2YubiPrefix extends SimpleSAML_Auth_Pro
 	 * @param array &$state  The state we should update.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("Attributes", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('Attributes', $state));
 		$attributes = $state['Attributes'];
 
 		SimpleSAML\Logger::debug('OTP2YubiPrefix: enter with attributes: ' . implode(',', array_keys($attributes)));

--- a/modules/authYubiKey/lib/Auth/Source/YubiKey.php
+++ b/modules/authYubiKey/lib/Auth/Source/YubiKey.php
@@ -70,8 +70,8 @@ class sspmod_authYubiKey_Auth_Source_YubiKey extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -95,7 +95,7 @@ class sspmod_authYubiKey_Auth_Source_YubiKey extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		// We are going to need the authId in order to retrieve this authentication source later
 		$state[self::AUTHID] = $this->authId;
@@ -120,14 +120,14 @@ class sspmod_authYubiKey_Auth_Source_YubiKey extends SimpleSAML_Auth_Source {
 	 * @return string  Error code in the case of an error.
 	 */
 	public static function handleLogin($authStateId, $otp) {
-		assert('is_string($authStateId)');
-		assert('is_string($otp)');
+		assert(is_string($authStateId));
+		assert(is_string($otp));
 
 		/* Retrieve the authentication state. */
 		$state = SimpleSAML_Auth_State::loadState($authStateId, self::STAGEID);
 
 		/* Find authentication source. */
-		assert('array_key_exists(self::AUTHID, $state)');
+		assert(array_key_exists(self::AUTHID, $state));
 		$source = SimpleSAML_Auth_Source::getById($state[self::AUTHID]);
 		if ($source === NULL) {
 			throw new Exception('Could not find authentication source with id ' . $state[self::AUTHID]);
@@ -178,7 +178,7 @@ class sspmod_authYubiKey_Auth_Source_YubiKey extends SimpleSAML_Auth_Source {
 	 * @return array  Associative array with the users attributes.
 	 */
 	protected function login($otp) {
-		assert('is_string($otp)');
+		assert(is_string($otp));
 
 		require_once dirname(dirname(dirname(dirname(__FILE__)))) . '/libextinc/Yubico.php';
 

--- a/modules/authcrypt/lib/Auth/Source/Hash.php
+++ b/modules/authcrypt/lib/Auth/Source/Hash.php
@@ -31,8 +31,8 @@ class sspmod_authcrypt_Auth_Source_Hash extends sspmod_core_Auth_UserPassBase
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -85,8 +85,8 @@ class sspmod_authcrypt_Auth_Source_Hash extends sspmod_core_Auth_UserPassBase
      */
     protected function login($username, $password)
     {
-        assert('is_string($username)');
-        assert('is_string($password)');
+        assert(is_string($username));
+        assert(is_string($password));
 
         foreach ($this->users as $userpass => $attrs) {
             $matches = explode(':', $userpass, 2);

--- a/modules/authcrypt/lib/Auth/Source/Htpasswd.php
+++ b/modules/authcrypt/lib/Auth/Source/Htpasswd.php
@@ -38,8 +38,8 @@ class sspmod_authcrypt_Auth_Source_Htpasswd extends sspmod_core_Auth_UserPassBas
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -79,8 +79,8 @@ class sspmod_authcrypt_Auth_Source_Htpasswd extends sspmod_core_Auth_UserPassBas
      */
     protected function login($username, $password)
     {
-        assert('is_string($username)');
-        assert('is_string($password)');
+        assert(is_string($username));
+        assert(is_string($password));
 
         foreach ($this->users as $userpass) {
             $matches = explode(':', $userpass, 2);

--- a/modules/authfacebook/lib/Auth/Source/Facebook.php
+++ b/modules/authfacebook/lib/Auth/Source/Facebook.php
@@ -61,8 +61,8 @@ class sspmod_authfacebook_Auth_Source_Facebook extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -82,7 +82,7 @@ class sspmod_authfacebook_Auth_Source_Facebook extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		// We are going to need the authId in order to retrieve this authentication source later
 		$state[self::AUTHID] = $this->authId;
@@ -100,7 +100,7 @@ class sspmod_authfacebook_Auth_Source_Facebook extends SimpleSAML_Auth_Source {
 		
 
 	public function finalStep(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		$facebook = new sspmod_authfacebook_Facebook(array('appId' => $this->api_key, 'secret' => $this->secret), $state);
 		$uid = $facebook->getUser();

--- a/modules/authlinkedin/lib/Auth/Source/LinkedIn.php
+++ b/modules/authlinkedin/lib/Auth/Source/LinkedIn.php
@@ -34,8 +34,8 @@ class sspmod_authlinkedin_Auth_Source_LinkedIn extends SimpleSAML_Auth_Source
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -67,7 +67,7 @@ class sspmod_authlinkedin_Auth_Source_LinkedIn extends SimpleSAML_Auth_Source
      */
     public function authenticate(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         // We are going to need the authId in order to retrieve this authentication source later
         $state[self::AUTHID] = $this->authId;

--- a/modules/authlinkedin/www/linkback.php
+++ b/modules/authlinkedin/www/linkback.php
@@ -17,7 +17,7 @@ if (array_key_exists('oauth_verifier', $_REQUEST)) {
 }
 
 // Find authentication source
-assert('array_key_exists(sspmod_authlinkedin_Auth_Source_LinkedIn::AUTHID, $state)');
+assert(array_key_exists(sspmod_authlinkedin_Auth_Source_LinkedIn::AUTHID, $state));
 $sourceId = $state[sspmod_authlinkedin_Auth_Source_LinkedIn::AUTHID];
 
 $source = SimpleSAML_Auth_Source::getById($sourceId);

--- a/modules/authmyspace/lib/Auth/Source/MySpace.php
+++ b/modules/authmyspace/lib/Auth/Source/MySpace.php
@@ -31,8 +31,8 @@ class sspmod_authmyspace_Auth_Source_MySpace extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -55,7 +55,7 @@ class sspmod_authmyspace_Auth_Source_MySpace extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		// We are going to need the authId in order to retrieve this authentication source later
 		$state[self::AUTHID] = $this->authId;

--- a/modules/authmyspace/www/linkback.php
+++ b/modules/authmyspace/www/linkback.php
@@ -28,7 +28,7 @@ if (array_key_exists('oauth_verifier', $_REQUEST)) {
 }
 
 // Find authentication source
-assert('array_key_exists(sspmod_authmyspace_Auth_Source_MySpace::AUTHID, $state)');
+assert(array_key_exists(sspmod_authmyspace_Auth_Source_MySpace::AUTHID, $state));
 $sourceId = $state[sspmod_authmyspace_Auth_Source_MySpace::AUTHID];
 
 $source = SimpleSAML_Auth_Source::getById($sourceId);

--- a/modules/authorize/lib/Auth/Process/Authorize.php
+++ b/modules/authorize/lib/Auth/Process/Authorize.php
@@ -41,7 +41,7 @@ class sspmod_authorize_Auth_Process_Authorize extends SimpleSAML_Auth_Processing
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		// Check for the deny option, get it and remove it
 		// Must be bool specifically, if not, it might be for a attrib filter below
@@ -79,8 +79,8 @@ class sspmod_authorize_Auth_Process_Authorize extends SimpleSAML_Auth_Processing
 	 */
 	public function process(&$request) {
 		$authorize = $this->deny;
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$attributes =& $request['Attributes'];
 

--- a/modules/authtwitter/lib/Auth/Source/Twitter.php
+++ b/modules/authtwitter/lib/Auth/Source/Twitter.php
@@ -32,8 +32,8 @@ class sspmod_authtwitter_Auth_Source_Twitter extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -53,7 +53,7 @@ class sspmod_authtwitter_Auth_Source_Twitter extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		// We are going to need the authId in order to retrieve this authentication source later
 		$state[self::AUTHID] = $this->authId;

--- a/modules/authwindowslive/lib/Auth/Source/LiveID.php
+++ b/modules/authwindowslive/lib/Auth/Source/LiveID.php
@@ -34,8 +34,8 @@ class sspmod_authwindowslive_Auth_Source_LiveID extends SimpleSAML_Auth_Source
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -61,7 +61,7 @@ class sspmod_authwindowslive_Auth_Source_LiveID extends SimpleSAML_Auth_Source
      */
     public function authenticate(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         // we are going to need the authId in order to retrieve this authentication source later
         $state[self::AUTHID] = $this->authId;

--- a/modules/authwindowslive/www/linkback.php
+++ b/modules/authwindowslive/www/linkback.php
@@ -33,7 +33,7 @@ if (array_key_exists('code', $_REQUEST)) {
 }
 
 // find authentication source
-assert('array_key_exists(sspmod_authwindowslive_Auth_Source_LiveID::AUTHID, $state)');
+assert(array_key_exists(sspmod_authwindowslive_Auth_Source_LiveID::AUTHID, $state));
 $sourceId = $state[sspmod_authwindowslive_Auth_Source_LiveID::AUTHID];
 
 $source = SimpleSAML_Auth_Source::getById($sourceId);

--- a/modules/cas/lib/Auth/Source/CAS.php
+++ b/modules/cas/lib/Auth/Source/CAS.php
@@ -48,8 +48,8 @@ class sspmod_cas_Auth_Source_CAS  extends SimpleSAML_Auth_Source  {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -194,7 +194,7 @@ class sspmod_cas_Auth_Source_CAS  extends SimpleSAML_Auth_Source  {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		// We are going to need the authId in order to retrieve this authentication source later
 		$state[self::AUTHID] = $this->authId;
@@ -224,7 +224,7 @@ class sspmod_cas_Auth_Source_CAS  extends SimpleSAML_Auth_Source  {
 	 * @param array &$state  Information about the current logout operation.
 	 */
 	public function logout(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 		$logoutUrl = $this->_casConfig['logout'];
 
 		SimpleSAML_Auth_State::deleteState($state);

--- a/modules/cas/www/linkback.php
+++ b/modules/cas/www/linkback.php
@@ -15,7 +15,7 @@ if (!isset($_GET['ticket'])) {
 $state['cas:ticket'] = (string)$_GET['ticket'];
 
 // Find authentication source
-assert('array_key_exists(sspmod_cas_Auth_Source_CAS::AUTHID, $state)');
+assert(array_key_exists(sspmod_cas_Auth_Source_CAS::AUTHID, $state));
 $sourceId = $state[sspmod_cas_Auth_Source_CAS::AUTHID];
 
 $source = SimpleSAML_Auth_Source::getById($sourceId);

--- a/modules/cdc/lib/Auth/Process/CDC.php
+++ b/modules/cdc/lib/Auth/Process/CDC.php
@@ -32,7 +32,7 @@ class sspmod_cdc_Auth_Process_CDC extends SimpleSAML_Auth_ProcessingFilter {
 	 */
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (!isset($config['domain'])) {
 			throw new SimpleSAML_Error_Exception('Missing domain option in cdc:CDC filter.');
@@ -49,7 +49,7 @@ class sspmod_cdc_Auth_Process_CDC extends SimpleSAML_Auth_ProcessingFilter {
 	 * @param array &$state  The request state.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		if (!isset($state['Source']['entityid'])) {
 			SimpleSAML\Logger::warning('saml:CDC: Could not find IdP entityID.');

--- a/modules/cdc/lib/Client.php
+++ b/modules/cdc/lib/Client.php
@@ -29,7 +29,7 @@ class sspmod_cdc_Client {
 	 * @param string $domain  The domain we should query the server for.
 	 */
 	public function __construct($domain) {
-		assert('is_string($domain)');
+		assert(is_string($domain));
 
 		$this->domain = $domain;
 		$this->server = new sspmod_cdc_Server($domain);
@@ -55,8 +55,8 @@ class sspmod_cdc_Client {
 	 * @param array $params  Additional parameters.
 	 */
 	public function sendRequest($returnTo, $op, array $params = array()) {
-		assert('is_string($returnTo)');
-		assert('is_string($op)');
+		assert(is_string($returnTo));
+		assert(is_string($op));
 
 		$params['op'] = $op;
 		$params['return'] = $returnTo;

--- a/modules/cdc/lib/Server.php
+++ b/modules/cdc/lib/Server.php
@@ -47,7 +47,7 @@ class sspmod_cdc_Server {
 	 * @param string $domain  The domain we are a server for.
 	 */
 	public function __construct($domain) {
-		assert('is_string($domain)');
+		assert(is_string($domain));
 
 		$cdcConfig = SimpleSAML_Configuration::getConfig('module_cdc.php');
 		$config = $cdcConfig->getConfigItem($domain, NULL);
@@ -73,8 +73,8 @@ class sspmod_cdc_Server {
 	 * @param array $request  The CDC request.
 	 */
 	public function sendRequest(array $request) {
-		assert('isset($request["return"])');
-		assert('isset($request["op"])');
+		assert(isset($request['return']));
+		assert(isset($request['op']));
 
 		$request['domain'] = $this->domain;
 		$this->send($this->server, 'CDCRequest', $request);
@@ -240,7 +240,7 @@ class sspmod_cdc_Server {
 	 * @return array|NULL  The response, or NULL if no response is received.
 	 */
 	private static function get($parameter) {
-		assert('is_string($parameter)');
+		assert(is_string($parameter));
 
 		if (!isset($_REQUEST[$parameter])) {
 			return NULL;
@@ -285,8 +285,8 @@ class sspmod_cdc_Server {
 	 * @param string $parameter  The name of the query parameter.
 	 */
 	private function validate($parameter) {
-		assert('is_string($parameter)');
-		assert('isset($_REQUEST[$parameter])');
+		assert(is_string($parameter));
+		assert(isset($_REQUEST[$parameter]));
 
 		$message = (string)$_REQUEST[$parameter];
 
@@ -310,8 +310,8 @@ class sspmod_cdc_Server {
 	 * @param array $message  The CDC message.
 	 */
 	private function send($to, $parameter, array $message) {
-		assert('is_string($to)');
-		assert('is_string($parameter)');
+		assert(is_string($to));
+		assert(is_string($parameter));
 
 		$message['timestamp'] = time();
 		$message = json_encode($message);
@@ -340,7 +340,7 @@ class sspmod_cdc_Server {
 	 * @return string  The signature.
 	 */
 	private function calcSignature($rawMessage) {
-		assert('is_string($rawMessage)');
+		assert(is_string($rawMessage));
 
 		return sha1($this->key . $rawMessage . $this->key);
 	}

--- a/modules/consent/lib/Auth/Process/Consent.php
+++ b/modules/consent/lib/Auth/Process/Consent.php
@@ -74,7 +74,7 @@ class sspmod_consent_Auth_Process_Consent extends SimpleSAML_Auth_ProcessingFilt
      */
     public function __construct($config, $reserved)
     {
-        assert('is_array($config)');
+        assert(is_array($config));
         parent::__construct($config, $reserved);
 
         if (array_key_exists('includeValues', $config)) {
@@ -218,13 +218,13 @@ class sspmod_consent_Auth_Process_Consent extends SimpleSAML_Auth_ProcessingFilt
      */
     public function process(&$state)
     {
-        assert('is_array($state)');
-        assert('array_key_exists("UserID", $state)');
-        assert('array_key_exists("Destination", $state)');
-        assert('array_key_exists("entityid", $state["Destination"])');
-        assert('array_key_exists("metadata-set", $state["Destination"])');
-        assert('array_key_exists("entityid", $state["Source"])');
-        assert('array_key_exists("metadata-set", $state["Source"])');
+        assert(is_array($state));
+        assert(array_key_exists('UserID', $state));
+        assert(array_key_exists('Destination', $state));
+        assert(array_key_exists('entityid', $state['Destination']));
+        assert(array_key_exists('metadata-set', $state['Destination']));
+        assert(array_key_exists('entityid', $state['Source']));
+        assert(array_key_exists('metadata-set', $state['Source']));
 
         $spEntityId = $state['Destination']['entityid'];
         $idpEntityId = $state['Source']['entityid'];

--- a/modules/consent/lib/Consent/Store/Cookie.php
+++ b/modules/consent/lib/Consent/Store/Cookie.php
@@ -34,9 +34,9 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     public function hasConsent($userId, $destinationId, $attributeSet)
     {
-        assert('is_string($userId)');
-        assert('is_string($destinationId)');
-        assert('is_string($attributeSet)');
+        assert(is_string($userId));
+        assert(is_string($destinationId));
+        assert(is_string($attributeSet));
 
         $cookieName = self::_getCookieName($userId, $destinationId);
 
@@ -90,9 +90,9 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     public function saveConsent($userId, $destinationId, $attributeSet)
     {
-        assert('is_string($userId)');
-        assert('is_string($destinationId)');
-        assert('is_string($attributeSet)');
+        assert(is_string($userId));
+        assert(is_string($destinationId));
+        assert(is_string($attributeSet));
 
         $name = self::_getCookieName($userId, $destinationId);
         $value = $userId . ':' . $attributeSet . ':' . $destinationId;
@@ -116,8 +116,8 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     public function deleteConsent($userId, $destinationId)
     {
-        assert('is_string($userId)');
-        assert('is_string($destinationId)');
+        assert(is_string($userId));
+        assert(is_string($destinationId));
 
         $name = self::_getCookieName($userId, $destinationId);
         $this->_setConsentCookie($name, null);
@@ -136,7 +136,7 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     public function deleteAllConsents($userId)
     {
-        assert('is_string($userId)');
+        assert(is_string($userId));
 
         throw new Exception(
             'The cookie consent handler does not support delete of all consents...'
@@ -155,7 +155,7 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     public function getConsents($userId)
     {
-        assert('is_string($userId)');
+        assert(is_string($userId));
 
         $ret = array();
 
@@ -203,7 +203,7 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     private static function _sign($data)
     {
-        assert('is_string($data)');
+        assert(is_string($data));
 
         $secretSalt = SimpleSAML\Utils\Config::getSecretSalt();
 
@@ -222,7 +222,7 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     private static function _verify($signedData)
     {
-        assert('is_string($signedData)');
+        assert(is_string($signedData));
 
         $data = explode(':', $signedData, 2);
         if (count($data) !== 2) {
@@ -253,8 +253,8 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     private static function _getCookieName($userId, $destinationId)
     {
-        assert('is_string($userId)');
-        assert('is_string($destinationId)');
+        assert(is_string($userId));
+        assert(is_string($destinationId));
 
         return 'sspmod_consent:' . sha1($userId . ':' . $destinationId);
     }
@@ -270,8 +270,8 @@ class sspmod_consent_Consent_Store_Cookie extends sspmod_consent_Store
      */
     private function _setConsentCookie($name, $value)
     {
-        assert('is_string($name)');
-        assert('is_string($value) || is_null($value)');
+        assert(is_string($name));
+        assert(is_string($value) || $value === null);
 
         $globalConfig = SimpleSAML_Configuration::getInstance();
         $params = array(

--- a/modules/consent/lib/Consent/Store/Database.php
+++ b/modules/consent/lib/Consent/Store/Database.php
@@ -150,9 +150,9 @@ class sspmod_consent_Consent_Store_Database extends sspmod_consent_Store
      */
     public function hasConsent($userId, $destinationId, $attributeSet)
     {
-        assert('is_string($userId)');
-        assert('is_string($destinationId)');
-        assert('is_string($attributeSet)');
+        assert(is_string($userId));
+        assert(is_string($destinationId));
+        assert(is_string($attributeSet));
 
         $st = $this->_execute(
             'UPDATE ' . $this->_table . ' ' .
@@ -190,9 +190,9 @@ class sspmod_consent_Consent_Store_Database extends sspmod_consent_Store
      */
     public function saveConsent($userId, $destinationId, $attributeSet)
     {
-        assert('is_string($userId)');
-        assert('is_string($destinationId)');
-        assert('is_string($attributeSet)');
+        assert(is_string($userId));
+        assert(is_string($destinationId));
+        assert(is_string($attributeSet));
 
         // Check for old consent (with different attribute set)
         $st = $this->_execute(
@@ -238,8 +238,8 @@ class sspmod_consent_Consent_Store_Database extends sspmod_consent_Store
      */
     public function deleteConsent($userId, $destinationId)
     {
-        assert('is_string($userId)');
-        assert('is_string($destinationId)');
+        assert(is_string($userId));
+        assert(is_string($destinationId));
 
         $st = $this->_execute(
             'DELETE FROM ' . $this->_table . ' WHERE hashed_user_id = ? AND service_id = ?;',
@@ -270,7 +270,7 @@ class sspmod_consent_Consent_Store_Database extends sspmod_consent_Store
      */
     public function deleteAllConsents($userId)
     {
-        assert('is_string($userId)');
+        assert(is_string($userId));
 
         $st = $this->_execute(
             'DELETE FROM ' . $this->_table . ' WHERE hashed_user_id = ?',
@@ -301,7 +301,7 @@ class sspmod_consent_Consent_Store_Database extends sspmod_consent_Store
      */
     public function getConsents($userId)
     {
-        assert('is_string($userId)');
+        assert(is_string($userId));
 
         $ret = array();
 
@@ -336,8 +336,8 @@ class sspmod_consent_Consent_Store_Database extends sspmod_consent_Store
      */
     private function _execute($statement, $parameters)
     {
-        assert('is_string($statement)');
-        assert('is_array($parameters)');
+        assert(is_string($statement));
+        assert(is_array($parameters));
 
         $db = $this->_getDB();
         if ($db === false) {
@@ -487,8 +487,8 @@ class sspmod_consent_Consent_Store_Database extends sspmod_consent_Store
      */
     private static function _formatError($error)
     {
-        assert('is_array($error)');
-        assert('count($error) >= 3');
+        assert(is_array($error));
+        assert(count($error) >= 3);
 
         return $error[0] . ' - ' . $error[2] . ' (' . $error[1] . ')';
     }

--- a/modules/consent/lib/Store.php
+++ b/modules/consent/lib/Store.php
@@ -17,7 +17,7 @@ abstract class sspmod_consent_Store
      */
     protected function __construct(&$config)
     {
-        assert('is_array($config)');
+        assert(is_array($config));
     }
 
 

--- a/modules/consent/templates/consentform.php
+++ b/modules/consent/templates/consentform.php
@@ -14,15 +14,15 @@
  *
  * @package SimpleSAMLphp
  */
-assert('is_array($this->data["srcMetadata"])');
-assert('is_array($this->data["dstMetadata"])');
-assert('is_string($this->data["yesTarget"])');
-assert('is_array($this->data["yesData"])');
-assert('is_string($this->data["noTarget"])');
-assert('is_array($this->data["noData"])');
-assert('is_array($this->data["attributes"])');
-assert('is_array($this->data["hiddenAttributes"])');
-assert('$this->data["sppp"] === false || is_string($this->data["sppp"])');
+assert(is_array($this->data['srcMetadata']));
+assert(is_array($this->data['dstMetadata']));
+assert(is_string($this->data['yesTarget']));
+assert(is_array($this->data['yesData']));
+assert(is_string($this->data['noTarget']));
+assert(is_array($this->data['noData']));
+assert(is_array($this->data['attributes']));
+assert(is_array($this->data['hiddenAttributes']));
+assert($this->data['sppp'] === false || is_string($this->data['sppp']));
 
 // Parse parameters
 if (array_key_exists('name', $this->data['srcMetadata'])) {

--- a/modules/consent/www/logout.php
+++ b/modules/consent/www/logout.php
@@ -13,5 +13,5 @@ $state = SimpleSAML_Auth_State::loadState($_GET['StateId'], 'consent:request');
 $state['Responder'] = array('sspmod_consent_Logout', 'postLogout');
 
 $idp = SimpleSAML_IdP::getByState($state);
-$idp->handleLogoutRequest($state, NULL);
-assert('FALSE');
+$idp->handleLogoutRequest($state, null);
+assert(false);

--- a/modules/consentAdmin/hooks/hook_frontpage.php
+++ b/modules/consentAdmin/hooks/hook_frontpage.php
@@ -5,8 +5,8 @@
  * @param array &$links  The links on the frontpage, split into sections.
  */
 function consentAdmin_hook_frontpage(&$links) {
-	assert('is_array($links)');
-	assert('array_key_exists("links", $links)');
+	assert(is_array($links));
+	assert(array_key_exists('links', $links));
 
 	$links['config'][] = array(
 		'href' => SimpleSAML\Module::getModuleURL('consentAdmin/consentAdmin.php'),

--- a/modules/core/hooks/hook_frontpage.php
+++ b/modules/core/hooks/hook_frontpage.php
@@ -5,8 +5,8 @@
  * @param array &$links  The links on the frontpage, split into sections.
  */
 function core_hook_frontpage(&$links) {
-	assert('is_array($links)');
-	assert('array_key_exists("links", $links)');
+	assert(is_array($links));
+	assert(array_key_exists('links', $links));
 
 	$links['links']['frontpage_welcome'] = array(
 		'href' => SimpleSAML\Module::getModuleURL('core/frontpage_welcome.php'),

--- a/modules/core/hooks/hook_sanitycheck.php
+++ b/modules/core/hooks/hook_sanitycheck.php
@@ -5,9 +5,9 @@
  * @param array &$hookinfo  hookinfo
  */
 function core_hook_sanitycheck(&$hookinfo) {
-	assert('is_array($hookinfo)');
-	assert('array_key_exists("errors", $hookinfo)');
-	assert('array_key_exists("info", $hookinfo)');
+	assert(is_array($hookinfo));
+	assert(array_key_exists('errors', $hookinfo));
+	assert(array_key_exists('info', $hookinfo));
 
 	$config = SimpleSAML_Configuration::getInstance();
 	

--- a/modules/core/lib/ACL.php
+++ b/modules/core/lib/ACL.php
@@ -21,7 +21,7 @@ class sspmod_core_ACL {
 	 * @param array|string $acl  The access control list.
 	 */
 	public function __construct($acl) {
-		assert('is_string($acl) || is_array($acl)');
+		assert(is_string($acl) || is_array($acl));
 
 		if (is_string($acl)) {
 			$acl = self::getById($acl);
@@ -53,7 +53,7 @@ class sspmod_core_ACL {
 	 * @return array  The access control list array.
 	 */
 	private static function getById($id) {
-		assert('is_string($id)');
+		assert(is_string($id));
 
 		$config = SimpleSAML_Configuration::getOptionalConfig('acl.php');
 		if (!$config->hasValue($id)) {

--- a/modules/core/lib/Auth/Process/AttributeAdd.php
+++ b/modules/core/lib/Auth/Process/AttributeAdd.php
@@ -33,7 +33,7 @@ class sspmod_core_Auth_Process_AttributeAdd extends SimpleSAML_Auth_ProcessingFi
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		foreach($config as $name => $values) {
 			if(is_int($name)) {
@@ -68,8 +68,8 @@ class sspmod_core_Auth_Process_AttributeAdd extends SimpleSAML_Auth_ProcessingFi
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$attributes =& $request['Attributes'];
 

--- a/modules/core/lib/Auth/Process/AttributeAlter.php
+++ b/modules/core/lib/Auth/Process/AttributeAlter.php
@@ -49,7 +49,7 @@ class sspmod_core_Auth_Process_AttributeAlter extends SimpleSAML_Auth_Processing
     public function __construct($config, $reserved) {
         parent::__construct($config, $reserved);
 
-        assert('is_array($config)');
+        assert(is_array($config));
 
         // parse filter configuration
         foreach ($config as $name => $value) {
@@ -96,8 +96,8 @@ class sspmod_core_Auth_Process_AttributeAlter extends SimpleSAML_Auth_Processing
      * @throws SimpleSAML_Error_Exception In case of invalid configuration.
      */
     public function process(&$request) {
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
 
         // get attributes from request
         $attributes =& $request['Attributes'];

--- a/modules/core/lib/Auth/Process/AttributeCopy.php
+++ b/modules/core/lib/Auth/Process/AttributeCopy.php
@@ -32,7 +32,7 @@ class sspmod_core_Auth_Process_AttributeCopy extends SimpleSAML_Auth_ProcessingF
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		foreach($config as $source => $destination) {
 
@@ -55,8 +55,8 @@ class sspmod_core_Auth_Process_AttributeCopy extends SimpleSAML_Auth_ProcessingF
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$attributes =& $request['Attributes'];
 

--- a/modules/core/lib/Auth/Process/AttributeLimit.php
+++ b/modules/core/lib/Auth/Process/AttributeLimit.php
@@ -32,7 +32,7 @@ class sspmod_core_Auth_Process_AttributeLimit extends SimpleSAML_Auth_Processing
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		foreach ($config as $index => $value) {
 			if ($index === 'default') {
@@ -85,8 +85,8 @@ class sspmod_core_Auth_Process_AttributeLimit extends SimpleSAML_Auth_Processing
      * @throws SimpleSAML_Error_Exception If invalid configuration is found.
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		if ($this->isDefault) {
 			$allowedAttributes = self::getSPIdPAllowed($request);

--- a/modules/core/lib/Auth/Process/AttributeMap.php
+++ b/modules/core/lib/Auth/Process/AttributeMap.php
@@ -33,7 +33,7 @@ class sspmod_core_Auth_Process_AttributeMap extends SimpleSAML_Auth_ProcessingFi
     {
         parent::__construct($config, $reserved);
 
-        assert('is_array($config)');
+        assert(is_array($config));
         $mapFiles = array();
 
         foreach ($config as $origName => $newName) {
@@ -112,8 +112,8 @@ class sspmod_core_Auth_Process_AttributeMap extends SimpleSAML_Auth_ProcessingFi
      */
     public function process(&$request)
     {
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
 
         $attributes =& $request['Attributes'];
 

--- a/modules/core/lib/Auth/Process/AttributeRealm.php
+++ b/modules/core/lib/Auth/Process/AttributeRealm.php
@@ -20,7 +20,7 @@ class sspmod_core_Auth_Process_AttributeRealm extends SimpleSAML_Auth_Processing
      */
     public function __construct($config, $reserved) {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (array_key_exists('attributename', $config))
             $this->attributename = $config['attributename'];
@@ -35,8 +35,8 @@ class sspmod_core_Auth_Process_AttributeRealm extends SimpleSAML_Auth_Processing
      * @param array &$request  The current request
      */
     public function process(&$request) {
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
 
         $attributes =& $request['Attributes'];
 

--- a/modules/core/lib/Auth/Process/AttributeValueMap.php
+++ b/modules/core/lib/Auth/Process/AttributeValueMap.php
@@ -47,7 +47,7 @@ class AttributeValueMap extends \SimpleSAML_Auth_ProcessingFilter
     {
         parent::__construct($config, $reserved);
 
-        assert('is_array($config)');
+        assert(is_array($config));
 
         // parse configuration
         foreach ($config as $name => $value) {
@@ -104,8 +104,8 @@ class AttributeValueMap extends \SimpleSAML_Auth_ProcessingFilter
     {
         \SimpleSAML\Logger::debug('Processing the AttributeValueMap filter.');
 
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
         $attributes =& $request['Attributes'];
 
         if (!array_key_exists($this->sourceattribute, $attributes)) {

--- a/modules/core/lib/Auth/Process/ExtendIdPSession.php
+++ b/modules/core/lib/Auth/Process/ExtendIdPSession.php
@@ -6,7 +6,7 @@
 class sspmod_core_Auth_Process_ExtendIdPSession extends SimpleSAML_Auth_ProcessingFilter {
 
 	public function process(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		if (empty($state['Expire']) || empty($state['Authority'])) {
 			return;

--- a/modules/core/lib/Auth/Process/GenerateGroups.php
+++ b/modules/core/lib/Auth/Process/GenerateGroups.php
@@ -24,7 +24,7 @@ class sspmod_core_Auth_Process_GenerateGroups extends SimpleSAML_Auth_Processing
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (count($config) === 0) {
 			// Use default groups
@@ -54,8 +54,8 @@ class sspmod_core_Auth_Process_GenerateGroups extends SimpleSAML_Auth_Processing
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$groups = array();
 		$attributes =& $request['Attributes'];
@@ -99,7 +99,7 @@ class sspmod_core_Auth_Process_GenerateGroups extends SimpleSAML_Auth_Processing
 	 * @return string|NULL  The realm of the user, or NULL if we are unable to determine the realm.
 	 */
 	private static function getRealm($attributes) {
-		assert('is_array($attributes)');
+		assert(is_array($attributes));
 
 		if (!array_key_exists('eduPersonPrincipalName', $attributes)) {
 			return NULL;
@@ -132,7 +132,7 @@ class sspmod_core_Auth_Process_GenerateGroups extends SimpleSAML_Auth_Processing
 	 * @return string  The escaped string.
 	 */
 	private static function escapeIllegalChars($string) {
-		assert('is_string($string)');
+		assert(is_string($string));
 
 		return preg_replace_callback('/([^a-zA-Z0-9_@=.])/',
 			function ($m) { return sprintf("%%%02x", ord($m[1])); },

--- a/modules/core/lib/Auth/Process/LanguageAdaptor.php
+++ b/modules/core/lib/Auth/Process/LanguageAdaptor.php
@@ -19,7 +19,7 @@ class sspmod_core_Auth_Process_LanguageAdaptor extends SimpleSAML_Auth_Processin
 	 */
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (array_key_exists('attributename', $config)) {
 			$this->langattr = $config['attributename'];
@@ -35,8 +35,8 @@ class sspmod_core_Auth_Process_LanguageAdaptor extends SimpleSAML_Auth_Processin
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$attributes =& $request['Attributes'];
 

--- a/modules/core/lib/Auth/Process/PHP.php
+++ b/modules/core/lib/Auth/Process/PHP.php
@@ -29,7 +29,7 @@ class sspmod_core_Auth_Process_PHP extends SimpleSAML_Auth_ProcessingFilter
     {
         parent::__construct($config, $reserved);
 
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (!isset($config['code'])) {
             throw new SimpleSAML_Error_Exception("core:PHP: missing mandatory configuration option 'code'.");
@@ -45,8 +45,8 @@ class sspmod_core_Auth_Process_PHP extends SimpleSAML_Auth_ProcessingFilter
      */
     public function process(&$request)
     {
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
 
         $function = create_function('&$attributes', $this->code);
         $function($request['Attributes']);

--- a/modules/core/lib/Auth/Process/ScopeAttribute.php
+++ b/modules/core/lib/Auth/Process/ScopeAttribute.php
@@ -46,7 +46,7 @@ class sspmod_core_Auth_Process_ScopeAttribute extends SimpleSAML_Auth_Processing
 	 */
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		$config = SimpleSAML_Configuration::loadFromArray($config, 'ScopeAttribute');
 
@@ -63,8 +63,8 @@ class sspmod_core_Auth_Process_ScopeAttribute extends SimpleSAML_Auth_Processing
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$attributes =& $request['Attributes'];
 

--- a/modules/core/lib/Auth/Process/ScopeFromAttribute.php
+++ b/modules/core/lib/Auth/Process/ScopeFromAttribute.php
@@ -38,7 +38,7 @@ class sspmod_core_Auth_Process_ScopeFromAttribute extends SimpleSAML_Auth_Proces
 	 */
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		$config = SimpleSAML_Configuration::loadFromArray($config, 'ScopeFromAttribute');
 		$this->targetAttribute = $config->getString('targetAttribute');
@@ -52,8 +52,8 @@ class sspmod_core_Auth_Process_ScopeFromAttribute extends SimpleSAML_Auth_Proces
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$attributes =& $request['Attributes'];
 

--- a/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
+++ b/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
@@ -26,7 +26,7 @@ class sspmod_core_Auth_Process_StatisticsWithAttribute extends SimpleSAML_Auth_P
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (array_key_exists('attributename', $config)) {
 			$this->attribute = $config['attributename'];
@@ -50,8 +50,8 @@ class sspmod_core_Auth_Process_StatisticsWithAttribute extends SimpleSAML_Auth_P
 	 * @param array &$state  The current state.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("Attributes", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('Attributes', $state));
 
 		$logAttribute = 'NA';
 		$source = 'NA';

--- a/modules/core/lib/Auth/Process/TargetedID.php
+++ b/modules/core/lib/Auth/Process/TargetedID.php
@@ -55,7 +55,7 @@ class sspmod_core_Auth_Process_TargetedID extends SimpleSAML_Auth_ProcessingFilt
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (array_key_exists('attributename', $config)) {
 			$this->attribute = $config['attributename'];
@@ -79,8 +79,8 @@ class sspmod_core_Auth_Process_TargetedID extends SimpleSAML_Auth_ProcessingFilt
 	 * @param array &$state  The current state.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("Attributes", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('Attributes', $state));
 
 		if ($this->attribute === NULL) {
 			if (!array_key_exists('UserID', $state)) {
@@ -152,7 +152,7 @@ class sspmod_core_Auth_Process_TargetedID extends SimpleSAML_Auth_ProcessingFilt
 	 * @return string  The unique identifier for the entity.
 	 */
 	private static function getEntityId($metadata) {
-		assert('is_array($metadata)');
+		assert(is_array($metadata));
 
 		$id = '';
 

--- a/modules/core/lib/Auth/Process/WarnShortSSOInterval.php
+++ b/modules/core/lib/Auth/Process/WarnShortSSOInterval.php
@@ -16,7 +16,7 @@ class sspmod_core_Auth_Process_WarnShortSSOInterval extends SimpleSAML_Auth_Proc
 	 * @param array $state  The state of the response.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		if (!array_key_exists('PreviousSSOTimestamp', $state)) {
 			/*

--- a/modules/core/lib/Auth/Source/AdminPassword.php
+++ b/modules/core/lib/Auth/Source/AdminPassword.php
@@ -16,8 +16,8 @@ class sspmod_core_Auth_Source_AdminPassword extends sspmod_core_Auth_UserPassBas
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -40,8 +40,8 @@ class sspmod_core_Auth_Source_AdminPassword extends sspmod_core_Auth_UserPassBas
 	 * @return array  Associative array with the users attributes.
 	 */
 	protected function login($username, $password) {
-		assert('is_string($username)');
-		assert('is_string($password)');
+		assert(is_string($username));
+		assert(is_string($password));
 
 		$config = SimpleSAML_Configuration::getInstance();
 		$adminPassword = $config->getString('auth.adminpassword', '123');

--- a/modules/core/lib/Auth/UserPassBase.php
+++ b/modules/core/lib/Auth/UserPassBase.php
@@ -82,8 +82,8 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 	 * @param array &$config  Configuration for this authentication source.
 	 */
 	public function __construct($info, &$config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 		
 		if (isset($config['core:loginpage_links'])) {
 			$this->loginLinks = $config['core:loginpage_links'];
@@ -115,7 +115,7 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 	 * @param string|NULL $forcedUsername  The forced username.
 	 */
 	public function setForcedUsername($forcedUsername) {
-		assert('is_string($forcedUsername) || is_null($forcedUsername)');
+		assert(is_string($forcedUsername) || $forcedUsername === null);
 		$this->forcedUsername = $forcedUsername;
 	}
 
@@ -167,7 +167,7 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		/*
 		 * Save the identifier of this authentication source, so that we can
@@ -197,7 +197,7 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 		\SimpleSAML\Utils\HTTP::redirectTrustedURL($url, $params);
 
 		/* The previous function never returns, so this code is never executed. */
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -229,15 +229,15 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 	 * @param string $password  The password the user wrote.
 	 */
 	public static function handleLogin($authStateId, $username, $password) {
-		assert('is_string($authStateId)');
-		assert('is_string($username)');
-		assert('is_string($password)');
+		assert(is_string($authStateId));
+		assert(is_string($username));
+		assert(is_string($password));
 
 		/* Here we retrieve the state array we saved in the authenticate-function. */
 		$state = SimpleSAML_Auth_State::loadState($authStateId, self::STAGEID);
 
 		/* Retrieve the authentication source we are executing. */
-		assert('array_key_exists(self::AUTHID, $state)');
+		assert(array_key_exists(self::AUTHID, $state));
 		$source = SimpleSAML_Auth_Source::getById($state[self::AUTHID]);
 		if ($source === NULL) {
 			throw new Exception('Could not find authentication source with id ' . $state[self::AUTHID]);
@@ -259,7 +259,7 @@ abstract class sspmod_core_Auth_UserPassBase extends SimpleSAML_Auth_Source {
 		SimpleSAML\Logger::stats('User \''.$username.'\' successfully authenticated from '.$_SERVER['REMOTE_ADDR']);
 
 		/* Save the attributes we received from the login-function in the $state-array. */
-		assert('is_array($attributes)');
+		assert(is_array($attributes));
 		$state['Attributes'] = $attributes;
 
 		/* Return control to SimpleSAMLphp after successful authentication. */

--- a/modules/core/lib/Auth/UserPassOrgBase.php
+++ b/modules/core/lib/Auth/UserPassOrgBase.php
@@ -68,8 +68,8 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 * @param array &$config  Configuration for this authentication source.
 	 */
 	public function __construct($info, &$config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -101,7 +101,7 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 * @param string $usernameOrgMethod  The method which should be used.
 	 */
 	protected function setUsernameOrgMethod($usernameOrgMethod) {
-		assert('in_array($usernameOrgMethod, array("none", "allow", "force"), TRUE)');
+		assert(in_array($usernameOrgMethod, array('none', 'allow', 'force'), true));
 
 		$this->usernameOrgMethod = $usernameOrgMethod;
 	}
@@ -147,7 +147,7 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		// We are going to need the authId in order to retrieve this authentication source later
 		$state[self::AUTHID] = $this->authId;
@@ -203,16 +203,16 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 * @param string $organization  The id of the organization the user chose.
 	 */
 	public static function handleLogin($authStateId, $username, $password, $organization) {
-		assert('is_string($authStateId)');
-		assert('is_string($username)');
-		assert('is_string($password)');
-		assert('is_string($organization)');
+		assert(is_string($authStateId));
+		assert(is_string($username));
+		assert(is_string($password));
+		assert(is_string($organization));
 
 		/* Retrieve the authentication state. */
 		$state = SimpleSAML_Auth_State::loadState($authStateId, self::STAGEID);
 
 		/* Find authentication source. */
-		assert('array_key_exists(self::AUTHID, $state)');
+		assert(array_key_exists(self::AUTHID, $state));
 		$source = SimpleSAML_Auth_Source::getById($state[self::AUTHID]);
 		if ($source === NULL) {
 			throw new Exception('Could not find authentication source with id ' . $state[self::AUTHID]);
@@ -254,13 +254,13 @@ abstract class sspmod_core_Auth_UserPassOrgBase extends SimpleSAML_Auth_Source {
 	 *         organization as part of the username.
 	 */
 	public static function listOrganizations($authStateId) {
-		assert('is_string($authStateId)');
+		assert(is_string($authStateId));
 
 		/* Retrieve the authentication state. */
 		$state = SimpleSAML_Auth_State::loadState($authStateId, self::STAGEID);
 
 		/* Find authentication source. */
-		assert('array_key_exists(self::AUTHID, $state)');
+		assert(array_key_exists(self::AUTHID, $state));
 		$source = SimpleSAML_Auth_Source::getById($state[self::AUTHID]);
 		if ($source === NULL) {
 			throw new Exception('Could not find authentication source with id ' . $state[self::AUTHID]);

--- a/modules/core/lib/Stats/Output/File.php
+++ b/modules/core/lib/Stats/Output/File.php
@@ -51,7 +51,7 @@ class sspmod_core_Stats_Output_File extends SimpleSAML_Stats_Output {
 	 * @param string $date  The date for the log file.
 	 */
 	private function openLog($date) {
-		assert('is_string($date)');
+		assert(is_string($date));
 
 		if ($this->file !== NULL && $this->file !== FALSE) {
 			fclose($this->file);
@@ -77,7 +77,7 @@ class sspmod_core_Stats_Output_File extends SimpleSAML_Stats_Output {
 	 * @param array $data  The event.
 	 */
 	public function emit(array $data) {
-		assert('isset($data["time"])');
+		assert(isset($data['time']));
 
 		$time = $data['time'];
 		$milliseconds = (int)(($time - (int)$time) * 1000);

--- a/modules/core/templates/logout-iframe-wrapper.php
+++ b/modules/core/templates/logout-iframe-wrapper.php
@@ -19,7 +19,7 @@ foreach ($SPs as $assocId => $sp) {
     if ($sp['core:Logout-IFrame:State'] !== 'inprogress') {
         continue;
     }
-    assert('isset($sp["core:Logout-IFrame:URL"])');
+    assert(isset($sp['core:Logout-IFrame:URL']));
 
     $url = $sp["core:Logout-IFrame:URL"];
 

--- a/modules/core/templates/logout-iframe.php
+++ b/modules/core/templates/logout-iframe.php
@@ -26,7 +26,7 @@ $spTimeout = array();
 $nFailed = 0;
 $nProgress = 0;
 foreach ($SPs as $assocId => $sp) {
-    assert('isset($sp["core:Logout-IFrame:State"])');
+    assert(isset($sp['core:Logout-IFrame:State']));
     $state = $sp['core:Logout-IFrame:State'];
     $spStatus[sha1($assocId)] = $state;
     if (isset($sp['core:Logout-IFrame:Timeout'])) {
@@ -101,7 +101,7 @@ foreach ($SPs as $assocId => $sp) {
         $spName = $assocId;
     }
 
-    assert('isset($sp["core:Logout-IFrame:State"])');
+    assert(isset($sp['core:Logout-IFrame:State']));
     $spState = $sp['core:Logout-IFrame:State'];
 
     $spId = sha1($assocId);
@@ -178,7 +178,7 @@ if ($type === 'init') {
             if ($sp['core:Logout-IFrame:State'] !== 'inprogress') {
                 continue;
             }
-            assert('isset($sp["core:Logout-IFrame:URL"])');
+            assert(isset($sp['core:Logout-IFrame:URL']));
             echo '<iframe style="width:0; height:0; border:0;" src="'.
                  htmlspecialchars($sp['core:Logout-IFrame:URL']).'"></iframe>';
         }

--- a/modules/core/templates/no_cookie.tpl.php
+++ b/modules/core/templates/no_cookie.tpl.php
@@ -1,6 +1,6 @@
 <?php
 
-assert('array_key_exists("retryURL", $this->data)');
+assert(array_key_exists('retryURL', $this->data));
 $retryURL = $this->data['retryURL'];
 
 $header = htmlspecialchars($this->t('{core:no_cookie:header}'));

--- a/modules/core/www/authenticate.php
+++ b/modules/core/www/authenticate.php
@@ -21,7 +21,7 @@ if (array_key_exists(SimpleSAML_Auth_State::EXCEPTION_PARAM, $_REQUEST)) {
     // This is just a simple example of an error
 
     $state = SimpleSAML_Auth_State::loadExceptionState();
-    assert('array_key_exists(SimpleSAML_Auth_State::EXCEPTION_DATA, $state)');
+    assert(array_key_exists(SimpleSAML_Auth_State::EXCEPTION_DATA, $state));
     $e = $state[SimpleSAML_Auth_State::EXCEPTION_DATA];
 
     throw $e;

--- a/modules/core/www/postredirect.php
+++ b/modules/core/www/postredirect.php
@@ -40,9 +40,9 @@ if ($postData === NULL) {
 
 $session->deleteData('core_postdatalink', $postId);
 
-assert('is_array($postData)');
-assert('array_key_exists("url", $postData)');
-assert('array_key_exists("post", $postData)');
+assert(is_array($postData));
+assert(array_key_exists('url', $postData));
+assert(array_key_exists('post', $postData));
 
 $config = SimpleSAML_Configuration::getInstance();
 $template = new SimpleSAML_XHTML_Template($config, 'post.php');

--- a/modules/cron/hooks/hook_cron.php
+++ b/modules/cron/hooks/hook_cron.php
@@ -5,9 +5,9 @@
  * @param array &$croninfo  Output
  */
 function cron_hook_cron(&$croninfo) {
-	assert('is_array($croninfo)');
-	assert('array_key_exists("summary", $croninfo)');
-	assert('array_key_exists("tag", $croninfo)');
+	assert(is_array($croninfo));
+	assert(array_key_exists('summary', $croninfo));
+	assert(array_key_exists('tag', $croninfo));
 
 	$cronconfig = SimpleSAML_Configuration::getConfig('module_cron.php');
 	

--- a/modules/cron/hooks/hook_frontpage.php
+++ b/modules/cron/hooks/hook_frontpage.php
@@ -5,8 +5,8 @@
  * @param array &$links  The links on the frontpage, split into sections.
  */
 function cron_hook_frontpage(&$links) {
-	assert('is_array($links)');
-	assert('array_key_exists("links", $links)');
+	assert(is_array($links));
+	assert(array_key_exists('links', $links));
 
 	$links['config'][] = array(
 		'href' => SimpleSAML\Module::getModuleURL('cron/croninfo.php'),

--- a/modules/discopower/lib/PowerIdPDisco.php
+++ b/modules/discopower/lib/PowerIdPDisco.php
@@ -319,7 +319,7 @@ class sspmod_discopower_PowerIdPDisco extends SimpleSAML_XHTML_IdPDisco
      */
     protected function setPreviousIdP($idp)
     {
-        assert('is_string($idp)');
+        assert(is_string($idp));
 
         if ($this->cdcDomain === null) {
             parent::setPreviousIdP($idp);

--- a/modules/discopower/templates/disco.tpl.php
+++ b/modules/discopower/templates/disco.tpl.php
@@ -70,7 +70,7 @@ function showEntry($t, $metadata, $favourite = FALSE) {
 function getTranslatedName($t, $metadata) {
 	if (isset($metadata['UIInfo']['DisplayName'])) {
 		$displayName = $metadata['UIInfo']['DisplayName'];
-		assert('is_array($displayName)'); // Should always be an array of language code -> translation
+		assert(is_array($displayName)); // Should always be an array of language code -> translation
 		if (!empty($displayName)) {
 			return $t->getTranslator()->getPreferredTranslation($displayName);
 		}

--- a/modules/exampleauth/lib/Auth/Process/RedirectTest.php
+++ b/modules/exampleauth/lib/Auth/Process/RedirectTest.php
@@ -13,8 +13,8 @@ class sspmod_exampleauth_Auth_Process_RedirectTest extends SimpleSAML_Auth_Proce
 	 * @param array &$state  The state we should update.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("Attributes", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('Attributes', $state));
 
 		// To check whether the state is saved correctly
 		$state['Attributes']['RedirectTest1'] = array('OK');

--- a/modules/exampleauth/lib/Auth/Source/External.php
+++ b/modules/exampleauth/lib/Auth/Source/External.php
@@ -29,8 +29,8 @@ class sspmod_exampleauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -90,7 +90,7 @@ class sspmod_exampleauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		$attributes = $this->getUser();
 		if ($attributes !== NULL) {
@@ -162,7 +162,7 @@ class sspmod_exampleauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 		/*
 		 * The redirect function never returns, so we never get this far.
 		 */
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -240,7 +240,7 @@ class sspmod_exampleauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 		/*
 		 * The completeAuth-function never returns, so we never get this far.
 		 */
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -251,7 +251,7 @@ class sspmod_exampleauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array &$state  The logout state array.
 	 */
 	public function logout(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		if (!session_id()) {
 			/* session_start not called before. Do it here. */

--- a/modules/exampleauth/lib/Auth/Source/Static.php
+++ b/modules/exampleauth/lib/Auth/Source/Static.php
@@ -25,8 +25,8 @@ class sspmod_exampleauth_Auth_Source_Static extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -49,7 +49,7 @@ class sspmod_exampleauth_Auth_Source_Static extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		$state['Attributes'] = $this->attributes;
 	}

--- a/modules/exampleauth/lib/Auth/Source/UserPass.php
+++ b/modules/exampleauth/lib/Auth/Source/UserPass.php
@@ -26,8 +26,8 @@ class sspmod_exampleauth_Auth_Source_UserPass extends sspmod_core_Auth_UserPassB
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -76,8 +76,8 @@ class sspmod_exampleauth_Auth_Source_UserPass extends sspmod_core_Auth_UserPassB
 	 * @return array  Associative array with the users attributes.
 	 */
 	protected function login($username, $password) {
-		assert('is_string($username)');
-		assert('is_string($password)');
+		assert(is_string($username));
+		assert(is_string($password));
 
 		$userpass = $username . ':' . $password;
 		if (!array_key_exists($userpass, $this->users)) {

--- a/modules/expirycheck/lib/Auth/Process/ExpiryDate.php
+++ b/modules/expirycheck/lib/Auth/Process/ExpiryDate.php
@@ -37,7 +37,7 @@ class sspmod_expirycheck_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Process
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (array_key_exists('warndaysbefore', $config)) {
 			$this->warndaysbefore = $config['warndaysbefore'];
@@ -120,7 +120,7 @@ class sspmod_expirycheck_Auth_Process_ExpiryDate extends SimpleSAML_Auth_Process
 		$expireOnDate = strtotime($state['Attributes'][$this->expirydate_attr][0]);
 
 		if (self::shWarning($state, $expireOnDate, $this->warndaysbefore)) {
-			assert('is_array($state)');
+			assert(is_array($state));
 			if (isset($state['isPassive']) && $state['isPassive'] === TRUE) {
 				// We have a passive request. Skip the warning.
 				return;

--- a/modules/ldap/lib/Auth/Process/AttributeAddFromLDAP.php
+++ b/modules/ldap/lib/Auth/Process/AttributeAddFromLDAP.php
@@ -137,8 +137,8 @@ class sspmod_ldap_Auth_Process_AttributeAddFromLDAP extends sspmod_ldap_Auth_Pro
      */
     public function process(&$request)
     {
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
 
         $attributes =& $request['Attributes'];
 

--- a/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
+++ b/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
@@ -21,8 +21,8 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
      */
     public function process(&$request)
     {
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
 
         // Log the process
         SimpleSAML\Logger::debug(
@@ -183,7 +183,7 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
      */
     protected function search($memberof)
     {
-        assert('is_array($memberof)');
+        assert(is_array($memberof));
 
         // Used to determine what DN's have already been searched
         static $searched = array();
@@ -248,7 +248,7 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
      */
     protected function searchActiveDirectory($dn)
     {
-        assert('is_string($dn) && $dn != ""');
+        assert(is_string($dn) && $dn != '');
 
         // Shorten the variable name
         $map =& $this->attribute_map;

--- a/modules/ldap/lib/Auth/Source/LDAP.php
+++ b/modules/ldap/lib/Auth/Source/LDAP.php
@@ -27,8 +27,8 @@ class sspmod_ldap_Auth_Source_LDAP extends sspmod_core_Auth_UserPassBase
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -48,8 +48,8 @@ class sspmod_ldap_Auth_Source_LDAP extends sspmod_core_Auth_UserPassBase
      */
     protected function login($username, $password, array $sasl_args = null)
     {
-        assert('is_string($username)');
-        assert('is_string($password)');
+        assert(is_string($username));
+        assert(is_string($password));
 
         return $this->ldapConfig->login($username, $password, $sasl_args);
     }

--- a/modules/ldap/lib/Auth/Source/LDAPMulti.php
+++ b/modules/ldap/lib/Auth/Source/LDAPMulti.php
@@ -37,8 +37,8 @@ class sspmod_ldap_Auth_Source_LDAPMulti extends sspmod_core_Auth_UserPassOrgBase
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -92,9 +92,9 @@ class sspmod_ldap_Auth_Source_LDAPMulti extends sspmod_core_Auth_UserPassOrgBase
      */
     protected function login($username, $password, $org, array $sasl_args = null)
     {
-        assert('is_string($username)');
-        assert('is_string($password)');
-        assert('is_string($org)');
+        assert(is_string($username));
+        assert(is_string($password));
+        assert(is_string($org));
 
         if (!array_key_exists($org, $this->ldapOrgs)) {
             // The user has selected an organization which doesn't exist anymore.

--- a/modules/ldap/lib/ConfigHelper.php
+++ b/modules/ldap/lib/ConfigHelper.php
@@ -129,8 +129,8 @@ class sspmod_ldap_ConfigHelper
      */
     public function __construct($config, $location)
     {
-        assert('is_array($config)');
-        assert('is_string($location)');
+        assert(is_array($config));
+        assert(is_string($location));
 
         $this->location = $location;
 
@@ -183,8 +183,8 @@ class sspmod_ldap_ConfigHelper
      */
     public function login($username, $password, array $sasl_args = null)
     {
-        assert('is_string($username)');
-        assert('is_string($password)');
+        assert(is_string($username));
+        assert(is_string($password));
 
         if (empty($password)) {
             SimpleSAML\Logger::info($this->location . ': Login with empty password disallowed.');

--- a/modules/memcacheMonitor/hooks/hook_frontpage.php
+++ b/modules/memcacheMonitor/hooks/hook_frontpage.php
@@ -5,8 +5,8 @@
  * @param array &$links  The links on the frontpage, split into sections.
  */
 function memcacheMonitor_hook_frontpage(&$links) {
-	assert('is_array($links)');
-	assert('array_key_exists("links", $links)');
+	assert(is_array($links));
+	assert(array_key_exists('links', $links));
 
 	$links['config'][] = array(
 		'href' => SimpleSAML\Module::getModuleURL('memcacheMonitor/memcachestat.php'),

--- a/modules/memcacheMonitor/hooks/hook_sanitycheck.php
+++ b/modules/memcacheMonitor/hooks/hook_sanitycheck.php
@@ -8,9 +8,9 @@
  * @param array &$hookinfo  hookinfo
  */
 function memcacheMonitor_hook_sanitycheck(&$hookinfo) {
-	assert('is_array($hookinfo)');
-	assert('array_key_exists("errors", $hookinfo)');
-	assert('array_key_exists("info", $hookinfo)');
+	assert(is_array($hookinfo));
+	assert(array_key_exists('errors', $hookinfo));
+	assert(array_key_exists('info', $hookinfo));
 
 	try {
 		$servers = SimpleSAML_Memcache::getRawStats();

--- a/modules/metarefresh/hooks/hook_cron.php
+++ b/modules/metarefresh/hooks/hook_cron.php
@@ -5,9 +5,9 @@
  * @param array &$croninfo  Output
  */
 function metarefresh_hook_cron(&$croninfo) {
-	assert('is_array($croninfo)');
-	assert('array_key_exists("summary", $croninfo)');
-	assert('array_key_exists("tag", $croninfo)');
+	assert(is_array($croninfo));
+	assert(array_key_exists('summary', $croninfo));
+	assert(array_key_exists('tag', $croninfo));
 
 	SimpleSAML\Logger::info('cron [metarefresh]: Running cron in cron tag [' . $croninfo['tag'] . '] ');
 

--- a/modules/metarefresh/hooks/hook_frontpage.php
+++ b/modules/metarefresh/hooks/hook_frontpage.php
@@ -5,8 +5,8 @@
  * @param array &$links  The links on the frontpage, split into sections.
  */
 function metarefresh_hook_frontpage(&$links) {
-	assert('is_array($links)');
-	assert('array_key_exists("links", $links)');
+	assert(is_array($links));
+	assert(array_key_exists('links', $links));
 
 	$links['federation'][] = array(
 		'href' => SimpleSAML\Module::getModuleURL('metarefresh/fetch.php'),

--- a/modules/metarefresh/lib/MetaLoader.php
+++ b/modules/metarefresh/lib/MetaLoader.php
@@ -359,7 +359,7 @@ class sspmod_metarefresh_MetaLoader {
 	 */
 	function writeARPfile($config) {
 		
-		assert('is_a($config, \'SimpleSAML_Configuration\')');
+		assert($config instanceof SimpleSAML_Configuration);
 		
 		$arpfile = $config->getValue('arpfile');
 		$types = array('saml20-sp-remote');
@@ -440,7 +440,7 @@ class sspmod_metarefresh_MetaLoader {
 	 * @param string $outputDir  The directory we should save the metadata to.
 	 */
 	public function writeMetadataSerialize($outputDir) {
-		assert('is_string($outputDir)');
+		assert(is_string($outputDir));
 
 		$metaHandler = new SimpleSAML_Metadata_MetaDataStorageHandlerSerialize(array('directory' => $outputDir));
 

--- a/modules/metarefresh/lib/MetaLoader.php
+++ b/modules/metarefresh/lib/MetaLoader.php
@@ -357,7 +357,7 @@ class sspmod_metarefresh_MetaLoader {
 	/**
 	 * This function writes the metadata to an ARP file
 	 */
-	function writeARPfile($config) {
+	public function writeARPfile($config) {
 		
 		assert($config instanceof SimpleSAML_Configuration);
 		
@@ -389,7 +389,7 @@ class sspmod_metarefresh_MetaLoader {
 	/**
 	 * This function writes the metadata to to separate files in the output directory.
 	 */
-	function writeMetadataFiles($outputDir) {
+	public function writeMetadataFiles($outputDir) {
 	
 		while(strlen($outputDir) > 0 && $outputDir[strlen($outputDir) - 1] === '/') {
 			$outputDir = substr($outputDir, 0, strlen($outputDir) - 1);

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -42,8 +42,8 @@ class sspmod_multiauth_Auth_Source_MultiAuth extends SimpleSAML_Auth_Source {
 	 * @param array $config	 Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -102,7 +102,7 @@ class sspmod_multiauth_Auth_Source_MultiAuth extends SimpleSAML_Auth_Source {
 	 * @param array &$state	 Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		$state[self::AUTHID] = $this->authId;
 		$state[self::SOURCESID] = $this->sources;
@@ -124,7 +124,7 @@ class sspmod_multiauth_Auth_Source_MultiAuth extends SimpleSAML_Auth_Source {
 
 		/* The previous function never returns, so this code is never
 		executed */
-		assert('FALSE');
+		assert(false);
 	}
 
 	/**
@@ -139,8 +139,8 @@ class sspmod_multiauth_Auth_Source_MultiAuth extends SimpleSAML_Auth_Source {
 	 * @param array	 $state	 Information about the current authentication.
 	 */
 	public static function delegateAuthentication($authId, $state) {
-		assert('is_string($authId)');
-		assert('is_array($state)');
+		assert(is_string($authId));
+		assert(is_array($state));
 
 		$as = SimpleSAML_Auth_Source::getById($authId);
 		$valid_sources = array_map(
@@ -177,7 +177,7 @@ class sspmod_multiauth_Auth_Source_MultiAuth extends SimpleSAML_Auth_Source {
 	 * @param array &$state	 Information about the current logout operation.
 	 */
 	public function logout(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		/* Get the source that was used to authenticate */
 		$session = SimpleSAML_Session::getSessionFromRequest();
@@ -200,7 +200,7 @@ class sspmod_multiauth_Auth_Source_MultiAuth extends SimpleSAML_Auth_Source {
 	* @param string $source Name of the authentication source the user selected.
 	*/
 	public function setPreviousSource($source) {
-		assert('is_string($source)');
+		assert(is_string($source));
 
 		$cookieName = 'multiauth_source_' . $this->authId;
 

--- a/modules/negotiate/lib/Auth/Source/Negotiate.php
+++ b/modules/negotiate/lib/Auth/Source/Negotiate.php
@@ -40,8 +40,8 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         if (!extension_loaded('krb5')) {
             throw new Exception('KRB5 Extension not installed');
@@ -82,7 +82,7 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
      */
     public function authenticate(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         // set the default backend to config
         $state['LogoutState'] = array(
@@ -107,13 +107,13 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
             SimpleSAML\Logger::debug('Negotiate - session disabled. falling back');
             $this->fallBack($state);
             // never executed
-            assert('FALSE');
+            assert(false);
         }
         $mask = $this->checkMask();
         if (!$mask) {
             $this->fallBack($state);
             // never executed
-            assert('FALSE');
+            assert(false);
         }
 
         SimpleSAML\Logger::debug('Negotiate - authenticate(): looking for Negotiate');
@@ -160,10 +160,10 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
                     SimpleSAML\Logger::info('Negotiate - authenticate(): '.$user.' authorized.');
                     SimpleSAML_Auth_Source::completeAuth($state);
                     // Never reached.
-                    assert('FALSE');
+                    assert(false);
                 }
             } else {
-                // Some error in the recieved ticket. Expired?
+                // Some error in the received ticket. Expired?
                 SimpleSAML\Logger::info('Negotiate - authenticate(): Kerberos authN failed. Skipping.');
             }
         } else {
@@ -182,7 +182,7 @@ class sspmod_negotiate_Auth_Source_Negotiate extends SimpleSAML_Auth_Source
         $this->fallBack($state);
         /* The previous function never returns, so this code is never
            executed */
-        assert('FALSE');
+        assert(false);
     }
 
 
@@ -348,7 +348,7 @@ EOF;
      */
     public function logout(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
         // get the source that was used to authenticate
         $authId = $state['negotiate:backend'];
         SimpleSAML\Logger::debug('Negotiate - logout has the following authId: "'.$authId.'"');

--- a/modules/negotiate/www/retry.php
+++ b/modules/negotiate/www/retry.php
@@ -23,8 +23,8 @@ if (isset($idpmeta['auth'])) {
 	$session->setData('negotiate:disable', 'session', FALSE, 24*60*60);
 	SimpleSAML\Logger::debug('Negotiate(retry) - session enabled, retrying.');
 	$source->authenticate($state);
-	assert('FALSE');
+	assert(false);
 } else {
 	SimpleSAML\Logger::error('Negotiate - retry - no "auth" parameter found in IdP metadata.');
-	assert('FALSE');
+	assert(false);
 }

--- a/modules/oauth/hooks/hook_cron.php
+++ b/modules/oauth/hooks/hook_cron.php
@@ -5,9 +5,9 @@
  * @param array &$croninfo  Output
  */
 function oauth_hook_cron(&$croninfo) {
-	assert('is_array($croninfo)');
-	assert('array_key_exists("summary", $croninfo)');
-	assert('array_key_exists("tag", $croninfo)');
+	assert(is_array($croninfo));
+	assert(array_key_exists('summary', $croninfo));
+	assert(array_key_exists('tag', $croninfo));
 
 	$oauthconfig = SimpleSAML_Configuration::getOptionalConfig('module_statistics.php');
 	

--- a/modules/oauth/hooks/hook_frontpage.php
+++ b/modules/oauth/hooks/hook_frontpage.php
@@ -5,8 +5,8 @@
  * @param array &$links  The links on the frontpage, split into sections.
  */
 function oauth_hook_frontpage(&$links) {
-	assert('is_array($links)');
-	assert('array_key_exists("links", $links)');
+	assert(is_array($links));
+	assert(array_key_exists('links', $links));
 
 	$links['federation']['oauthregistry'] = array(
 		'href' => SimpleSAML\Module::getModuleURL('oauth/registry.php'),

--- a/modules/portal/hooks/hook_htmlinject.php
+++ b/modules/portal/hooks/hook_htmlinject.php
@@ -6,10 +6,10 @@
  * @param array &$hookinfo  hookinfo
  */
 function portal_hook_htmlinject(&$hookinfo) {
-	assert('is_array($hookinfo)');
-	assert('array_key_exists("pre", $hookinfo)');
-	assert('array_key_exists("post", $hookinfo)');
-	assert('array_key_exists("page", $hookinfo)');
+	assert(is_array($hookinfo));
+	assert(array_key_exists('pre', $hookinfo));
+	assert(array_key_exists('post', $hookinfo));
+	assert(array_key_exists('page', $hookinfo));
 
 	$links = array('links' => array());
 	SimpleSAML\Module::callHooks('frontpage', $links);

--- a/modules/preprodwarning/lib/Auth/Process/Warning.php
+++ b/modules/preprodwarning/lib/Auth/Process/Warning.php
@@ -18,7 +18,7 @@ class sspmod_preprodwarning_Auth_Process_Warning extends SimpleSAML_Auth_Process
 	 * @param array $state  The state of the response.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		if (isset($state['isPassive']) && $state['isPassive'] === TRUE) {
 			// We have a passive request. Skip the warning

--- a/modules/radius/lib/Auth/Source/Radius.php
+++ b/modules/radius/lib/Auth/Source/Radius.php
@@ -73,8 +73,8 @@ class sspmod_radius_Auth_Source_Radius extends sspmod_core_Auth_UserPassBase
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -116,8 +116,8 @@ class sspmod_radius_Auth_Source_Radius extends sspmod_core_Auth_UserPassBase
      */
     protected function login($username, $password)
     {
-        assert('is_string($username)');
-        assert('is_string($password)');
+        assert(is_string($username));
+        assert(is_string($password));
 
         $radius = radius_auth_open();
 

--- a/modules/riak/hooks/hook_cron.php
+++ b/modules/riak/hooks/hook_cron.php
@@ -29,9 +29,9 @@
  * @param array &$croninfo  Output
  */
 function riak_hook_cron(&$croninfo) {
-	assert('is_array($croninfo)');
-	assert('array_key_exists("summary", $croninfo)');
-	assert('array_key_exists("tag", $croninfo)');
+	assert(is_array($croninfo));
+	assert(array_key_exists('summary', $croninfo));
+	assert(array_key_exists('tag', $croninfo));
 
 	if ($croninfo['tag'] !== 'hourly') return;
 

--- a/modules/riak/lib/Store/Store.php
+++ b/modules/riak/lib/Store/Store.php
@@ -44,8 +44,8 @@ class sspmod_riak_Store_Store extends SimpleSAML\Store {
 	 * @return mixed|NULL  The value.
 	 */
 	public function get($type, $key) {
-		assert('is_string($type)');
-		assert('is_string($key)');
+		assert(is_string($type));
+		assert(is_string($key));
 
 		$v = $this->bucket->getBinary("$type.$key");
 		if (!$v->exists()) {
@@ -71,9 +71,9 @@ class sspmod_riak_Store_Store extends SimpleSAML\Store {
 	 * @param int|NULL $expire  The expiration time (unix timestamp), or NULL if it never expires.
 	 */
 	public function set($type, $key, $value, $expire = NULL) {
-		assert('is_string($type)');
-		assert('is_string($key)');
-		assert('is_null($expire) || (is_int($expire) && $expire > 2592000)');
+		assert(is_string($type));
+		assert(is_string($key));
+		assert($expire === null || (is_int($expire) && $expire > 2592000));
 
 		$v = $this->bucket->newBinary("$type.$key", serialize($value), 'application/php');
 		if (!is_null($expire)) {
@@ -90,8 +90,8 @@ class sspmod_riak_Store_Store extends SimpleSAML\Store {
 	 * @param string $key  The key.
 	 */
 	public function delete($type, $key) {
-		assert('is_string($type)');
-		assert('is_string($key)');
+		assert(is_string($type));
+		assert(is_string($key));
 
 		$v = $this->bucket->getBinary("$type.$key");
 		if (!$v->exists()) {

--- a/modules/saml/hooks/hook_metadata_hosted.php
+++ b/modules/saml/hooks/hook_metadata_hosted.php
@@ -6,7 +6,7 @@
  * @param array &$metadataHosted  The metadata links for hosted metadata on the frontpage.
  */
 function saml_hook_metadata_hosted(&$metadataHosted) {
-	assert('is_array($metadataHosted)');
+	assert(is_array($metadataHosted));
 
 	$sources = SimpleSAML_Auth_Source::getSourcesOfType('saml:SP');
 

--- a/modules/saml/lib/Auth/Process/AttributeNameID.php
+++ b/modules/saml/lib/Auth/Process/AttributeNameID.php
@@ -28,7 +28,7 @@ class sspmod_saml_Auth_Process_AttributeNameID extends sspmod_saml_BaseNameIDGen
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (!isset($config['Format'])) {
             throw new SimpleSAML_Error_Exception("AttributeNameID: Missing required option 'Format'.");

--- a/modules/saml/lib/Auth/Process/AuthnContextClassRef.php
+++ b/modules/saml/lib/Auth/Process/AuthnContextClassRef.php
@@ -28,7 +28,7 @@ class sspmod_saml_Auth_Process_AuthnContextClassRef extends SimpleSAML_Auth_Proc
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (!isset($config['AuthnContextClassRef'])) {
             throw new SimpleSAML_Error_Exception('Missing AuthnContextClassRef option in processing filter.');
@@ -45,7 +45,7 @@ class sspmod_saml_Auth_Process_AuthnContextClassRef extends SimpleSAML_Auth_Proc
      */
     public function process(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         $state['saml:AuthnContextClassRef'] = $this->authnContextClassRef;
     }

--- a/modules/saml/lib/Auth/Process/ExpectedAuthnContextClassRef.php
+++ b/modules/saml/lib/Auth/Process/ExpectedAuthnContextClassRef.php
@@ -45,7 +45,7 @@ class sspmod_saml_Auth_Process_ExpectedAuthnContextClassRef extends SimpleSAML_A
     {
         parent::__construct($config, $reserved);
 
-        assert('is_array($config)');
+        assert(is_array($config));
         if (empty($config['accepted'])) {
             SimpleSAML\Logger::error(
                 'ExpectedAuthnContextClassRef: Configuration error. There is no accepted AuthnContextClassRef.'
@@ -64,8 +64,8 @@ class sspmod_saml_Auth_Process_ExpectedAuthnContextClassRef extends SimpleSAML_A
      */
     public function process(&$request)
     {
-        assert('is_array($request)');
-        assert('array_key_exists("Attributes", $request)');
+        assert(is_array($request));
+        assert(array_key_exists('Attributes', $request));
 
         $this->AuthnContextClassRef = $request['saml:sp:State']['saml:sp:AuthnContext'];
 

--- a/modules/saml/lib/Auth/Process/FilterScopes.php
+++ b/modules/saml/lib/Auth/Process/FilterScopes.php
@@ -32,7 +32,7 @@ class FilterScopes extends \SimpleSAML_Auth_ProcessingFilter
     public function __construct(&$config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (array_key_exists('attributes', $config) && !empty($config['attributes'])) {
             $this->scopedAttributes = $config['attributes'];

--- a/modules/saml/lib/Auth/Process/NameIDAttribute.php
+++ b/modules/saml/lib/Auth/Process/NameIDAttribute.php
@@ -34,7 +34,7 @@ class sspmod_saml_Auth_Process_NameIDAttribute extends SimpleSAML_Auth_Processin
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (isset($config['attribute'])) {
             $this->attribute = (string) $config['attribute'];
@@ -62,7 +62,7 @@ class sspmod_saml_Auth_Process_NameIDAttribute extends SimpleSAML_Auth_Processin
      */
     private static function parseFormat($format)
     {
-        assert('is_string($format)');
+        assert(is_string($format));
 
         $ret = array();
         $pos = 0;
@@ -105,16 +105,16 @@ class sspmod_saml_Auth_Process_NameIDAttribute extends SimpleSAML_Auth_Processin
      */
     public function process(&$state)
     {
-        assert('is_array($state)');
-        assert('isset($state["Source"]["entityid"])');
-        assert('isset($state["Destination"]["entityid"])');
+        assert(is_array($state));
+        assert(isset($state['Source']['entityid']));
+        assert(isset($state['Destination']['entityid']));
 
         if (!isset($state['saml:sp:NameID'])) {
             return;
         }
 
         $rep = $state['saml:sp:NameID'];
-        assert('isset($rep["Value"])');
+        assert(isset($rep['Value']));
 
         $rep['%'] = '%';
         if (!isset($rep['Format'])) {

--- a/modules/saml/lib/Auth/Process/PersistentNameID.php
+++ b/modules/saml/lib/Auth/Process/PersistentNameID.php
@@ -28,7 +28,7 @@ class sspmod_saml_Auth_Process_PersistentNameID extends sspmod_saml_BaseNameIDGe
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         $this->format = \SAML2\Constants::NAMEID_PERSISTENT;
 

--- a/modules/saml/lib/Auth/Process/PersistentNameID2TargetedID.php
+++ b/modules/saml/lib/Auth/Process/PersistentNameID2TargetedID.php
@@ -34,7 +34,7 @@ class sspmod_saml_Auth_Process_PersistentNameID2TargetedID extends SimpleSAML_Au
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (isset($config['attribute'])) {
             $this->attribute = (string) $config['attribute'];
@@ -57,7 +57,7 @@ class sspmod_saml_Auth_Process_PersistentNameID2TargetedID extends SimpleSAML_Au
      */
     public function process(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         if (!isset($state['saml:NameID'][\SAML2\Constants::NAMEID_PERSISTENT])) {
             SimpleSAML\Logger::warning(

--- a/modules/saml/lib/Auth/Process/SQLPersistentNameID.php
+++ b/modules/saml/lib/Auth/Process/SQLPersistentNameID.php
@@ -49,7 +49,7 @@ class sspmod_saml_Auth_Process_SQLPersistentNameID extends sspmod_saml_BaseNameI
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         $this->format = \SAML2\Constants::NAMEID_PERSISTENT;
 

--- a/modules/saml/lib/Auth/Process/TransientNameID.php
+++ b/modules/saml/lib/Auth/Process/TransientNameID.php
@@ -18,7 +18,7 @@ class sspmod_saml_Auth_Process_TransientNameID extends sspmod_saml_BaseNameIDGen
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         $this->format = \SAML2\Constants::NAMEID_TRANSIENT;
     }

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -41,8 +41,8 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -106,7 +106,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @return SimpleSAML_Configuration  The metadata of the IdP.
 	 */
 	public function getIdPMetadata($entityId) {
-		assert('is_string($entityId)');
+		assert(is_string($entityId));
 
 		if ($this->idp !== NULL && $this->idp !== $entityId) {
 			throw new SimpleSAML_Error_Exception('Cannot retrieve metadata for IdP ' . var_export($entityId, TRUE) .
@@ -297,7 +297,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 
 		$this->sendSAML2AuthnRequest($state, $b, $ar);
 
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -312,7 +312,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 */
 	public function sendSAML2AuthnRequest(array &$state, \SAML2\Binding $binding, \SAML2\AuthnRequest $ar) {
 		$binding->send($ar);
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -323,7 +323,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $state  The state array for the current authentication.
 	 */
 	public function startSSO($idp, array $state) {
-		assert('is_string($idp)');
+		assert(is_string($idp));
 
 		$idpMetadata = $this->getIdPMetadata($idp);
 
@@ -331,13 +331,13 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 		switch ($type) {
 		case 'shib13-idp-remote':
 			$this->startSSO1($idpMetadata, $state);
-			assert('FALSE'); /* Should not return. */
+			assert(false); /* Should not return. */
 		case 'saml20-idp-remote':
 			$this->startSSO2($idpMetadata, $state);
-			assert('FALSE'); /* Should not return. */
+			assert(false); /* Should not return. */
 		default:
 			/* Should only be one of the known types. */
-			assert('FALSE');
+			assert(false);
 		}
 	}
 
@@ -387,7 +387,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		/* We are going to need the authId in order to retrieve this authentication source later. */
 		$state['saml:sp:AuthId'] = $this->authId;
@@ -423,13 +423,13 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 			}
 		}
 
-		if ($idp === NULL) {
+		if ($idp === null) {
 			$this->startDisco($state);
-			assert('FALSE');
+			assert(false);
 		}
 
 		$this->startSSO($idp, $state);
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -442,7 +442,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function reauthenticate(array &$state) {
-		assert('is_array($state)');
+		assert(is_array($state));
 
 		$session = SimpleSAML_Session::getSessionFromRequest();
 		$data = $session->getAuthState($this->authId);
@@ -517,10 +517,10 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 */
 	public static function askForIdPChange(array &$state)
 	{
-		assert('array_key_exists("saml:sp:IdPMetadata", $state)');
-		assert('array_key_exists("saml:sp:AuthId", $state)');
-		assert('array_key_exists("core:IdP", $state)');
-		assert('array_key_exists("SPMetadata", $state)');
+		assert(array_key_exists('saml:sp:IdPMetadata', $state));
+		assert(array_key_exists('saml:sp:AuthId', $state));
+		assert(array_key_exists('core:IdP', $state));
+		assert(array_key_exists('SPMetadata', $state));
 
 		if (isset($state['isPassive']) && (bool)$state['isPassive']) {
 			// passive request, we cannot authenticate the user
@@ -531,7 +531,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 		$id = SimpleSAML_Auth_State::saveState($state, 'saml:proxy:invalid_idp', true);
 		$url = SimpleSAML\Module::getModuleURL('saml/proxy/invalid_session.php');
 		SimpleSAML\Utils\HTTP::redirectTrustedURL($url, array('AuthState' => $id));
-		assert('false');
+		assert(false);
 	}
 
 
@@ -553,7 +553,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 
 		$idp = SimpleSAML_IdP::getByState($state);
 		$idp->handleLogoutRequest($state, null);
-		assert('false');
+		assert(false);
 	}
 
 
@@ -563,7 +563,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $state  The authentication state.
 	 */
 	public static function reauthPostLogin(array $state) {
-		assert('isset($state["ReturnCallback"])');
+		assert(isset($state['ReturnCallback']));
 
 		// Update session state
 		$session = SimpleSAML_Session::getSessionFromRequest();
@@ -572,7 +572,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 
 		// resume the login process
 		call_user_func($state['ReturnCallback'], $state);
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -585,7 +585,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array &$state The state array with the state during logout.
 	 */
 	public static function reauthPostLogout(SimpleSAML_IdP $idp, array $state) {
-		assert('isset($state["saml:sp:AuthId"])');
+		assert(isset($state['saml:sp:AuthId']));
 
 		SimpleSAML\Logger::debug('Proxy: logout completed.');
 
@@ -597,7 +597,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 		/** @var sspmod_saml_Auth_Source_SP $authSource */
 		SimpleSAML\Logger::debug('Proxy: logging in again.');
 		$sp->authenticate($state);
-		assert('false');
+		assert(false);
 	}
 
 
@@ -607,10 +607,10 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $state  The logout state.
 	 */
 	public function startSLO2(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("saml:logout:IdP", $state)');
-		assert('array_key_exists("saml:logout:NameID", $state)');
-		assert('array_key_exists("saml:logout:SessionIndex", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('saml:logout:IdP', $state));
+		assert(array_key_exists('saml:logout:NameID', $state));
+		assert(array_key_exists('saml:logout:SessionIndex', $state));
 
 		$id = SimpleSAML_Auth_State::saveState($state, 'saml:slosent');
 
@@ -645,7 +645,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 		$b = \SAML2\Binding::getBinding($endpoint['Binding']);
 		$b->send($lr);
 
-		assert('FALSE');
+		assert(false);
 	}
 
 
@@ -655,8 +655,8 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $state  The logout state.
 	 */
 	public function logout(&$state) {
-		assert('is_array($state)');
-		assert('array_key_exists("saml:logout:Type", $state)');
+		assert(is_array($state));
+		assert(array_key_exists('saml:logout:Type', $state));
 
 		$logoutType = $state['saml:logout:Type'];
 		switch ($logoutType) {
@@ -668,7 +668,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 			return;
 		default:
 			/* Should never happen. */
-			assert('FALSE');
+			assert(false);
 		}
 	}
 
@@ -681,9 +681,9 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $attributes  The attributes.
 	 */
 	public function handleResponse(array $state, $idp, array $attributes) {
-		assert('is_string($idp)');
-		assert('array_key_exists("LogoutState", $state)');
-		assert('array_key_exists("saml:logout:Type", $state["LogoutState"])');
+		assert(is_string($idp));
+		assert(array_key_exists('LogoutState', $state));
+		assert(array_key_exists('saml:logout:Type', $state['LogoutState']));
 		
 		$idpMetadata = $this->getIdpMetadata($idp);
 
@@ -724,7 +724,7 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param string $idpEntityId  The entity ID of the IdP.
 	 */
 	public function handleLogout($idpEntityId) {
-		assert('is_string($idpEntityId)');
+		assert(is_string($idpEntityId));
 
 		/* Call the logout callback we registered in onProcessingCompleted(). */
 		$this->callLogoutCallback($idpEntityId);
@@ -744,8 +744,8 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * 'trusted.url.domains' configuration directive for more information about allowing (or disallowing) URLs.
 	 */
 	public static function handleUnsolicitedAuth($authId, array $state, $redirectTo) {
-		assert('is_string($authId)');
-		assert('is_string($redirectTo)');
+		assert(is_string($authId));
+		assert(is_string($redirectTo));
 
 		$session = SimpleSAML_Session::getSessionFromRequest();
 		$session->doLogin($authId, SimpleSAML_Auth_State::getPersistentAuthData($state));
@@ -760,9 +760,9 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $authProcState  The processing chain state.
 	 */
 	public static function onProcessingCompleted(array $authProcState) {
-		assert('array_key_exists("saml:sp:IdP", $authProcState)');
-		assert('array_key_exists("saml:sp:State", $authProcState)');
-		assert('array_key_exists("Attributes", $authProcState)');
+		assert(array_key_exists('saml:sp:IdP', $authProcState));
+		assert(array_key_exists('saml:sp:State', $authProcState));
+		assert(array_key_exists('Attributes', $authProcState));
 
 		$idp = $authProcState['saml:sp:IdP'];
 		$state = $authProcState['saml:sp:State'];

--- a/modules/saml/lib/BaseNameIDGenerator.php
+++ b/modules/saml/lib/BaseNameIDGenerator.php
@@ -49,7 +49,7 @@ abstract class sspmod_saml_BaseNameIDGenerator extends SimpleSAML_Auth_Processin
 	 */
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (isset($config['NameQualifier'])) {
 			$this->nameQualifier = $config['NameQualifier'];
@@ -79,8 +79,8 @@ abstract class sspmod_saml_BaseNameIDGenerator extends SimpleSAML_Auth_Processin
 	 * @param array &$state  The request state.
 	 */
 	public function process(&$state) {
-		assert('is_array($state)');
-		assert('is_string($this->format)');
+		assert(is_array($state));
+		assert(is_string($this->format));
 
 		$value = $this->getValue($state);
 		if ($value === NULL) {

--- a/modules/saml/lib/Error.php
+++ b/modules/saml/lib/Error.php
@@ -40,15 +40,15 @@ class sspmod_saml_Error extends SimpleSAML_Error_Exception {
 	 * @param Exception|NULL $cause  The cause of this exception. Can be NULL.
 	 */
 	public function __construct($status, $subStatus = NULL, $statusMessage = NULL, Exception $cause = NULL) {
-		assert('is_string($status)');
-		assert('is_null($subStatus) || is_string($subStatus)');
-		assert('is_null($statusMessage) || is_string($statusMessage)');
+		assert(is_string($status));
+		assert($subStatus === null || is_string($subStatus));
+		assert($statusMessage === null || is_string($statusMessage));
 
 		$st = self::shortStatus($status);
-		if ($subStatus !== NULL) {
+		if ($subStatus !== null) {
 			$st .= '/' . self::shortStatus($subStatus);
 		}
-		if ($statusMessage !== NULL) {
+		if ($statusMessage !== null) {
 			$st .= ': ' . $statusMessage;
 		}
 		parent::__construct($st, 0, $cause);
@@ -182,7 +182,7 @@ class sspmod_saml_Error extends SimpleSAML_Error_Exception {
 	 * @return string  A shorter version of the status code.
 	 */
 	private static function shortStatus($status) {
-		assert('is_string($status)');
+		assert(is_string($status));
 
 		$t = 'urn:oasis:names:tc:SAML:2.0:status:';
 		if (substr($status, 0, strlen($t)) === $t) {

--- a/modules/saml/lib/IdP/SAML1.php
+++ b/modules/saml/lib/IdP/SAML1.php
@@ -14,10 +14,10 @@ class sspmod_saml_IdP_SAML1 {
 	 * @param array $state  The authentication state.
 	 */
 	public static function sendResponse(array $state) {
-		assert('isset($state["Attributes"])');
-		assert('isset($state["SPMetadata"])');
-		assert('isset($state["saml:shire"])');
-		assert('array_key_exists("saml:target", $state)'); // Can be NULL
+		assert(isset($state['Attributes']));
+		assert(isset($state['SPMetadata']));
+		assert(isset($state['saml:shire']));
+		assert(array_key_exists('saml:target', $state)); // Can be NULL
 
 		$spMetadata = $state["SPMetadata"];
 		$spEntityId = $spMetadata['entityid'];

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -18,11 +18,11 @@ class sspmod_saml_IdP_SAML2
      */
     public static function sendResponse(array $state)
     {
-        assert('isset($state["Attributes"])');
-        assert('isset($state["SPMetadata"])');
-        assert('isset($state["saml:ConsumerURL"])');
-        assert('array_key_exists("saml:RequestId", $state)'); // Can be NULL
-        assert('array_key_exists("saml:RelayState", $state)'); // Can be NULL.
+        assert(isset($state['Attributes']));
+        assert(isset($state['SPMetadata']));
+        assert(isset($state['saml:ConsumerURL']));
+        assert(array_key_exists('saml:RequestId', $state)); // Can be NULL
+        assert(array_key_exists('saml:RelayState', $state)); // Can be NULL.
 
         $spMetadata = $state["SPMetadata"];
         $spEntityId = $spMetadata['entityid'];
@@ -95,10 +95,10 @@ class sspmod_saml_IdP_SAML2
      */
     public static function handleAuthError(SimpleSAML_Error_Exception $exception, array $state)
     {
-        assert('isset($state["SPMetadata"])');
-        assert('isset($state["saml:ConsumerURL"])');
-        assert('array_key_exists("saml:RequestId", $state)'); // Can be NULL.
-        assert('array_key_exists("saml:RelayState", $state)'); // Can be NULL.
+        assert(isset($state['SPMetadata']));
+        assert(isset($state['saml:ConsumerURL']));
+        assert(array_key_exists('saml:RequestId', $state)); // Can be NULL.
+        assert(array_key_exists('saml:RelayState', $state)); // Can be NULL.
 
         $spMetadata = $state["SPMetadata"];
         $spEntityId = $spMetadata['entityid'];
@@ -166,9 +166,9 @@ class sspmod_saml_IdP_SAML2
         $ProtocolBinding,
         $AssertionConsumerServiceIndex
     ) {
-        assert('is_string($AssertionConsumerServiceURL) || is_null($AssertionConsumerServiceURL)');
-        assert('is_string($ProtocolBinding) || is_null($ProtocolBinding)');
-        assert('is_int($AssertionConsumerServiceIndex) || is_null($AssertionConsumerServiceIndex)');
+        assert(is_string($AssertionConsumerServiceURL) || $AssertionConsumerServiceURL === null);
+        assert(is_string($ProtocolBinding) || $ProtocolBinding === null);
+        assert(is_int($AssertionConsumerServiceIndex) || $AssertionConsumerServiceIndex === null);
 
         /* We want to pick the best matching endpoint in the case where for example
          * only the ProtocolBinding is given. We therefore pick endpoints with the
@@ -441,7 +441,7 @@ class sspmod_saml_IdP_SAML2
      */
     public static function sendLogoutRequest(SimpleSAML_IdP $idp, array $association, $relayState)
     {
-        assert('is_string($relayState) || is_null($relayState)');
+        assert(is_string($relayState) || $relayState === null);
 
         SimpleSAML\Logger::info('Sending SAML 2.0 LogoutRequest to: '.var_export($association['saml:entityID'], true));
 
@@ -477,9 +477,9 @@ class sspmod_saml_IdP_SAML2
      */
     public static function sendLogoutResponse(SimpleSAML_IdP $idp, array $state)
     {
-        assert('isset($state["saml:SPEntityId"])');
-        assert('isset($state["saml:RequestId"])');
-        assert('array_key_exists("saml:RelayState", $state)'); // Can be NULL.
+        assert(isset($state['saml:SPEntityId']));
+        assert(isset($state['saml:RequestId']));
+        assert(array_key_exists('saml:RelayState', $state)); // Can be NULL.
 
         $spEntityId = $state['saml:SPEntityId'];
 
@@ -610,7 +610,7 @@ class sspmod_saml_IdP_SAML2
      */
     public static function getLogoutURL(SimpleSAML_IdP $idp, array $association, $relayState)
     {
-        assert('is_string($relayState) || is_null($relayState)');
+        assert(is_string($relayState) || $relayState === null);
 
         SimpleSAML\Logger::info('Sending SAML 2.0 LogoutRequest to: '.var_export($association['saml:entityID'], true));
 
@@ -779,7 +779,7 @@ class sspmod_saml_IdP_SAML2
                             $doc = \SAML2\DOMDocumentFactory::fromString('<root>'.$value.'</root>');
                             $value = $doc->firstChild->childNodes;
                         }
-                        assert('$value instanceof DOMNodeList || $value instanceof \SAML2\XML\saml\NameID');
+                        assert($value instanceof DOMNodeList || $value instanceof \SAML2\XML\saml\NameID);
                         break;
                     default:
                         throw new SimpleSAML_Error_Exception('Invalid encoding for attribute '.
@@ -847,8 +847,8 @@ class sspmod_saml_IdP_SAML2
         SimpleSAML_Configuration $spMetadata,
         array &$state
     ) {
-        assert('isset($state["Attributes"])');
-        assert('isset($state["saml:ConsumerURL"])');
+        assert(isset($state['Attributes']));
+        assert(isset($state['saml:ConsumerURL']));
 
         $now = time();
 

--- a/modules/saml/lib/IdP/SQLNameID.php
+++ b/modules/saml/lib/IdP/SQLNameID.php
@@ -64,10 +64,10 @@ class sspmod_saml_IdP_SQLNameID  {
 	 * @param string $value  The NameID value.
 	 */
 	public static function add($idpEntityId, $spEntityId, $user, $value) {
-		assert('is_string($idpEntityId)');
-		assert('is_string($spEntityId)');
-		assert('is_string($user)');
-		assert('is_string($value)');
+		assert(is_string($idpEntityId));
+		assert(is_string($spEntityId));
+		assert(is_string($user));
+		assert(is_string($value));
 
 		$store = self::getStore();
 
@@ -93,9 +93,9 @@ class sspmod_saml_IdP_SQLNameID  {
 	 * @return string|NULL $value  The NameID value, or NULL of no NameID value was found.
 	 */
 	public static function get($idpEntityId, $spEntityId, $user) {
-		assert('is_string($idpEntityId)');
-		assert('is_string($spEntityId)');
-		assert('is_string($user)');
+		assert(is_string($idpEntityId));
+		assert(is_string($spEntityId));
+		assert(is_string($user));
 
 		$store = self::getStore();
 
@@ -127,9 +127,9 @@ class sspmod_saml_IdP_SQLNameID  {
 	 * @param string $user  The user's unique identificator (e.g. username).
 	 */
 	public static function delete($idpEntityId, $spEntityId, $user) {
-		assert('is_string($idpEntityId)');
-		assert('is_string($spEntityId)');
-		assert('is_string($user)');
+		assert(is_string($idpEntityId));
+		assert(is_string($spEntityId));
+		assert(is_string($user));
 
 		$store = self::getStore();
 
@@ -153,8 +153,8 @@ class sspmod_saml_IdP_SQLNameID  {
 	 * @return array  Array of userid => NameID.
 	 */
 	public static function getIdentities($idpEntityId, $spEntityId) {
-		assert('is_string($idpEntityId)');
-		assert('is_string($spEntityId)');
+		assert(is_string($idpEntityId));
+		assert(is_string($spEntityId));
 
 		$store = self::getStore();
 

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -304,7 +304,7 @@ class sspmod_saml_Message
         // load the new private key if it exists
         $keyArray = SimpleSAML\Utils\Crypto::loadPrivateKey($dstMetadata, false, 'new_');
         if ($keyArray !== null) {
-            assert('isset($keyArray["PEM"])');
+            assert(isset($keyArray['PEM']));
 
             $key = new XMLSecurityKey(XMLSecurityKey::RSA_1_5, array('type' => 'private'));
             if (array_key_exists('password', $keyArray)) {
@@ -316,7 +316,7 @@ class sspmod_saml_Message
 
         // find the existing private key
         $keyArray = SimpleSAML\Utils\Crypto::loadPrivateKey($dstMetadata, true);
-        assert('isset($keyArray["PEM"])');
+        assert(isset($keyArray['PEM']));
 
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_1_5, array('type' => 'private'));
         if (array_key_exists('password', $keyArray)) {
@@ -369,7 +369,7 @@ class sspmod_saml_Message
         SimpleSAML_Configuration $dstMetadata,
         $assertion
     ) {
-        assert('$assertion instanceof \SAML2\Assertion || $assertion instanceof \SAML2\EncryptedAssertion');
+        assert($assertion instanceof \SAML2\Assertion || $assertion instanceof \SAML2\EncryptedAssertion);
 
         if ($assertion instanceof \SAML2\Assertion) {
             $encryptAssertion = $srcMetadata->getBoolean('assertion.encryption', null);
@@ -605,8 +605,8 @@ class sspmod_saml_Message
         $assertion,
         $responseSigned
     ) {
-        assert('$assertion instanceof \SAML2\Assertion || $assertion instanceof \SAML2\EncryptedAssertion');
-        assert('is_bool($responseSigned)');
+        assert($assertion instanceof \SAML2\Assertion || $assertion instanceof \SAML2\EncryptedAssertion);
+        assert(is_bool($responseSigned));
 
         $assertion = self::decryptAssertion($idpMetadata, $spMetadata, $assertion);
 

--- a/modules/saml/lib/SP/LogoutStore.php
+++ b/modules/saml/lib/SP/LogoutStore.php
@@ -76,11 +76,11 @@ class sspmod_saml_SP_LogoutStore {
 	 * @param string $sessionIndex  The SessionIndex of the user.
 	 */
 	private static function addSessionSQL(\SimpleSAML\Store\SQL $store, $authId, $nameId, $sessionIndex, $expire, $sessionId) {
-		assert('is_string($authId)');
-		assert('is_string($nameId)');
-		assert('is_string($sessionIndex)');
-		assert('is_string($sessionId)');
-		assert('is_int($expire)');
+		assert(is_string($authId));
+		assert(is_string($nameId));
+		assert(is_string($sessionIndex));
+		assert(is_string($sessionId));
+		assert(is_int($expire));
 
 		self::createLogoutTable($store);
 
@@ -108,8 +108,8 @@ class sspmod_saml_SP_LogoutStore {
 	 * @return array  Associative array of SessionIndex =>  SessionId.
 	 */
 	private static function getSessionsSQL(\SimpleSAML\Store\SQL $store, $authId, $nameId) {
-		assert('is_string($authId)');
-		assert('is_string($nameId)');
+		assert(is_string($authId));
+		assert(is_string($nameId));
 
 		self::createLogoutTable($store);
 
@@ -144,8 +144,8 @@ class sspmod_saml_SP_LogoutStore {
 	 * @return array  Associative array of SessionIndex =>  SessionId.
 	 */
 	private static function getSessionsStore(\SimpleSAML\Store $store, $authId, $nameId, array $sessionIndexes) {
-		assert('is_string($authId)');
-		assert('is_string($nameId)');
+		assert(is_string($authId));
+		assert(is_string($nameId));
 
 		$res = array();
 		foreach ($sessionIndexes as $sessionIndex) {
@@ -153,7 +153,7 @@ class sspmod_saml_SP_LogoutStore {
 			if ($sessionId === NULL) {
 				continue;
 			}
-			assert('is_string($sessionId)');
+			assert(is_string($sessionId));
 			$res[$sessionIndex] = $sessionId;
 		}
 
@@ -175,9 +175,9 @@ class sspmod_saml_SP_LogoutStore {
 	 * @param string|NULL $sessionIndex  The SessionIndex of the user.
 	 */
 	public static function addSession($authId, $nameId, $sessionIndex, $expire) {
-		assert('is_string($authId)');
-		assert('is_string($sessionIndex) || is_null($sessionIndex)');
-		assert('is_int($expire)');
+		assert(is_string($authId));
+		assert(is_string($sessionIndex) || $sessionIndex === null);
+		assert(is_int($expire));
 
 		if ($sessionIndex === NULL) {
 			/* This IdP apparently did not include a SessionIndex, and thus probably does not
@@ -227,7 +227,7 @@ class sspmod_saml_SP_LogoutStore {
 	 * @returns int|FALSE  Number of sessions logged out, or FALSE if not supported.
 	 */
 	public static function logoutSessions($authId, $nameId, array $sessionIndexes) {
-		assert('is_string($authId)');
+		assert(is_string($authId));
 
 		$store = \SimpleSAML\Store::getInstance();
 		if ($store === FALSE) {
@@ -245,7 +245,7 @@ class sspmod_saml_SP_LogoutStore {
 
 		/* Normalize SessionIndexes. */
 		foreach ($sessionIndexes as &$sessionIndex) {
-			assert('is_string($sessionIndex)');
+			assert(is_string($sessionIndex));
 			if (strlen($sessionIndex) > 50) {
 				$sessionIndex = sha1($sessionIndex);
 			}

--- a/modules/saml/www/sp/discoresp.php
+++ b/modules/saml/www/sp/discoresp.php
@@ -14,7 +14,7 @@ if (!array_key_exists('idpentityid', $_REQUEST)) {
 $state = SimpleSAML_Auth_State::loadState($_REQUEST['AuthID'], 'saml:sp:sso');
 
 // Find authentication source
-assert('array_key_exists("saml:sp:AuthId", $state)');
+assert(array_key_exists('saml:sp:AuthId', $state));
 $sourceId = $state['saml:sp:AuthId'];
 
 $source = SimpleSAML_Auth_Source::getById($sourceId);

--- a/modules/saml/www/sp/saml1-acs.php
+++ b/modules/saml/www/sp/saml1-acs.php
@@ -38,12 +38,12 @@ if (preg_match('@^https?://@i', $target)) {
 	$state = SimpleSAML_Auth_State::loadState($_REQUEST['TARGET'], 'saml:sp:sso');
 
 	// Check that the authentication source is correct.
-	assert('array_key_exists("saml:sp:AuthId", $state)');
+	assert(array_key_exists('saml:sp:AuthId', $state));
 	if ($state['saml:sp:AuthId'] !== $sourceId) {
 		throw new SimpleSAML_Error_Exception('The authentication source id in the URL does not match the authentication source which sent the request.');
 	}
 
-	assert('isset($state["saml:idp"])');
+	assert(isset($state['saml:idp']));
 }
 
 $spMetadata = $source->getMetadata();
@@ -62,7 +62,7 @@ if (array_key_exists('SAMLart', $_REQUEST)) {
 	$responseXML = base64_decode($responseXML);
 	$isValidated = FALSE; /* Must check signature on response. */
 } else {
-	assert('FALSE');
+	assert(false);
 }
 
 $response = new \SimpleSAML\XML\Shib13\AuthnResponse();
@@ -86,4 +86,4 @@ $state['LogoutState'] = $logoutState;
 $state['saml:sp:NameID'] = $response->getNameID();
 
 $source->handleResponse($state, $responseIssuer, $attributes);
-assert('FALSE');
+assert(false);

--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -87,7 +87,7 @@ if (!empty($stateId)) {
 
 if ($state) {
     // check that the authentication source is correct
-    assert('array_key_exists("saml:sp:AuthId", $state)');
+    assert(array_key_exists('saml:sp:AuthId', $state));
     if ($state['saml:sp:AuthId'] !== $sourceId) {
         throw new SimpleSAML_Error_Exception(
             'The authentication source id in the URL does not match the authentication source which sent the request.'
@@ -95,7 +95,7 @@ if ($state) {
     }
 
     // check that the issuer is the one we are expecting
-    assert('array_key_exists("ExpectedIssuer", $state)');
+    assert(array_key_exists('ExpectedIssuer', $state));
     if ($state['ExpectedIssuer'] !== $idp) {
         $idpMetadata = $source->getIdPMetadata($idp);
         $idplist = $idpMetadata->getArrayize('IDPList', array());
@@ -255,4 +255,4 @@ if (isset($state['SimpleSAML_Auth_Source.ReturnURL'])) {
 $state['PersistentAuthData'][] = 'saml:sp:prevAuth';
 
 $source->handleResponse($state, $idp, $attributes);
-assert('FALSE');
+assert(false);

--- a/modules/sanitycheck/hooks/hook_cron.php
+++ b/modules/sanitycheck/hooks/hook_cron.php
@@ -6,9 +6,9 @@
  */
 function sanitycheck_hook_cron(&$croninfo)
 {
-    assert('is_array($croninfo)');
-    assert('array_key_exists("summary", $croninfo)');
-    assert('array_key_exists("tag", $croninfo)');
+    assert(is_array($croninfo));
+    assert(array_key_exists('summary', $croninfo));
+    assert(array_key_exists('tag', $croninfo));
 
     SimpleSAML\Logger::info('cron [sanitycheck]: Running cron in cron tag [' . $croninfo['tag'] . '] ');
 

--- a/modules/sanitycheck/hooks/hook_frontpage.php
+++ b/modules/sanitycheck/hooks/hook_frontpage.php
@@ -6,8 +6,8 @@
  */
 function sanitycheck_hook_frontpage(&$links)
 {
-    assert('is_array($links)');
-    assert('array_key_exists("links", $links)');
+    assert(is_array($links));
+    assert(array_key_exists('links', $links));
 
     $links['config']['santitycheck'] = array(
         'href' => SimpleSAML\Module::getModuleURL('sanitycheck/index.php'),

--- a/modules/sanitycheck/hooks/hook_moduleinfo.php
+++ b/modules/sanitycheck/hooks/hook_moduleinfo.php
@@ -6,8 +6,8 @@
  */
 function sanitycheck_hook_moduleinfo(&$moduleinfo)
 {
-    assert('is_array($moduleinfo)');
-    assert('array_key_exists("info", $moduleinfo)');
+    assert(is_array($moduleinfo));
+    assert(array_key_exists('info', $moduleinfo));
 
     $moduleinfo['info']['sanitycheck'] = array(
         'name' => array('en' => 'Sanity check'),

--- a/modules/sanitycheck/hooks/hook_sanitycheck.php
+++ b/modules/sanitycheck/hooks/hook_sanitycheck.php
@@ -6,9 +6,9 @@
  */
 function sanitycheck_hook_sanitycheck(&$hookinfo)
 {
-    assert('is_array($hookinfo)');
-    assert('array_key_exists("errors", $hookinfo)');
-    assert('array_key_exists("info", $hookinfo)');
+    assert(is_array($hookinfo));
+    assert(array_key_exists('errors', $hookinfo));
+    assert(array_key_exists('info', $hookinfo));
 
     $hookinfo['info'][] = '[sanitycheck] At least the sanity check itself is working :)';
 }

--- a/modules/smartattributes/lib/Auth/Process/SmartID.php
+++ b/modules/smartattributes/lib/Auth/Process/SmartID.php
@@ -47,7 +47,7 @@ class sspmod_smartattributes_Auth_Process_SmartID extends SimpleSAML_Auth_Proces
 	public function __construct($config, $reserved) {
 		parent::__construct($config, $reserved);
 
-		assert('is_array($config)');
+		assert(is_array($config));
 
 		if (array_key_exists('candidates', $config)) {
 			$this->_candidates = $config['candidates'];
@@ -107,8 +107,8 @@ class sspmod_smartattributes_Auth_Process_SmartID extends SimpleSAML_Auth_Proces
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$ID = $this->addID($request['Attributes'], $request);
 

--- a/modules/smartattributes/lib/Auth/Process/SmartName.php
+++ b/modules/smartattributes/lib/Auth/Process/SmartName.php
@@ -62,8 +62,8 @@ class sspmod_smartattributes_Auth_Process_SmartName extends SimpleSAML_Auth_Proc
 	 * @param array &$request  The current request
 	 */
 	public function process(&$request) {
-		assert('is_array($request)');
-		assert('array_key_exists("Attributes", $request)');
+		assert(is_array($request));
+		assert(array_key_exists('Attributes', $request));
 
 		$attributes =& $request['Attributes'];
 		

--- a/modules/sqlauth/lib/Auth/Source/SQL.php
+++ b/modules/sqlauth/lib/Auth/Source/SQL.php
@@ -44,8 +44,8 @@ class sspmod_sqlauth_Auth_Source_SQL extends sspmod_core_Auth_UserPassBase {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		// Call the parent constructor first, as required by the interface
 		parent::__construct($info, $config);
@@ -121,8 +121,8 @@ class sspmod_sqlauth_Auth_Source_SQL extends sspmod_core_Auth_UserPassBase {
 	 * @return array  Associative array with the users attributes.
 	 */
 	protected function login($username, $password) {
-		assert('is_string($username)');
-		assert('is_string($password)');
+		assert(is_string($username));
+		assert(is_string($password));
 
 		$db = $this->connect();
 

--- a/modules/statistics/hooks/hook_cron.php
+++ b/modules/statistics/hooks/hook_cron.php
@@ -6,9 +6,9 @@
  */
 function statistics_hook_cron(&$croninfo)
 {
-    assert('is_array($croninfo)');
-    assert('array_key_exists("summary", $croninfo)');
-    assert('array_key_exists("tag", $croninfo)');
+    assert(is_array($croninfo));
+    assert(array_key_exists('summary', $croninfo));
+    assert(array_key_exists('tag', $croninfo));
 
     $statconfig = SimpleSAML_Configuration::getConfig('module_statistics.php');
 	

--- a/modules/statistics/hooks/hook_frontpage.php
+++ b/modules/statistics/hooks/hook_frontpage.php
@@ -6,8 +6,8 @@
  */
 function statistics_hook_frontpage(&$links)
 {
-    assert('is_array($links)');
-    assert('array_key_exists("links", $links)');
+    assert(is_array($links));
+    assert(array_key_exists('links', $links));
 
     $links['config']['statistics'] = array(
         'href' => SimpleSAML\Module::getModuleURL('statistics/showstats.php'),

--- a/modules/statistics/hooks/hook_sanitycheck.php
+++ b/modules/statistics/hooks/hook_sanitycheck.php
@@ -6,9 +6,9 @@
  */
 function statistics_hook_sanitycheck(&$hookinfo)
 {
-    assert('is_array($hookinfo)');
-    assert('array_key_exists("errors", $hookinfo)');
-    assert('array_key_exists("info", $hookinfo)');
+    assert(is_array($hookinfo));
+    assert(array_key_exists('errors', $hookinfo));
+    assert(array_key_exists('info', $hookinfo));
 
     try {
         $statconfig = SimpleSAML_Configuration::getConfig('module_statistics.php');

--- a/modules/statistics/lib/StatDataset.php
+++ b/modules/statistics/lib/StatDataset.php
@@ -29,8 +29,8 @@ class sspmod_statistics_StatDataset
      */
     public function __construct($statconfig, $ruleconfig, $ruleid, $timeres, $fileslot)
     {
-        assert('$statconfig instanceof SimpleSAML_Configuration');
-        assert('$ruleconfig instanceof SimpleSAML_Configuration');
+        assert($statconfig instanceof SimpleSAML_Configuration);
+        assert($ruleconfig instanceof SimpleSAML_Configuration);
         $this->statconfig = $statconfig;
         $this->ruleconfig = $ruleconfig;
 

--- a/modules/statistics/lib/Statistics/Rulesets/BaseRule.php
+++ b/modules/statistics/lib/Statistics/Rulesets/BaseRule.php
@@ -15,8 +15,8 @@ class sspmod_statistics_Statistics_Rulesets_BaseRule
      */
     public function __construct($statconfig, $ruleconfig, $ruleid, $available)
     {
-        assert('$statconfig instanceof SimpleSAML_Configuration');
-        assert('$ruleconfig instanceof SimpleSAML_Configuration');
+        assert($statconfig instanceof SimpleSAML_Configuration);
+        assert($ruleconfig instanceof SimpleSAML_Configuration);
         $this->statconfig = $statconfig;
         $this->ruleconfig = $ruleconfig;
         $this->ruleid = $ruleid;

--- a/modules/statistics/lib/Statistics/Rulesets/Ratio.php
+++ b/modules/statistics/lib/Statistics/Rulesets/Ratio.php
@@ -13,8 +13,8 @@ class sspmod_statistics_Statistics_Rulesets_Ratio extends sspmod_statistics_Stat
      */
     public function __construct($statconfig, $ruleconfig, $ruleid, $available)
     {
-        assert('$statconfig instanceof SimpleSAML_Configuration');
-        assert('$ruleconfig instanceof SimpleSAML_Configuration');
+        assert($statconfig instanceof SimpleSAML_Configuration);
+        assert($ruleconfig instanceof SimpleSAML_Configuration);
 
         parent::__construct($statconfig, $ruleconfig, $ruleid, $available);
 

--- a/templates/attributequery.php
+++ b/templates/attributequery.php
@@ -2,26 +2,26 @@
 $this->includeAtTemplateBase('includes/header.php');
 
 $dataId = $this->data['dataId'];
-assert('is_string($dataId)');
+assert(is_string($dataId));
 
 $url = $this->data['url'];
-assert('is_string($url)');
+assert(is_string($url));
 
 $nameIdFormat = $this->data['nameIdFormat'];
-assert('is_string($nameIdFormat)');
+assert(is_string($nameIdFormat));
 
 $nameIdValue = $this->data['nameIdValue'];
-assert('is_string($nameIdValue)');
+assert(is_string($nameIdValue));
 
 $nameIdQualifier = $this->data['nameIdQualifier'];
-assert('is_string($nameIdQualifier)');
+assert(is_string($nameIdQualifier));
 
 $nameIdSPQualifier = $this->data['nameIdSPQualifier'];
-assert('is_string($nameIdSPQualifier)');
+assert(is_string($nameIdSPQualifier));
 
 
 $attributes = $this->data['attributes'];
-assert('is_null($attributes) || is_array($attributes)');
+assert($attributes === null || is_array($attributes));
 
 
 ?>

--- a/templates/post.php
+++ b/templates/post.php
@@ -28,9 +28,9 @@ if (array_key_exists('post', $this->data)) {
     $post = $this->data['post'];
 } else {
     // For backwards compatibility
-    assert('array_key_exists("response", $this->data)');
-    assert('array_key_exists("RelayStateName", $this->data)');
-    assert('array_key_exists("RelayState", $this->data)');
+    assert(array_key_exists('response', $this->data));
+    assert(array_key_exists('RelayStateName', $this->data));
+    assert(array_key_exists('RelayState', $this->data));
         $post = array(
         'SAMLResponse' => $this->data['response'],
         $this->data['RelayStateName'] => $this->data['RelayState'],
@@ -48,8 +48,8 @@ if (array_key_exists('post', $this->data)) {
  * @param string|array $value  The value of the element.
  */
 function printItem($name, $value) {
-    assert('is_string($name)');
-    assert('is_string($value) || is_array($value)');
+    assert(is_string($name));
+    assert(is_string($value) || is_array($value));
     if (is_string($value)) {
         echo '<input type="hidden" name="' . 
             htmlspecialchars($name) . '" value="' . 

--- a/www/module.php
+++ b/www/module.php
@@ -43,7 +43,7 @@ if (empty($_SERVER['PATH_INFO'])) {
 }
 
 $url = $_SERVER['PATH_INFO'];
-assert('substr($url, 0, 1) === "/"');
+assert(substr($url, 0, 1) === '/');
 
 /* clear the PATH_INFO option, so that a script can detect whether it is called with anything following the
  *'.php'-ending.

--- a/www/saml2/idp/SSOService.php
+++ b/www/saml2/idp/SSOService.php
@@ -24,4 +24,4 @@ try {
         throw $e; // do not ignore other exceptions!
     }
 }
-assert('FALSE');
+assert(false);

--- a/www/saml2/idp/SingleLogoutService.php
+++ b/www/saml2/idp/SingleLogoutService.php
@@ -33,4 +33,4 @@ if (isset($_REQUEST['ReturnTo'])) {
         }
     }
 }
-assert('FALSE');
+assert(FALSE);

--- a/www/saml2/idp/initSLO.php
+++ b/www/saml2/idp/initSLO.php
@@ -12,4 +12,4 @@ if (!isset($_GET['RelayState'])) {
 }
 
 $idp->doLogoutRedirect(\SimpleSAML\Utils\HTTP::checkURLAllowed((string) $_GET['RelayState']));
-assert('FALSE');
+assert(FALSE);

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -55,7 +55,7 @@ try {
 
     if ($idpmeta->hasValue('https.certificate')) {
         $httpsCert = Crypto::loadPublicKey($idpmeta, true, 'https.');
-        assert('isset($httpsCert["certData"])');
+        assert(isset($httpsCert['certData']));
         $availableCerts['https.crt'] = $httpsCert;
         $keys[] = array(
             'type'            => 'X509Certificate',

--- a/www/shib13/idp/SSOService.php
+++ b/www/shib13/idp/SSOService.php
@@ -8,7 +8,7 @@
  * @package SimpleSAMLphp
  */
 
-require_once('../../_include.php');
+require_once '../../_include.php';
 
 SimpleSAML\Logger::info('Shib1.3 - IdP.SSOService: Accessing Shibboleth 1.3 IdP endpoint SSOService');
 
@@ -16,4 +16,4 @@ $metadata = SimpleSAML_Metadata_MetaDataStorageHandler::getMetadataHandler();
 $idpEntityId = $metadata->getMetaDataCurrentEntityID('shib13-idp-hosted');
 $idp = SimpleSAML_IdP::getById('saml1:' . $idpEntityId);
 sspmod_saml_IdP_SAML1::receiveAuthnRequest($idp);
-assert('FALSE');
+assert(false);


### PR DESCRIPTION
Fixes #573

Removed string-based usage of assert. Where applicable in the assert calls, I also replaced `is_null` with `=== null`, double quotes to single quotes (to match style elsewhere) and lowercased PHP constants (false/null)