### PR TITLE
Make MDQ more robust on errors (fixes #723)

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -444,7 +444,7 @@ class HTTP
         }
 
         $context = stream_context_create($context);
-        $data = file_get_contents($url, false, $context);
+        $data = @file_get_contents($url, false, $context);
         if ($data === false) {
             $error = error_get_last();
             throw new \SimpleSAML_Error_Exception('Error fetching '.var_export($url, true).':'.


### PR DESCRIPTION
Don't bail out if the MDQ cache is broken or the query fails, because
later other metadata sources might provide the metadata for the entity.