### PR TITLE
Set entityId as array-key too

### DIFF
--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
@@ -113,6 +113,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerFlatFile extends SimpleSAML_Meta
         foreach ($metadataSet as $entityId => &$entry) {
             if (preg_match('/__DYNAMIC(:[0-9]+)?__/', $entityId)) {
                 $entry['entityid'] = $this->generateDynamicHostedEntityID($set);
+                $metadataSet[$entry['entityid']] = $entry;
+                unset($metadataSet[$entityId]);
             } else {
                 $entry['entityid'] = $entityId;
             }

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -133,6 +133,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
         foreach ($metadataSet as $entityId => &$entry) {
             if (preg_match('/__DYNAMIC(:[0-9]+)?__/', $entityId)) {
                 $entry['entityid'] = $this->generateDynamicHostedEntityID($set);
+                $metadataSet[$entry['entityid']] = $entry;
+                unset($metadataSet[$entityId]);
             } else {
                 $entry['entityid'] = $entityId;
             }


### PR DESCRIPTION
To me it doesn't make sense to not also replace the array-key with the proper entityId, especially given there is no easy way to do it afterwards;   generateDynamicHostedEntityID is a private method.

I'm not entirely confident this doesn't break anything, so that's why I made this PR.