### PR TITLE
ldap: fix groupname-setting in AttributeAddUsersGroups

### DIFF
--- a/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
+++ b/modules/ldap/lib/Auth/Process/AttributeAddUsersGroups.php
@@ -178,6 +178,14 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
 			' Group Type: ' . $this->type_map['group']
 		);
 
+		// Work out what attributes to get for a group
+		$use_group_name = FALSE;
+		$get_attributes = array($map['memberof'], $map['type']);
+		if (isset($map['name']) && $map['name']) {
+			$get_attributes[] = $map['name'];
+			$use_group_name = TRUE;
+		}
+
 		// Check each DN of the passed memberOf
 		foreach ($memberof as $dn) {
 
@@ -192,7 +200,7 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
 
 			// Query LDAP for the attribute values for the DN
 			try {
-				$attributes = $this->getLdap()->getAttributes($dn, array($map['memberof'], $map['type']));
+				$attributes = $this->getLdap()->getAttributes($dn, $get_attributes);
 			} catch (SimpleSAML_Error_AuthSource $e) {
 				continue; // DN must not exist, just continue. Logged by the LDAP object
 			}
@@ -203,7 +211,11 @@ class sspmod_ldap_Auth_Process_AttributeAddUsersGroups extends sspmod_ldap_Auth_
 			}
 
 			// Add to found groups array
-			$groups[] = $dn;
+			if ($use_group_name && isset($attributes[$map['name']]) && is_array($attributes[$map['name']])) {
+				$groups[] = $attributes[$map['name']][0];
+			} else {
+				$groups[] = $dn;
+			}
 
 			// Recursively search "sub" groups
 			$groups = array_merge($groups, $this->search($attributes[$map['memberof']]));


### PR DESCRIPTION
Fixes https://github.com/simplesamlphp/simplesamlphp/issues/482

If attribute.groupname is set in the module configuration use the configured attribute as the group name. The setting wasn't used at all...