### PR TITLE
Fix count slave checking

### DIFF
--- a/lib/SimpleSAML/Database.php
+++ b/lib/SimpleSAML/Database.php
@@ -90,18 +90,16 @@ class Database
 
         // connect to any configured slaves
         $slaves = $config->getArray('database.slaves', array());
-        if (count($slaves >= 1)) {
-            foreach ($slaves as $slave) {
-                array_push(
-                    $this->dbSlaves,
-                    $this->connect(
-                        $slave['dsn'],
-                        $slave['username'],
-                        $slave['password'],
-                        $driverOptions
-                    )
-                );
-            }
+        foreach ($slaves as $slave) {
+            array_push(
+                $this->dbSlaves,
+                $this->connect(
+                    $slave['dsn'],
+                    $slave['username'],
+                    $slave['password'],
+                    $driverOptions
+                )
+            );
         }
 
         $this->tablePrefix = $config->getString('database.prefix', '');


### PR DESCRIPTION
The use of count function is wrong and unnecessary. 

```
if (count($slaves >= 1)) {
```
should be

```
if (count($slaves) >= 1) {
```

In PHP7.2 this cause an error because `count` check than the parameter must be a `Countable` object or an array.

Anyway, if the array is empty the foreach loop will not run so I remove it.