### PR TITLE
Missing SubjectConfirmationData must not break validation

### DIFF
--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -739,8 +739,8 @@ class sspmod_saml_Message
 
             // if no SubjectConfirmationData then don't do anything.
             if ($scd === null) {
-                $lastError = 'No SubjectConfirmationData provided';
-                continue;
+                $found = true;
+                break;
             }
 
             if ($scd->NotBefore && $scd->NotBefore > time() + 60) {


### PR DESCRIPTION
SubjectConfirmationData is optional , but must not break validation if absent!