### PR TITLE
Support metadataxml in config

### DIFF
--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
@@ -55,7 +55,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerXML extends SimpleSAML_Metadata_
         if(isset($src)) {
             $entities = SimpleSAML_Metadata_SAMLParser::parseDescriptorsFile($src);
         } elseif(isset($srcXml)) {
-            $entities = SimpleSAML_Metadata_SAMLParser::parseDescriptorsString($srcXML);
+            $entities = SimpleSAML_Metadata_SAMLParser::parseDescriptorsString($srcXml);
         } else {
             throw new Exception("Neither source file path/URI nor string data provided");
         }

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
@@ -32,11 +32,10 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerXML extends SimpleSAML_Metadata_
      */
     protected function __construct($config)
     {
-        // get the configuration
-        $globalConfig = SimpleSAML_Configuration::getInstance();
-
         $src = $srcXml = null;
         if (array_key_exists('file', $config)) {
+            // get the configuration
+            $globalConfig = SimpleSAML_Configuration::getInstance();
             $src = $globalConfig->resolvePath($config['file']);
         } elseif (array_key_exists('url', $config)) {
             $src = $config['url'];

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
@@ -35,12 +35,15 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerXML extends SimpleSAML_Metadata_
         // get the configuration
         $globalConfig = SimpleSAML_Configuration::getInstance();
 
+        $src = $srcXml = null;
         if (array_key_exists('file', $config)) {
             $src = $globalConfig->resolvePath($config['file']);
         } elseif (array_key_exists('url', $config)) {
             $src = $config['url'];
+        } elseif (array_key_exists('xml', $config)) {
+            $srcXml = $config['xml'];
         } else {
-            throw new Exception("Missing either 'file' or 'url' in XML metadata source configuration.");
+            throw new Exception("Missing one of 'file', 'url' and 'xml' in XML metadata source configuration.");
         }
 
 
@@ -50,7 +53,13 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerXML extends SimpleSAML_Metadata_
         $IdP20 = array();
         $AAD = array();
 
-        $entities = SimpleSAML_Metadata_SAMLParser::parseDescriptorsFile($src);
+        if(isset($src)) {
+            $entities = SimpleSAML_Metadata_SAMLParser::parseDescriptorsFile($src);
+        } elseif(isset($srcXml)) {
+            $entities = SimpleSAML_Metadata_SAMLParser::parseDescriptorsString($srcXML);
+        } else {
+            throw new Exception("Neither source file path/URI nor string data provided");
+        }
         foreach ($entities as $entityId => $entity) {
 
             $md = $entity->getMetadata1xSP();

--- a/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
+++ b/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
@@ -39,18 +39,18 @@ ServiceDisplayName=\"SimpleSAMLphp Test\"
 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
 xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">
 <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
-<SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/sso/\"/>
+<SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/sso/\"/>
 <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/logout/\"/>
 </RoleDescriptor>
+<IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"/>
 </EntityDescriptor>
 ";
         // The primary test here is that - in contrast to the others above - this loads without error
         // As a secondary thing, check that the entity ID from the static source provided can be extracted
         $source = SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "xml"=>$strTestXML]);
-        $expMetadata = $source->getMetadataSet($testEntityId);
-        $this->assertNotEmpty($expMetadata, "Did not extract expected entity ID from static XML source");
+        $idpSet = $source->getMetadataSet("saml20-idp-remote");
+        $this->assertArrayHasKey($testEntityId, $idpSet,  "Did not extract expected IdP entity ID from static XML source");
 	// Finally verify that a different entity ID does not get loaded
-        $unexpMetadata = $source->getMetadataSet("https://not.the.same.idp/entityid");
-        $this->assertEmpty($unexpMetadata, "Unexpectedly got metadata for an alternate entity than that defined");
+        $this->assertCount(1, $idpSet, "Unexpectedly got metadata for an alternate entity than that defined");
     }
 }

--- a/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
+++ b/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
@@ -43,6 +43,10 @@ xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">
 </RoleDescriptor>
 </EntityDescriptor>
 ";
-        SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "xml"=>$strTestXML]);
+        // The primary test here is that - in contrast to the others above - this loads without error
+        // As a secondary thing, check that the entity ID matches the static source provided and isn't coming from elsewheree
+        $source = SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "xml"=>$strTestXML]);
+        $idpEntityId = $source->getEntityId();
+        $this->assertEquals("https://saml.idp/entityid", $idpEntityId, "Did not extract expected entity ID from static XML source");
     }
 }

