### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -27,13 +27,13 @@ definition:
 namespace SimpleSAML\Test\Utils;
 ```
 
-The test classes need to extend `PHPUnit_Framework_TestCase`, and inside
+The test classes need to extend `PHPUnit\Framework\TestCase`, and inside
 you can implement as many methods as you want. `phpunit` will only run
 the ones prefixed with "test".
 
 You will usually make use of the `assert*()` methods provided by
-`PHPUnit_Framework_TestCase`, but you can also tell `phpunit` to expect
-an exception to be thrown using *phpdoc*. For example, if you want to 
+`PHPUnit\Framework\TestCase`, but you can also tell `phpunit` to expect
+an exception to be thrown using *phpdoc*. For example, if you want to
 ensure that the `SimpleSAML\Utils\HTTP::addURLParameters()` method
 throws an exception in a specific situation:
 
@@ -47,7 +47,7 @@ throws an exception in a specific situation:
 ```
 
 Refer to [the `phpunit 4.8` documentation](https://phpunit.de/manual/4.8/en/installation.html)
-for more information on how to write tests. We currently use the `phpunit 4.8` 
+for more information on how to write tests. We currently use the `phpunit 4.8`
 since it is the last version to support php 5.3.
 
 Once you have implemented your tests, you can run them locally. First,
@@ -66,7 +66,7 @@ the old version installed by composer
 ./vendor/bin/phpunit -c tools/phpunit/phpunit.xml
 ```
 
-All the tests are run by our *continuous integration* platform, 
+All the tests are run by our *continuous integration* platform,
 [travis](https://travis-ci.org/simplesamlphp/simplesamlphp). If you are
 submitting a pull request, Travis will run your tests and notify whether
 your code builds or not according to them.

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "~4.8.35",
         "mikey179/vfsStream": "~1.6",
         "friendsofphp/php-cs-fixer": "^2.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "66d40cfe8e5bf764140f170bd2abed71",
+    "content-hash": "b4321ba6aa21f1dfd919f942037f2692",
     "packages": [
         {
             "name": "gettext/gettext",

--- a/tests/Utils/ClearStateTestCase.php
+++ b/tests/Utils/ClearStateTestCase.php
@@ -4,10 +4,12 @@ namespace SimpleSAML\Test\Utils;
 
 include(dirname(__FILE__) . '/StateClearer.php');
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * A base SSP test case that takes care of removing global state prior to test runs
  */
-class ClearStateTestCase extends \PHPUnit_Framework_TestCase
+class ClearStateTestCase extends TestCase
 {
     /**
      * Used for managing and clearing state

--- a/tests/lib/SimpleSAML/Auth/StateTest.php
+++ b/tests/lib/SimpleSAML/Auth/StateTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for SimpleSAML_Auth_State
  */
-class Auth_StateTest extends PHPUnit_Framework_TestCase
+class Auth_StateTest extends TestCase
 {
 
 

--- a/tests/lib/SimpleSAML/DatabaseTest.php
+++ b/tests/lib/SimpleSAML/DatabaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * This test ensures that the SimpleSAML_Database class can properly
@@ -12,7 +13,7 @@
  * @author Tyler Antonio, University of Alberta. <tantonio@ualberta.ca>
  * @package SimpleSAMLphp
  */
-class SimpleSAML_DatabaseTest extends PHPUnit_Framework_TestCase
+class SimpleSAML_DatabaseTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Locale/LanguageTest.php
+++ b/tests/lib/SimpleSAML/Locale/LanguageTest.php
@@ -2,9 +2,10 @@
 
 namespace SimpleSAML\Test\Locale;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Locale\Language;
 
-class LanguageTest extends \PHPUnit_Framework_TestCase
+class LanguageTest extends TestCase
 {
 
 

--- a/tests/lib/SimpleSAML/Locale/LocalizationTest.php
+++ b/tests/lib/SimpleSAML/Locale/LocalizationTest.php
@@ -2,11 +2,12 @@
 
 namespace SimpleSAML\Test\Locale;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Locale\Localization;
 use \SimpleSAML_Configuration as Configuration;
 
 
-class LocalizationTest extends \PHPUnit_Framework_TestCase
+class LocalizationTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/lib/SimpleSAML/Locale/TranslateTest.php
+++ b/tests/lib/SimpleSAML/Locale/TranslateTest.php
@@ -2,9 +2,10 @@
 
 namespace SimpleSAML\Test\Locale;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Locale\Translate;
 
-class TranslateTest extends \PHPUnit_Framework_TestCase
+class TranslateTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Metadata/SAMLBuilderTest.php
+++ b/tests/lib/SimpleSAML/Metadata/SAMLBuilderTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SimpleSAML_Metadata_SAMLBuilderTest
  */
-class SimpleSAML_Metadata_SAMLBuilderTest extends PHPUnit_Framework_TestCase
+class SimpleSAML_Metadata_SAMLBuilderTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace SimpleSAML\Metadata;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test SAML parsing
  */
-class SAMLParserTest extends \PHPUnit_Framework_TestCase
+class SAMLParserTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/ModuleTest.php
+++ b/tests/lib/SimpleSAML/ModuleTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace SimpleSAML\Test;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Module;
 
-class ModuleTest extends \PHPUnit_Framework_TestCase
+class ModuleTest extends TestCase
 {
 
 

--- a/tests/lib/SimpleSAML/Store/RedisTest.php
+++ b/tests/lib/SimpleSAML/Store/RedisTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\Store;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 use \SimpleSAML\Store;
 
@@ -13,7 +14,7 @@ use \SimpleSAML\Store;
  *
  * @package simplesamlphp/simplesamlphp
  */
-class RedisTest extends \PHPUnit_Framework_TestCase
+class RedisTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/lib/SimpleSAML/Store/SQLTest.php
+++ b/tests/lib/SimpleSAML/Store/SQLTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\Store;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 use \SimpleSAML\Store;
 
@@ -14,7 +15,7 @@ use \SimpleSAML\Store;
  * @author Sergio Gómez <sergio@uco.es>
  * @package simplesamlphp/simplesamlphp
  */
-class SQLTest extends \PHPUnit_Framework_TestCase
+class SQLTest extends TestCase
 {
     protected function setUp()
     {
@@ -106,10 +107,10 @@ class SQLTest extends \PHPUnit_Framework_TestCase
     {
         /** @var \SimpleSAML\Store\SQL $store */
         $store = Store::getInstance();
-        
+
         $store->set('test', 'foo', 'bar');
         $value = $store->get('test', 'foo');
-        
+
         $this->assertEquals('bar', $value);
     }
 

--- a/tests/lib/SimpleSAML/StoreTest.php
+++ b/tests/lib/SimpleSAML/StoreTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 use \SimpleSAML\Store;
 
@@ -14,7 +15,7 @@ use \SimpleSAML\Store;
  * @author Sergio Gómez <sergio@uco.es>
  * @package simplesamlphp/simplesamlphp
  */
-class StoreTest extends \PHPUnit_Framework_TestCase
+class StoreTest extends TestCase
 {
     /**
      * @covers \SimpleSAML\Store::getInstance

--- a/tests/lib/SimpleSAML/Utils/ArraysTest.php
+++ b/tests/lib/SimpleSAML/Utils/ArraysTest.php
@@ -2,12 +2,13 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Arrays;
 
 /**
  * Tests for SimpleSAML\Utils\Arrays.
  */
-class ArraysTest extends \PHPUnit_Framework_TestCase
+class ArraysTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Utils/AttributesTest.php
+++ b/tests/lib/SimpleSAML/Utils/AttributesTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Attributes;
 
 /**
@@ -9,7 +10,7 @@ use SimpleSAML\Utils\Attributes;
  *
  * @author Jaime Perez, UNINETT AS <jaime.perez@uninett.no>
  */
-class AttributesTest extends \PHPUnit_Framework_TestCase
+class AttributesTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Utils/Config/MetadataTest.php
+++ b/tests/lib/SimpleSAML/Utils/Config/MetadataTest.php
@@ -2,12 +2,13 @@
 
 namespace SimpleSAML\Test\Utils\Config;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Config\Metadata;
 
 /**
  * Tests related to SAML metadata.
  */
-class MetadataTest extends \PHPUnit_Framework_TestCase
+class MetadataTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Utils/ConfigTest.php
+++ b/tests/lib/SimpleSAML/Utils/ConfigTest.php
@@ -2,12 +2,13 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Config;
 
 /**
  * Tests for SimpleSAML\Utils\Config
  */
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Utils/CryptoTest.php
+++ b/tests/lib/SimpleSAML/Utils/CryptoTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Crypto;
 use \SimpleSAML_Configuration as Configuration;
 
@@ -10,7 +11,7 @@ use \org\bovigo\vfs\vfsStream;
 /**
  * Tests for SimpleSAML\Utils\Crypto.
  */
-class CryptoTest extends \PHPUnit_Framework_TestCase
+class CryptoTest extends TestCase
 {
     const ROOTDIRNAME = 'testdir';
     const DEFAULTCERTDIR = 'certdir';

--- a/tests/lib/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/lib/SimpleSAML/Utils/HTTPTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\HTTP;
 
-class HTTPTest extends \PHPUnit_Framework_TestCase
+class HTTPTest extends TestCase
 {
 
 

--- a/tests/lib/SimpleSAML/Utils/NetTest.php
+++ b/tests/lib/SimpleSAML/Utils/NetTest.php
@@ -2,12 +2,13 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Net;
 
 /**
  * Tests for SimpleSAML\Utils\Test.
  */
-class NetTest extends \PHPUnit_Framework_TestCase
+class NetTest extends TestCase
 {
 
 

--- a/tests/lib/SimpleSAML/Utils/RandomTest.php
+++ b/tests/lib/SimpleSAML/Utils/RandomTest.php
@@ -2,12 +2,13 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Random;
 
 /**
  * Tests for SimpleSAML\Utils\Random.
  */
-class RandomTest extends \PHPUnit_Framework_TestCase
+class RandomTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Utils/SystemTest.php
+++ b/tests/lib/SimpleSAML/Utils/SystemTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 use \SimpleSAML\Utils\System;
 
@@ -10,7 +11,7 @@ use \org\bovigo\vfs\vfsStream;
 /**
  * Tests for SimpleSAML\Utils\System.
  */
-class SystemTest extends \PHPUnit_Framework_TestCase
+class SystemTest extends TestCase
 {
     const ROOTDIRNAME = 'testdir';
     const DEFAULTTEMPDIR = 'tempdir';

--- a/tests/lib/SimpleSAML/Utils/TimeTest.php
+++ b/tests/lib/SimpleSAML/Utils/TimeTest.php
@@ -2,9 +2,10 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Time;
 
-class TimeTest extends \PHPUnit_Framework_TestCase
+class TimeTest extends TestCase
 {
 
     /**

--- a/tests/lib/SimpleSAML/Utils/XMLTest.php
+++ b/tests/lib/SimpleSAML/Utils/XMLTest.php
@@ -2,13 +2,14 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 use \SimpleSAML\Utils\XML;
 
 /**
  * Tests for SimpleSAML\Utils\XML.
  */
-class XMLTest extends \PHPUnit_Framework_TestCase
+class XMLTest extends TestCase
 {
     /**
      * @covers \SimpleSAML\Utils\XML::isDOMNodeOfType

--- a/tests/lib/SimpleSAML/XML/ErrorsTest.php
+++ b/tests/lib/SimpleSAML/XML/ErrorsTest.php
@@ -12,9 +12,10 @@
 
 namespace SimpleSAML\Test\XML;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\XML\Errors;
 
-class ErrorsTest extends \PHPUnit_Framework_TestCase
+class ErrorsTest extends TestCase
 {
     /**
      * @covers \SimpleSAML\XML\Errors::begin

--- a/tests/lib/SimpleSAML/XML/ParserTest.php
+++ b/tests/lib/SimpleSAML/XML/ParserTest.php
@@ -11,9 +11,10 @@
 
 namespace SimpleSAML\Test\XML;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\XML\Parser;
 
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     const XMLDOC = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/lib/SimpleSAML/XML/Shib13/AuthnResponseTest.php
+++ b/tests/lib/SimpleSAML/XML/Shib13/AuthnResponseTest.php
@@ -11,12 +11,13 @@
 
 namespace SimpleSAML\Test\XML\Shib13;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\XML\Shib13\AuthnResponse;
 
-class AuthnResponseTest extends \PHPUnit_Framework_TestCase
+class AuthnResponseTest extends TestCase
 {
     const XMLDOC = <<< XML
-<Response xmlns="urn:oasis:names:tc:SAML:1.0:protocol" 
+<Response xmlns="urn:oasis:names:tc:SAML:1.0:protocol"
     MajorVersion="1" MinorVersion="1"
     ResponseID="" IssueInstant="">
     <Assertion xmlns="urn:oasis:names:tc:SAML:1.0:assertion"
@@ -34,7 +35,7 @@ class AuthnResponseTest extends \PHPUnit_Framework_TestCase
 XML;
 
     const BADXMLDOC = <<< XML
-<Response xmlns="urn:oasis:names:tc:SAML:1.0:protocol" 
+<Response xmlns="urn:oasis:names:tc:SAML:1.0:protocol"
     MajorVersion="1" MinorVersion="1"
     ResponseID="" IssueInstant="">
     <Assertion xmlns="urn:oasis:names:tc:SAML:1.0:assertion"

--- a/tests/lib/SimpleSAML/XML/SignerTest.php
+++ b/tests/lib/SimpleSAML/XML/SignerTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\Utils;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 use \SimpleSAML\XML\Signer;
 
@@ -10,7 +11,7 @@ use \org\bovigo\vfs\vfsStream;
 /**
  * Tests for SimpleSAML\XML\Signer.
  */
-class SignerTest extends \PHPUnit_Framework_TestCase
+class SignerTest extends TestCase
 {
     // openssl genrsa -out private.pem 2048
     private $private_key = <<<'NOWDOC'

--- a/tests/lib/SimpleSAML/XML/ValidatorTest.php
+++ b/tests/lib/SimpleSAML/XML/ValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\XML;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 use \SimpleSAML\XML\Signer;
 use \SimpleSAML\XML\Validator;
@@ -11,7 +12,7 @@ use \org\bovigo\vfs\vfsStream;
 /**
  * Tests for SimpleSAML\XML\Validator.
  */
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     // openssl genrsa -out ca.key.pem 2048
     private $ca_private_key = <<<'NOWDOC'

--- a/tests/modules/consent/lib/Auth/Process/ConsentTest.php
+++ b/tests/modules/consent/lib/Auth/Process/ConsentTest.php
@@ -8,9 +8,10 @@
 
 namespace SimpleSAML\Test\Module\consent\Auth\Process;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 
-class ConsentTest extends \PHPUnit_Framework_TestCase
+class ConsentTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/modules/core/lib/Auth/Process/AttributeAddTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeAddTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:AttributeAdd filter.
  */
-class Test_Core_Auth_Process_AttributeAdd extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_AttributeAdd extends TestCase
 {
 
     /**

--- a/tests/modules/core/lib/Auth/Process/AttributeAlterTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeAlterTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:AttributeAlter filter.
  */
-class Test_Core_Auth_Process_AttributeAlter extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_AttributeAlter extends TestCase
 {
 
     /**
@@ -354,4 +356,3 @@ class Test_Core_Auth_Process_AttributeAlter extends PHPUnit_Framework_TestCase
         $result = self::processFilter($config, $request);
     }
 }
-

--- a/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeCopyTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:AttributeCopy filter.
  */
-class Test_Core_Auth_Process_AttributeCopy extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_AttributeCopy extends TestCase
 {
 
     /**

--- a/tests/modules/core/lib/Auth/Process/AttributeLimitTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeLimitTest.php
@@ -1,8 +1,11 @@
 <?php
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:AttributeLimit filter.
  */
-class Test_Core_Auth_Process_AttributeLimitTest extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_AttributeLimitTest extends TestCase
 {
 
     /**
@@ -197,8 +200,8 @@ class Test_Core_Auth_Process_AttributeLimitTest extends PHPUnit_Framework_TestCa
 
     /**
      * Test for exception with illegal config.
-     * 
-     * @expectedException Exception 
+     *
+     * @expectedException Exception
      */
     public function testInvalidConfig()
     {
@@ -211,8 +214,8 @@ class Test_Core_Auth_Process_AttributeLimitTest extends PHPUnit_Framework_TestCa
 
     /**
      * Test for invalid attribute name
-     * 
-     * @expectedException Exception 
+     *
+     * @expectedException Exception
      */
     public function testInvalidAttributeName()
     {
@@ -265,12 +268,12 @@ class Test_Core_Auth_Process_AttributeLimitTest extends PHPUnit_Framework_TestCa
     }
 
     /**
-     * Test for allowed attributes not an array. 
+     * Test for allowed attributes not an array.
      *
-     * This test is very unlikely and would require malformed metadata processing. 
+     * This test is very unlikely and would require malformed metadata processing.
      * Cannot be generated via config options.
      *
-     * @expectedException Exception 
+     * @expectedException Exception
      */
     public function testMatchAttributeValuesNotArray()
     {

--- a/tests/modules/core/lib/Auth/Process/AttributeRealmTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeRealmTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:AttributeRealm filter.
  */
-class Test_Core_Auth_Process_AttributeRealm extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_AttributeRealm extends TestCase
 {
 
     /**

--- a/tests/modules/core/lib/Auth/Process/AttributeValueMapTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeValueMapTest.php
@@ -2,12 +2,13 @@
 
 namespace SimpleSAML\Test\Module\core\Auth\Process;
 
+use PHPUnit\Framework\TestCase;
 use SimpleSAML\Module\core\Auth\Process\AttributeValueMap;
 
 /**
  * Test for the core:AttributeValueMap filter.
  */
-class AttributeValueMapTest extends \PHPUnit_Framework_TestCase
+class AttributeValueMapTest extends TestCase
 {
 
     /**

--- a/tests/modules/core/lib/Auth/Process/PHPTest.php
+++ b/tests/modules/core/lib/Auth/Process/PHPTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test for the core:PHP filter.
  */
-class Test_Core_Auth_Process_PHP extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_PHP extends TestCase
 {
 
     /**

--- a/tests/modules/core/lib/Auth/Process/ScopeAttributeTest.php
+++ b/tests/modules/core/lib/Auth/Process/ScopeAttributeTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:ScopeAttribute filter.
  */
-class Test_Core_Auth_Process_ScopeAttribute extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_ScopeAttribute extends TestCase
 {
 
     /*

--- a/tests/modules/core/lib/Auth/Process/ScopeFromAttributeTest.php
+++ b/tests/modules/core/lib/Auth/Process/ScopeFromAttributeTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:ScopeFromAttribute filter.
  */
-class Test_Core_Auth_Process_ScopeFromAttribute extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_ScopeFromAttribute extends TestCase
 {
 
     /*

--- a/tests/modules/core/lib/Auth/Process/TargetedIDTest.php
+++ b/tests/modules/core/lib/Auth/Process/TargetedIDTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for the core:TargetedID filter.
  */
-class Test_Core_Auth_Process_TargetedID extends PHPUnit_Framework_TestCase
+class Test_Core_Auth_Process_TargetedID extends TestCase
 {
     /**
      * Helper function to run the filter with a given configuration.
@@ -149,13 +151,13 @@ class Test_Core_Auth_Process_TargetedID extends PHPUnit_Framework_TestCase
 //        $request['UserID'] = 'user3@example.org';
 //	$result = self::processFilter($config, $request);
 //	$tid2 = $result['Attributes']['eduPersonTargetedID'][0];
-//        
+//
 //        $this->assertNotEquals($tid1, $tid2);
 //
 //        $request['Destination']['entityid'] = 'urn:example.org:another-sp';
 //	$result = self::processFilter($config, $request);
 //	$tid3 = $result['Attributes']['eduPersonTargetedID'][0];
-//        
+//
 //        $this->assertNotEquals($tid2, $tid3);
 //    }
 

--- a/tests/modules/ldap/lib/Auth/Process/BaseFilterTest.php
+++ b/tests/modules/ldap/lib/Auth/Process/BaseFilterTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class sspmod_ldap_Auth_Process_BaseFilter_Test extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class sspmod_ldap_Auth_Process_BaseFilter_Test extends TestCase
 {
     public function testVarExportHidesLdapPassword()
     {

--- a/tests/modules/saml/lib/Auth/Process/FilterScopesTest.php
+++ b/tests/modules/saml/lib/Auth/Process/FilterScopesTest.php
@@ -8,8 +8,9 @@
 
 namespace SimpleSAML\Test\Module\saml\Auth\Process;
 
+use PHPUnit\Framework\TestCase;
 
-class FilterScopesTest extends \PHPUnit_Framework_TestCase
+class FilterScopesTest extends TestCase
 {
 
     /*

--- a/tests/modules/saml/lib/Auth/Source/Auth_Source_SP_Test.php
+++ b/tests/modules/saml/lib/Auth/Source/Auth_Source_SP_Test.php
@@ -2,6 +2,7 @@
 
 namespace SimpleSAML\Test\Module\saml\Auth\Source;
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML_Configuration as Configuration;
 
 /**
@@ -67,7 +68,7 @@ class SP_Tester extends \sspmod_saml_Auth_Source_SP
 /**
  * Set of test cases for sspmod_saml_Auth_Source_SP.
  */
-class SP_Test extends \PHPUnit_Framework_TestCase
+class SP_Test extends TestCase
 {
 
     private $idpMetadata = null;

--- a/tests/www/IndexTest.php
+++ b/tests/www/IndexTest.php
@@ -12,9 +12,10 @@ namespace SimpleSAML\Test\Web;
 
 include(dirname(__FILE__).'/../BuiltInServer.php');
 
+use PHPUnit\Framework\TestCase;
 use \SimpleSAML\Test\BuiltInServer;
 
-class IndexTest extends \PHPUnit_Framework_TestCase
+class IndexTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.

I've also changed the `TESTING.md` file, to encourage new testers to use this `namespace`.