### PR TITLE
Prevent an assert by only calling a sub-search if needed

### DIFF
--- a/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
+++ b/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
@@ -263,7 +263,9 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
             $groups[] = $dn;
 
             // Recursively search "sub" groups
-            $groups = array_merge($groups, $this->search($attributes[$map['memberof']]));
+            if (is_array($attributes[$map['memberof']])) {
+                $groups = array_merge($groups, $this->search($attributes[$map['memberof']]));
+            }
         }
 
         // Return only the unique group names

--- a/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
+++ b/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
@@ -263,7 +263,7 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
             $groups[] = $dn;
 
             // Recursively search "sub" groups
-            if (is_array($attributes[$map['memberof']])) {
+            if (!empty($attributes[$map['memberof']])) {
                 $groups = array_merge($groups, $this->search($attributes[$map['memberof']]));
             }
         }


### PR DESCRIPTION
There's no need to call another search if a group is not a member of any other groups. At present, if it's not, it'll just throw an assertion.