### PR TITLE
Updated config.php template to include comma after baseURL

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -48,7 +48,7 @@ $config = array(
          * need to compute the right URLs yourself and pass them dynamically
          * to SimpleSAMLphp's API.
          */
-        //'baseURL' => 'https://example.com'
+        //'baseURL' => 'https://example.com',
     //),
 
     /*


### PR DESCRIPTION
This is minor, but if a comma is required when this is enabled the template should reflect that.