### PR TITLE
[FIX] ms-ds-consistencyguid need also to be Base64 encode

### DIFF
--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -569,7 +569,7 @@ class SimpleSAML_Auth_LDAP
                 }
 
                 // Base64 encode binary attributes
-                if (strtolower($name) === 'jpegphoto' || strtolower($name) === 'objectguid') {
+                if (strtolower($name) === 'jpegphoto' || strtolower($name) === 'objectguid' || strtolower($name) === 'ms-ds-consistencyguid') {
                     $values[] = base64_encode($value);
                 } else {
                     $values[] = $value;


### PR DESCRIPTION
In case of ADAzure synchronization, the main attribute used is ms-ds-consistencyguid.
It need to be Base64 encode.