### PR TITLE
Fix missing cookie params in authtoken cookie when using remember-me mechanism

### DIFF
--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -755,13 +755,19 @@ class SimpleSAML_Session implements Serializable
     {
         $sessionHandler = \SimpleSAML\SessionHandler::getSessionHandler();
 
+        if (is_array($params) && !empty($params)) {
+            $params = array_merge($sessionHandler->getCookieParams(), $params);
+        } else {
+            $params = $sessionHandler->getCookieParams();
+        }
+
         if ($this->sessionId !== null) {
             $sessionHandler->setCookie($sessionHandler->getSessionCookieName(), $this->sessionId, $params);
         }
 
         if ($this->authToken !== null) {
             $globalConfig = SimpleSAML_Configuration::getInstance();
-            $sessionHandler->setCookie(
+            \SimpleSAML\Utils\HTTP::setCookie(
                 $globalConfig->getString('session.authtoken.cookiename', 'SimpleSAMLAuthToken'),
                 $this->authToken,
                 $params

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -761,7 +761,7 @@ class SimpleSAML_Session implements Serializable
 
         if ($this->authToken !== null) {
             $globalConfig = SimpleSAML_Configuration::getInstance();
-            \SimpleSAML\Utils\HTTP::setCookie(
+            $sessionHandler->setCookie(
                 $globalConfig->getString('session.authtoken.cookiename', 'SimpleSAMLAuthToken'),
                 $this->authToken,
                 $params


### PR DESCRIPTION
Fixes that the configured cookie settings are not correctly set for the auth token cookie when remember-me mechanism is enabled and checked.

Cookie ends up getting set with the default params in `HTTP::setCookie`  
https://github.com/simplesamlphp/simplesamlphp/blob/a5437da2dbbb8dc6348cac02dc343c03bc7f3e14/lib/SimpleSAML/Utils/HTTP.php#L1114-L1120