### PR TITLE
MySQL key value store now handles NULL expiries.

### DIFF
--- a/tests/lib/SimpleSAML/Store/SQLTest.php
+++ b/tests/lib/SimpleSAML/Store/SQLTest.php
@@ -49,7 +49,7 @@ class SQLTest extends \PHPUnit_Framework_TestCase
 
         $version = $store->getTableVersion('kvstore');
 
-        $this->assertEquals(1, $version);
+        $this->assertEquals(2, $version);
     }
 
     /**


### PR DESCRIPTION
Declaration of kvstore _expires field was defaulting to current timestamp in MySQL.
Added mini upgrade script to kvstore init method to add default null value.

This could have been fixed by changing the declaration of the _expire field in the kv store to `_expire TIMESTAMP NULL` but that would not have fixed existing installations.