### PR TITLE
Fix missing translation for metarefresh

### DIFF
--- a/modules/metarefresh/dictionaries/metarefresh.definition.json
+++ b/modules/metarefresh/dictionaries/metarefresh.definition.json
@@ -1,0 +1,12 @@
+{
+    "frontpage_link": {
+        "en": "Metarefresh: fetch metadata"
+    },
+    "metarefresh_header": {
+        "en": "Metarefresh fetch"
+    },
+    "no_output": {
+        "en": "No output from metarefresh."
+    }
+}
+

--- a/modules/metarefresh/dictionaries/metarefresh.translation.json
+++ b/modules/metarefresh/dictionaries/metarefresh.translation.json
@@ -1,0 +1,9 @@
+{
+    "frontpage_link": {
+    },
+    "metarefresh_header": {
+    },
+    "no_output": {
+    }
+}
+

--- a/modules/metarefresh/hooks/hook_frontpage.php
+++ b/modules/metarefresh/hooks/hook_frontpage.php
@@ -10,7 +10,7 @@ function metarefresh_hook_frontpage(&$links) {
 
 	$links['federation'][] = array(
 		'href' => SimpleSAML\Module::getModuleURL('metarefresh/fetch.php'),
-		'text' => array('en' => 'Metarefresh: fetch metadata'),
+		'text' => '{metarefresh:metarefresh:frontpage_link}',
 	);
 
 }

--- a/modules/metarefresh/templates/fetch.tpl.php
+++ b/modules/metarefresh/templates/fetch.tpl.php
@@ -1,20 +1,20 @@
 <?php
-$this->data['header'] = $this->t('{aggregator:aggregator:aggregator_header}');
+$this->data['header'] = $this->t('{metarefresh:metarefresh:metarefresh_header}');
 $this->includeAtTemplateBase('includes/header.php');
 
-echo('<h1>Metarefresh fetch</h1>');
+echo('<h1>'.$this->data['header'].'</h1>');
 
 
 if (!empty($this->data['logentries'])) {
-	
+
 	echo '<pre style="border: 1px solid #aaa; padding: .5em; overflow: scroll">';
 	foreach($this->data['logentries'] AS $l) {
-		echo $l . "\n";		
+		echo $l . "\n";
 	}
 	echo '</pre>';
-	
+
 } else {
-	echo 'No output from metarefresh.';
+	echo $this->t('{metarefresh:metarefresh:no_output}');
 }
 
 


### PR DESCRIPTION
Metarefresh had an inadvertent dependency on the translation files for the aggregator module that was removed in v1.15, resulting in a "not translated" error. 

This patch removes that dependency and provides the basis for the rest of the module to be translated. I have deliberately not ported the existing translations from the aggregator module as they set the header of metarefresh to "Aggregator", which in hindsight seems wrong to start with.


