### PR TITLE
Add 'no-store' to the cache-control header

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -176,7 +176,7 @@ class HTTP
 
             // disable caching of this response
             header('Pragma: no-cache');
-            header('Cache-Control: no-cache, must-revalidate');
+            header('Cache-Control: no-cache, no-store, must-revalidate');
         }
 
         // show a minimal web page with a clickable link to the URL


### PR DESCRIPTION
With the release of Google Chrome version 63, we started noticing that the 302 redirect to the Identity Provider was being served from disk cache randomly.  This caused a stale request condition at the Shibboleth Identity Provider.

By adding 'no-store' to the cache-control header, Google Chrome will no longer be able to store the 302 response in the local disk cache.

We will most likely be patching this on our production system, but would greatly appreciate it if this could be merged in so we can go back to having a clean install.

Regards,
Luke