### PR TITLE
Presence and value of HTTP_X_FORWARDED_PROTO

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -83,6 +83,11 @@ class HTTP
      */
     public static function getServerHTTPS()
     {
+        if ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+            // if behind an SSL-offloading reverse proxy
+            return true;
+        }
+
         if (!array_key_exists('HTTPS', $_SERVER)) {
             // not an https-request
             return false;


### PR DESCRIPTION
Consider that the server behind a a ssl-offloading reverse proxy is truly secure.
En consequence, that makes valid calls for the curl's cron against http://127.0.0.1 while the cookies are secured.