--- a/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
+++ b/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+
+/**
+ * Class SimpleSAML_Metadata_MetaDataStorageSourceTest
+ */
+class SimpleSAML_Metadata_MetaDataStorageSourceTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test SimpleSAML_Metadata_MetaDataStorageSourceTest::getConfig XML bad source
+     * @expectedException Exception
+     */
+    public function testBadXMLSource() {
+        SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "foo"=>"baa"]);
+   }
+
+    /**
+     * Test SimpleSAML_Metadata_MetaDataStorageSourceTest::getConfig XML static XML source
+     */
+    public function testStaticXMLSource() {
+        $strTestXML = "
+<EntityDescriptor ID=\"_12345678-90ab-cdef-1234-567890abcdef\" entityID=\"https://saml.idp/entityid\" xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">
+<RoleDescriptor xsi:type=\"fed:ApplicationServiceType\"
+protocolSupportEnumeration=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512 http://schemas.xmlsoap.org/ws/2005/02/trust http://docs.oasis-open.org/wsfed/federation/200706\"
+ServiceDisplayName=\"SimpleSAMLphp Test\"
+xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">
+<NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+<SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/sso/\"/>
+<SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/logout/"/>
+</RoleDescriptor>
+</EntityDescriptor>
+";
+        SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "xml"=>$strTestXML]);
+    }
+}

--- a/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
+++ b/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
@@ -12,7 +12,19 @@ class SimpleSAML_Metadata_MetaDataStorageSourceTest extends PHPUnit_Framework_Te
      */
     public function testBadXMLSource() {
         SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "foo"=>"baa"]);
-   }
+    }
+
+    /**
+     * Test SimpleSAML_Metadata_MetaDataStorageSourceTest::getConfig invalid static XML source
+     * @expectedException Exception
+     */
+    public function testInvalidStaticXMLSource() {
+        $strTestXML = "
+<EntityDescriptor ID=\"_12345678-90ab-cdef-1234-567890abcdef\" entityID=\"https://saml.idp/entityid\" xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">
+</EntityDescriptor>
+";
+        SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "xml"=>$strTestXML]);
+    }
 
     /**
      * Test SimpleSAML_Metadata_MetaDataStorageSourceTest::getConfig XML static XML source

--- a/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
+++ b/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
@@ -39,7 +39,7 @@ xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
 xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">
 <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
 <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/sso/\"/>
-<SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/logout/"/>
+<SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://saml.idp/logout/\"/>
 </RoleDescriptor>
 </EntityDescriptor>
 ";

--- a/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
+++ b/tests/lib/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
@@ -30,8 +30,9 @@ class SimpleSAML_Metadata_MetaDataStorageSourceTest extends PHPUnit_Framework_Te
      * Test SimpleSAML_Metadata_MetaDataStorageSourceTest::getConfig XML static XML source
      */
     public function testStaticXMLSource() {
+        $testEntityId = "https://saml.idp/entityid";
         $strTestXML = "
-<EntityDescriptor ID=\"_12345678-90ab-cdef-1234-567890abcdef\" entityID=\"https://saml.idp/entityid\" xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">
+<EntityDescriptor ID=\"_12345678-90ab-cdef-1234-567890abcdef\" entityID=\"$testEntityId\" xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">
 <RoleDescriptor xsi:type=\"fed:ApplicationServiceType\"
 protocolSupportEnumeration=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512 http://schemas.xmlsoap.org/ws/2005/02/trust http://docs.oasis-open.org/wsfed/federation/200706\"
 ServiceDisplayName=\"SimpleSAMLphp Test\"
@@ -44,9 +45,12 @@ xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">
 </EntityDescriptor>
 ";
         // The primary test here is that - in contrast to the others above - this loads without error
-        // As a secondary thing, check that the entity ID matches the static source provided and isn't coming from elsewheree
+        // As a secondary thing, check that the entity ID from the static source provided can be extracted
         $source = SimpleSAML_Metadata_MetaDataStorageSource::getSource(["type"=>"xml", "xml"=>$strTestXML]);
-        $idpEntityId = $source->getEntityId();
-        $this->assertEquals("https://saml.idp/entityid", $idpEntityId, "Did not extract expected entity ID from static XML source");
+        $expMetadata = $source->getMetadataSet($testEntityId);
+        $this->assertNotEmpty($expMetadata, "Did not extract expected entity ID from static XML source");
+	// Finally verify that a different entity ID does not get loaded
+        $unexpMetadata = $source->getMetadataSet("https://not.the.same.idp/entityid");
+        $this->assertEmpty($unexpMetadata, "Unexpectedly got metadata for an alternate entity than that defined");
     }
 }


### PR DESCRIPTION
Make the XML metadata storage source support loading from a supplied XML string, rather than necessarily opening/fetching a file.
Useful when generating configuration dynamically, as it allows the XML to be passed at that point, rather than having another abstraction to load it.