### PR TITLE
PSR-2 compliant whitespace in error classes

### DIFF
--- a/lib/SimpleSAML/Error/Assertion.php
+++ b/lib/SimpleSAML/Error/Assertion.php
@@ -6,76 +6,80 @@
  * @author Olav Morken, UNINETT AS.
  * @package SimpleSAMLphp
  */
-class SimpleSAML_Error_Assertion extends SimpleSAML_Error_Exception {
+class SimpleSAML_Error_Assertion extends SimpleSAML_Error_Exception
+{
 
 
-	/**
-	 * The assertion which failed, or NULL if only an expression was passed to the
-	 * assert-function.
-	 */
-	private $assertion;
+    /**
+     * The assertion which failed, or null if only an expression was passed to the
+     * assert-function.
+     */
+    private $assertion;
 
 
-	/**
-	 * Constructor for the assertion exception.
-	 *
-	 * Should only be called from the onAssertion handler.
-	 *
-	 * @param string|NULL $assertion  The assertion which failed, or NULL if the assert-function was
-	 *                                given an expression.
-	 */
-	public function __construct($assertion = NULL) {
-		assert($assertion === null || is_string($assertion));
+    /**
+     * Constructor for the assertion exception.
+     *
+     * Should only be called from the onAssertion handler.
+     *
+     * @param string|null $assertion  The assertion which failed, or null if the assert-function was
+     *                                given an expression.
+     */
+    public function __construct($assertion = null)
+    {
+        assert($assertion === null || is_string($assertion));
 
-		$msg = 'Assertion failed: ' . var_export($assertion, TRUE);
-		parent::__construct($msg);
+        $msg = 'Assertion failed: ' . var_export($assertion, true);
+        parent::__construct($msg);
 
-		$this->assertion = $assertion;
-	}
-
-
-	/**
-	 * Retrieve the assertion which failed.
-	 *
-	 * @return string|NULL  The assertion which failed, or NULL if the assert-function was called with an expression.
-	 */
-	public function getAssertion() {
-		return $this->assertion;
-	}
+        $this->assertion = $assertion;
+    }
 
 
-	/**
-	 * Install this assertion handler.
-	 *
-	 * This function will register this assertion handler. If will not enable assertions if they are
-	 * disabled.
-	 */
-	public static function installHandler() {
-
-		assert_options(ASSERT_WARNING,    0);
-		assert_options(ASSERT_QUIET_EVAL, 0);
-		assert_options(ASSERT_CALLBACK,   array('SimpleSAML_Error_Assertion', 'onAssertion'));
-	}
+    /**
+     * Retrieve the assertion which failed.
+     *
+     * @return string|null  The assertion which failed, or null if the assert-function was called with an expression.
+     */
+    public function getAssertion()
+    {
+        return $this->assertion;
+    }
 
 
-	/**
-	 * Handle assertion.
-	 *
-	 * This function handles an assertion.
-	 *
-	 * @param string $file  The file assert was called from.
-	 * @param int $line  The line assert was called from.
-	 * @param mixed $message  The expression which was passed to the assert-function.
-	 */
-	public static function onAssertion($file, $line, $message) {
+    /**
+     * Install this assertion handler.
+     *
+     * This function will register this assertion handler. If will not enable assertions if they are
+     * disabled.
+     */
+    public static function installHandler()
+    {
 
-		if(!empty($message)) {
-			$exception = new self($message);
-		} else {
-			$exception = new self();
-		}
+        assert_options(ASSERT_WARNING, 0);
+        assert_options(ASSERT_QUIET_EVAL, 0);
+        assert_options(ASSERT_CALLBACK, array('SimpleSAML_Error_Assertion', 'onAssertion'));
+    }
 
-		$exception->logError();
-	}
 
+    /**
+     * Handle assertion.
+     *
+     * This function handles an assertion.
+     *
+     * @param string $file  The file assert was called from.
+     * @param int $line  The line assert was called from.
+     * @param mixed $message  The expression which was passed to the assert-function.
+     */
+    public static function onAssertion($file, $line, $message)
+    {
+
+        if (!empty($message)) {
+            $exception = new self($message);
+        } else {
+            $exception = new self();
+        }
+
+        $exception->logError();
+    }
 }

--- a/lib/SimpleSAML/Error/AuthSource.php
+++ b/lib/SimpleSAML/Error/AuthSource.php
@@ -1,68 +1,70 @@
 <?php
 /**
  * Baseclass for auth source exceptions.
- * 
+ *
  * @package SimpleSAMLphp_base
  *
  */
-class SimpleSAML_Error_AuthSource extends SimpleSAML_Error_Error {
+class SimpleSAML_Error_AuthSource extends SimpleSAML_Error_Error
+{
 
 
-	/**
-	 * Authsource module name.
-	 */
-	private $authsource;
+    /**
+     * Authsource module name.
+     */
+    private $authsource;
 
 
-	/**
-	 * Reason why this request was invalid.
-	 */
-	private $reason;
+    /**
+     * Reason why this request was invalid.
+     */
+    private $reason;
 
 
-	/**
-	 * Create a new AuthSource error.
-	 *
-	 * @param string $authsource  Authsource module name from where this error was thrown.
-	 * @param string $reason  Description of the error.
-	 */
-	public function __construct($authsource, $reason, $cause = NULL) {
-		assert(is_string($authsource));
-		assert(is_string($reason));
+    /**
+     * Create a new AuthSource error.
+     *
+     * @param string $authsource  Authsource module name from where this error was thrown.
+     * @param string $reason  Description of the error.
+     */
+    public function __construct($authsource, $reason, $cause = null)
+    {
+        assert(is_string($authsource));
+        assert(is_string($reason));
 
-		$this->authsource = $authsource;
-		$this->reason = $reason;
-		parent::__construct(
-			array(
-				'AUTHSOURCEERROR',
-				'%AUTHSOURCE%' => htmlspecialchars(var_export($this->authsource, TRUE)),
-				'%REASON%' => htmlspecialchars(var_export($this->reason, TRUE))
-			),
-			$cause
-		);
+        $this->authsource = $authsource;
+        $this->reason = $reason;
+        parent::__construct(
+            array(
+                'AUTHSOURCEERROR',
+                '%AUTHSOURCE%' => htmlspecialchars(var_export($this->authsource, true)),
+                '%REASON%' => htmlspecialchars(var_export($this->reason, true))
+            ),
+            $cause
+        );
 
-		$this->message = "Error with authentication source '$authsource': $reason";
-	}
-
-
-	/**
-	 * Retrieve the authsource module name from where this error was thrown.
-	 *
-	 * @return string  Authsource module name.
-	 */
-	public function getAuthSource() {
-		return $this->authsource;
-	}
+        $this->message = "Error with authentication source '$authsource': $reason";
+    }
 
 
-	/**
-	 * Retrieve the reason why the request was invalid.
-	 *
-	 * @return string  The reason why the request was invalid.
-	 */
-	public function getReason() {
-		return $this->reason;
-	}
+    /**
+     * Retrieve the authsource module name from where this error was thrown.
+     *
+     * @return string  Authsource module name.
+     */
+    public function getAuthSource()
+    {
+        return $this->authsource;
+    }
 
-	
+
+    /**
+     * Retrieve the reason why the request was invalid.
+     *
+     * @return string  The reason why the request was invalid.
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
 }

--- a/lib/SimpleSAML/Error/BadRequest.php
+++ b/lib/SimpleSAML/Error/BadRequest.php
@@ -9,36 +9,38 @@
  * @author Olav Morken, UNINETT AS.
  * @package SimpleSAMLphp
  */
-class SimpleSAML_Error_BadRequest extends SimpleSAML_Error_Error {
+class SimpleSAML_Error_BadRequest extends SimpleSAML_Error_Error
+{
 
 
-	/**
-	 * Reason why this request was invalid.
-	 */
-	private $reason;
+    /**
+     * Reason why this request was invalid.
+     */
+    private $reason;
 
 
-	/**
-	 * Create a new BadRequest error.
-	 *
-	 * @param string $reason  Description of why the request was unacceptable.
-	 */
-	public function __construct($reason) {
-		assert(is_string($reason));
+    /**
+     * Create a new BadRequest error.
+     *
+     * @param string $reason  Description of why the request was unacceptable.
+     */
+    public function __construct($reason)
+    {
+        assert(is_string($reason));
 
-		$this->reason = $reason;
-		parent::__construct(array('BADREQUEST', '%REASON%' => $this->reason));
-		$this->httpCode = 400;
-	}
+        $this->reason = $reason;
+        parent::__construct(array('BADREQUEST', '%REASON%' => $this->reason));
+        $this->httpCode = 400;
+    }
 
 
-	/**
-	 * Retrieve the reason why the request was invalid.
-	 *
-	 * @return string  The reason why the request was invalid.
-	 */
-	public function getReason() {
-		return $this->reason;
-	}
-
+    /**
+     * Retrieve the reason why the request was invalid.
+     *
+     * @return string  The reason why the request was invalid.
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
 }

--- a/lib/SimpleSAML/Error/BadUserInnput.php
+++ b/lib/SimpleSAML/Error/BadUserInnput.php
@@ -1,11 +1,12 @@
 <?php
 /**
  * Exception indicating illegal innput from user.
- * 
+ *
  * @author Thomas Graff <thomas.graff@uninett.no>
  * @package SimpleSAMLphp_base
  *
  */
-class SimpleSAML_Error_BadUserInnput extends SimpleSAML_Error_User{
-	
+class SimpleSAML_Error_BadUserInnput extends SimpleSAML_Error_User
+{
+
 }

--- a/lib/SimpleSAML/Error/CannotSetCookie.php
+++ b/lib/SimpleSAML/Error/CannotSetCookie.php
@@ -8,7 +8,6 @@
 
 namespace SimpleSAML\Error;
 
-
 class CannotSetCookie extends \SimpleSAML_Error_Exception
 {
 

--- a/lib/SimpleSAML/Error/ConfigurationError.php
+++ b/lib/SimpleSAML/Error/ConfigurationError.php
@@ -8,7 +8,6 @@
 
 namespace SimpleSAML\Error;
 
-
 class ConfigurationError extends \SimpleSAML_Error_Error
 {
 

--- a/lib/SimpleSAML/Error/CriticalConfigurationError.php
+++ b/lib/SimpleSAML/Error/CriticalConfigurationError.php
@@ -20,7 +20,6 @@
 
 namespace SimpleSAML\Error;
 
-
 class CriticalConfigurationError extends ConfigurationError
 {
 

--- a/lib/SimpleSAML/Error/Exception.php
+++ b/lib/SimpleSAML/Error/Exception.php
@@ -87,7 +87,6 @@ class SimpleSAML_Error_Exception extends Exception
         $pos = $exception->getFile().':'.$exception->getLine();
 
         foreach ($exception->getTrace() as $t) {
-
             $function = $t['function'];
             if (array_key_exists('class', $t)) {
                 $function = $t['class'].'::'.$function;

--- a/lib/SimpleSAML/Error/InvalidCredential.php
+++ b/lib/SimpleSAML/Error/InvalidCredential.php
@@ -1,11 +1,12 @@
 <?php
 /**
  * Exception indicating wrong password given by user.
- * 
+ *
  * @author Thomas Graff <thomas.graff@uninett.no>
  * @package SimpleSAMLphp_base
  *
  */
-class SimpleSAML_Error_InvalidCredential extends SimpleSAML_Error_User{
-	
+class SimpleSAML_Error_InvalidCredential extends SimpleSAML_Error_User
+{
+
 }

--- a/lib/SimpleSAML/Error/MetadataNotFound.php
+++ b/lib/SimpleSAML/Error/MetadataNotFound.php
@@ -5,22 +5,23 @@
  *
  * @package SimpleSAMLphp
  */
-class SimpleSAML_Error_MetadataNotFound extends SimpleSAML_Error_Error {
+class SimpleSAML_Error_MetadataNotFound extends SimpleSAML_Error_Error
+{
 
 
-	/**
-	 * Create the error
-	 *
-	 * @param string $entityId  The entityID we were unable to locate.
-	 */
-	public function __construct($entityId) {
-		assert(is_string($entityId));
+    /**
+     * Create the error
+     *
+     * @param string $entityId  The entityID we were unable to locate.
+     */
+    public function __construct($entityId)
+    {
+        assert(is_string($entityId));
 
-		$this->includeTemplate = 'core:no_metadata.tpl.php';
-		parent::__construct(array(
-				'METADATANOTFOUND',
-				'%ENTITYID%' => htmlspecialchars(var_export($entityId, TRUE))
-		));
-	}
-
+        $this->includeTemplate = 'core:no_metadata.tpl.php';
+        parent::__construct(array(
+                'METADATANOTFOUND',
+                '%ENTITYID%' => htmlspecialchars(var_export($entityId, true))
+        ));
+    }
 }

--- a/lib/SimpleSAML/Error/NoPassive.php
+++ b/lib/SimpleSAML/Error/NoPassive.php
@@ -9,6 +9,7 @@
  *
  * @see \SimpleSAML\Module\saml\Error\NoPassive
  */
-class SimpleSAML_Error_NoPassive extends SimpleSAML_Error_Exception {
+class SimpleSAML_Error_NoPassive extends SimpleSAML_Error_Exception
+{
 
 }

--- a/lib/SimpleSAML/Error/NoState.php
+++ b/lib/SimpleSAML/Error/NoState.php
@@ -6,15 +6,16 @@
  *
  * @package SimpleSAMLphp
  */
-class SimpleSAML_Error_NoState extends SimpleSAML_Error_Error {
+class SimpleSAML_Error_NoState extends SimpleSAML_Error_Error
+{
 
 
-	/**
-	 * Create the error
-	 */
-	public function __construct() {
-		$this->includeTemplate = 'core:no_state.tpl.php';
-		parent::__construct('NOSTATE');
-	}
-
+    /**
+     * Create the error
+     */
+    public function __construct()
+    {
+        $this->includeTemplate = 'core:no_state.tpl.php';
+        parent::__construct('NOSTATE');
+    }
 }

--- a/lib/SimpleSAML/Error/NotFound.php
+++ b/lib/SimpleSAML/Error/NotFound.php
@@ -9,60 +9,64 @@
  * @author Olav Morken, UNINETT AS.
  * @package SimpleSAMLphp
  */
-class SimpleSAML_Error_NotFound extends SimpleSAML_Error_Error {
+class SimpleSAML_Error_NotFound extends SimpleSAML_Error_Error
+{
 
 
-	/**
-	 * Reason why the given page could not be found.
-	 */
-	private $reason;
+    /**
+     * Reason why the given page could not be found.
+     */
+    private $reason;
 
 
-	/**
-	 * Create a new NotFound error
-	 *
-	 * @param string $reason  Optional description of why the given page could not be found.
-	 */
-	public function __construct($reason = NULL) {
+    /**
+     * Create a new NotFound error
+     *
+     * @param string $reason  Optional description of why the given page could not be found.
+     */
+    public function __construct($reason = null)
+    {
 
-		assert($reason === null || is_string($reason));
+        assert($reason === null || is_string($reason));
 
-		$url = \SimpleSAML\Utils\HTTP::getSelfURL();
+        $url = \SimpleSAML\Utils\HTTP::getSelfURL();
 
-		if($reason === NULL) {
-			parent::__construct(array('NOTFOUND', '%URL%' => $url));
-			$this->message = "The requested page '$url' could not be found.";
-		} else {
-			parent::__construct(array('NOTFOUNDREASON', '%URL%' => $url, '%REASON%' => $reason));
-			$this->message = "The requested page '$url' could not be found. ".$reason;
-		}
+        if ($reason === null) {
+            parent::__construct(array('NOTFOUND', '%URL%' => $url));
+            $this->message = "The requested page '$url' could not be found.";
+        } else {
+            parent::__construct(array('NOTFOUNDREASON', '%URL%' => $url, '%REASON%' => $reason));
+            $this->message = "The requested page '$url' could not be found. ".$reason;
+        }
 
-		$this->reason = $reason;
-		$this->httpCode = 404;
-	}
-
-
-	/**
-	 * Retrieve the reason why the given page could not be found.
-	 *
-	 * @return string|NULL  The reason why the page could not be found.
-	 */
-	public function getReason() {
-		return $this->reason;
-	}
+        $this->reason = $reason;
+        $this->httpCode = 404;
+    }
 
 
-	/**
-	 * NotFound exceptions don't need to display a backtrace, as they are very simple and the trace is usually trivial,
-	 * so just log the message without any backtrace at all.
-	 *
-	 * @param bool $anonymize Whether to anonymize the trace or not.
-	 *
-	 * @return array
-	 */
-	public function format($anonymize = false) {
-		return array(
-			$this->getClass().': '.$this->getMessage(),
-		);
-	}
+    /**
+     * Retrieve the reason why the given page could not be found.
+     *
+     * @return string|null  The reason why the page could not be found.
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
+
+
+    /**
+     * NotFound exceptions don't need to display a backtrace, as they are very simple and the trace is usually trivial,
+     * so just log the message without any backtrace at all.
+     *
+     * @param bool $anonymize Whether to anonymize the trace or not.
+     *
+     * @return array
+     */
+    public function format($anonymize = false)
+    {
+        return array(
+            $this->getClass().': '.$this->getMessage(),
+        );
+    }
 }

--- a/lib/SimpleSAML/Error/ProxyCountExceeded.php
+++ b/lib/SimpleSAML/Error/ProxyCountExceeded.php
@@ -9,6 +9,7 @@
  *
  * @see \SimpleSAML\Module\saml\Error\ProxyCountExceeded
  */
-class SimpleSAML_Error_ProxyCountExceeded extends SimpleSAML_Error_Exception {
+class SimpleSAML_Error_ProxyCountExceeded extends SimpleSAML_Error_Exception
+{
 
 }

--- a/lib/SimpleSAML/Error/UnserializableException.php
+++ b/lib/SimpleSAML/Error/UnserializableException.php
@@ -12,44 +12,46 @@
  *
  * @package SimpleSAMLphp
  */
-class SimpleSAML_Error_UnserializableException extends SimpleSAML_Error_Exception {
+class SimpleSAML_Error_UnserializableException extends SimpleSAML_Error_Exception
+{
 
-	/**
-	 * The classname of the original exception.
-	 *
-	 * @var string
-	 */
-	private $class;
-
-
-	/**
-	 * Create a serializable exception representing an unserializable exception.
-	 *
-	 * @param Exception $original  The original exception.
-	 */
-	public function __construct(Exception $original) {
-
-		$this->class = get_class($original);
-		$msg = $original->getMessage();
-		$code = $original->getCode();
-
-		if (!is_int($code)) {
-			// PDOException uses a string as the code. Filter it out here.
-			$code = -1;
-		}
-
-		parent::__construct($msg, $code);
-		$this->initBacktrace($original);
-	}
+    /**
+     * The classname of the original exception.
+     *
+     * @var string
+     */
+    private $class;
 
 
-	/**
-	 * Retrieve the class of this exception.
-	 *
-	 * @return string  The classname.
-	 */
-	public function getClass() {
-		return $this->class;
-	}
+    /**
+     * Create a serializable exception representing an unserializable exception.
+     *
+     * @param Exception $original  The original exception.
+     */
+    public function __construct(Exception $original)
+    {
 
+        $this->class = get_class($original);
+        $msg = $original->getMessage();
+        $code = $original->getCode();
+
+        if (!is_int($code)) {
+            // PDOException uses a string as the code. Filter it out here.
+            $code = -1;
+        }
+
+        parent::__construct($msg, $code);
+        $this->initBacktrace($original);
+    }
+
+
+    /**
+     * Retrieve the class of this exception.
+     *
+     * @return string  The classname.
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
 }

--- a/lib/SimpleSAML/Error/User.php
+++ b/lib/SimpleSAML/Error/User.php
@@ -2,12 +2,13 @@
 
 /**
  * Baseclass for user error exceptions
- * 
- * 
+ *
+ *
  * @author Thomas Graff <thomas.graff@uninett.no>
  * @package SimpleSAMLphp_base
  *
  */
-class SimpleSAML_Error_User extends SimpleSAML_Error_Exception{
-	
+class SimpleSAML_Error_User extends SimpleSAML_Error_Exception
+{
+
 }

--- a/lib/SimpleSAML/Error/UserAborted.php
+++ b/lib/SimpleSAML/Error/UserAborted.php
@@ -5,15 +5,16 @@
  *
  * @package SimpleSAMLphp
  */
-class SimpleSAML_Error_UserAborted extends SimpleSAML_Error_Error {
+class SimpleSAML_Error_UserAborted extends SimpleSAML_Error_Error
+{
 
-	/**
-	 * Create the error
-	 *
-	 * @param Exception|NULL $cause  The exception that caused this error.
-	 */
-	public function __construct(Exception $cause = NULL) {
-		parent::__construct('USERABORTED', $cause);
-	}
-
+    /**
+     * Create the error
+     *
+     * @param Exception|null $cause  The exception that caused this error.
+     */
+    public function __construct(Exception $cause = null)
+    {
+        parent::__construct('USERABORTED', $cause);
+    }
 }

--- a/lib/SimpleSAML/Error/UserNotFound.php
+++ b/lib/SimpleSAML/Error/UserNotFound.php
@@ -2,11 +2,12 @@
 
 /**
  * Exception indicating user not found by authsource.
- * 
+ *
  * @author Thomas Graff <thomas.graff@uninett.no>
  * @package SimpleSAMLphp_base
  *
  */
-class SimpleSAML_Error_UserNotFound extends SimpleSAML_Error_User{
-	
+class SimpleSAML_Error_UserNotFound extends SimpleSAML_Error_User
+{
+
 }


### PR DESCRIPTION
For #458.

Accomplished via: `phpcbf -n --standard=PSR2 lib/SimpleSAML/Error/`