### PR TITLE
NameIDAttribute filter: update to use SAML2\XML\saml\NameID

### DIFF
--- a/modules/saml/lib/Auth/Process/NameIDAttribute.php
+++ b/modules/saml/lib/Auth/Process/NameIDAttribute.php
@@ -81,7 +81,7 @@ class sspmod_saml_Auth_Process_NameIDAttribute extends SimpleSAML_Auth_Processin
                     $ret[] = 'SPNameQualifier';
                     break;
                 case 'V':
-                    $ret[] = 'Value';
+                    $ret[] = 'value';
                     break;
                 case '%':
                     $ret[] = '%';
@@ -114,17 +114,17 @@ class sspmod_saml_Auth_Process_NameIDAttribute extends SimpleSAML_Auth_Processin
         }
 
         $rep = $state['saml:sp:NameID'];
-        assert(isset($rep['Value']));
+        assert(isset($rep->value));
 
-        $rep['%'] = '%';
-        if (!isset($rep['Format'])) {
-            $rep['Format'] = \SAML2\Constants::NAMEID_UNSPECIFIED;
+        $rep->{'%'} = '%';
+        if (!isset($rep->Format)) {
+            $rep->Format = \SAML2\Constants::NAMEID_UNSPECIFIED;
         }
-        if (!isset($rep['NameQualifier'])) {
-            $rep['NameQualifier'] = $state['Source']['entityid'];
+        if (!isset($rep->NameQualifier)) {
+            $rep->NameQualifier = $state['Source']['entityid'];
         }
-        if (!isset($rep['SPNameQualifier'])) {
-            $rep['SPNameQualifier'] = $state['Destination']['entityid'];
+        if (!isset($rep->SPNameQualifier)) {
+            $rep->SPNameQualifier = $state['Destination']['entityid'];
         }
 
         $value = '';
@@ -133,7 +133,7 @@ class sspmod_saml_Auth_Process_NameIDAttribute extends SimpleSAML_Auth_Processin
             if ($isString) {
                 $value .= $element;
             } else {
-                $value .= $rep[$element];
+                $value .= $rep->$element;
             }
             $isString = !$isString;
         }

--- a/tests/modules/saml/lib/Auth/Process/NameIDAttributeTest.php
+++ b/tests/modules/saml/lib/Auth/Process/NameIDAttributeTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Test for the saml:NameIDAttribute filter.
+ *
+ * @author Eugene Venter <eugene@catalyst.net.nz>
+ * @package SimpleSAMLphp
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class NameIDAttributeTest extends TestCase
+{
+
+    /*
+     * Helper function to run the filter with a given configuration.
+     *
+     * @param array $config  The filter configuration.
+     * @param array $request  The request state.
+     * @return array  The state array after processing.
+     */
+    private function processFilter(array $config, array $request)
+    {
+        $filter = new sspmod_saml_Auth_Process_NameIDAttribute($config, null);
+        $filter->process($request);
+        return $request;
+    }
+
+
+    /**
+     * Test minimal configuration.
+     */
+    public function testMinimalConfig()
+    {
+        $config = array();
+
+        $nameId = new \SAML2\XML\saml\NameID();
+        $nameId->value = 'eugene@oombaas';
+        $nameId->Format = \SAML2\Constants::NAMEID_PERSISTENT;
+
+        $spId = 'eugeneSP';
+        $idpId = 'eugeneIdP';
+
+        $request = array(
+            'Source'     => array(
+                'entityid' => $spId,
+            ),
+            'Destination' => array(
+                'entityid' => $idpId,
+            ),
+            'saml:sp:NameID' => $nameId,
+        );
+        $result = $this->processFilter($config, $request);
+        $this->assertEquals("{$spId}!{$idpId}!{$nameId->value}", $result['Attributes']['nameid'][0]);
+    }
+
+    /**
+     * Test custom attribute name.
+     */
+    public function testCustomAttributeName()
+    {
+        $attributeName = 'eugeneNameIDAttribute';
+        $config = array('attribute' => $attributeName);
+
+        $nameId = new \SAML2\XML\saml\NameID();
+        $nameId->value = 'eugene@oombaas';
+        $nameId->Format = \SAML2\Constants::NAMEID_PERSISTENT;
+
+        $spId = 'eugeneSP';
+        $idpId = 'eugeneIdP';
+
+        $request = array(
+            'Source'     => array(
+                'entityid' => $spId,
+            ),
+            'Destination' => array(
+                'entityid' => $idpId,
+            ),
+            'saml:sp:NameID' => $nameId,
+        );
+        $result = $this->processFilter($config, $request);
+        $this->assertTrue(isset($result['Attributes'][$attributeName]));
+        $this->assertEquals("{$spId}!{$idpId}!{$nameId->value}", $result['Attributes'][$attributeName][0]);
+    }
+
+    /**
+     * Test custom format.
+     */
+    public function testFormat()
+    {
+        $config = array('format' => '%V');
+
+        $nameId = new \SAML2\XML\saml\NameID();
+        $nameId->value = 'eugene@oombaas';
+        $nameId->Format = \SAML2\Constants::NAMEID_PERSISTENT;
+
+        $spId = 'eugeneSP';
+        $idpId = 'eugeneIdP';
+
+        $request = array(
+            'Source'     => array(
+                'entityid' => $spId,
+            ),
+            'Destination' => array(
+                'entityid' => $idpId,
+            ),
+            'saml:sp:NameID' => $nameId,
+        );
+        $result = $this->processFilter($config, $request);
+        $this->assertEquals("{$nameId->value}", $result['Attributes']['nameid'][0]);
+    }
+
+
+    /**
+     * Test custom attribute name with format.
+     */
+    public function testCustomAttributeNameAndFormat()
+    {
+        $attributeName = 'eugeneNameIDAttribute';
+        $config = array('attribute' => $attributeName, 'format' => '%V');
+
+        $nameId = new \SAML2\XML\saml\NameID();
+        $nameId->value = 'eugene@oombaas';
+        $nameId->Format = \SAML2\Constants::NAMEID_PERSISTENT;
+
+        $spId = 'eugeneSP';
+        $idpId = 'eugeneIdP';
+
+        $request = array(
+            'Source'     => array(
+                'entityid' => $spId,
+            ),
+            'Destination' => array(
+                'entityid' => $idpId,
+            ),
+            'saml:sp:NameID' => $nameId,
+        );
+        $result = $this->processFilter($config, $request);
+        $this->assertTrue(isset($result['Attributes'][$attributeName]));
+        $this->assertEquals("{$nameId->value}", $result['Attributes'][$attributeName][0]);
+    }
+}


### PR DESCRIPTION
This patch fixes the following error when attempting to use NameIDAttribute filter (https://simplesamlphp.org/docs/1.15/saml:nameidattribute):
```SimpleSAML_Error_Exception: Error 1 - Cannot use object of type SAML2\XML\saml\NameID as array```