### PR TITLE
Log requesterid instead of entityid for stats

### DIFF
--- a/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
+++ b/modules/core/lib/Auth/Process/StatisticsWithAttribute.php
@@ -88,7 +88,11 @@ class StatisticsWithAttribute extends \SimpleSAML\Auth\ProcessingFilter
         }
 
         $source = $this->setIdentifier('Source', $state);
-        $dest = $this->setIdentifier('Destination', $state);
+        if (array_key_exists('saml:RequesterID', $state) && !empty($state['saml:RequesterID'])) {
+            $dest = $state['saml:RequesterID'][0];
+        } else {
+            $dest = $this->setIdentifier('Destination', $state);
+        }
 
         if (!array_key_exists('PreviousSSOTimestamp', $state)) {
             // The user hasn't authenticated with this SP earlier in this session


### PR DESCRIPTION
When it comes to statistics, I'd like to now the number of logins per originating SP, instead of per SP-proxy...