### PR TITLE
Make sure that session is closed and only then update cookie params

### DIFF
--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -343,6 +343,11 @@ class SessionHandlerPHP extends SessionHandler
             );
         }
 
+        if (session_id() !== '') {
+            // session already started, close it
+            session_write_close();
+        }
+
         session_set_cookie_params(
             $cookieParams['lifetime'],
             $cookieParams['path'],
@@ -350,11 +355,6 @@ class SessionHandlerPHP extends SessionHandler
             $cookieParams['secure'],
             $cookieParams['httponly']
         );
-
-        if (session_id() !== '') {
-            // session already started, close it
-            session_write_close();
-        }
 
         session_id($sessionID);
         $this->sessionStart();


### PR DESCRIPTION
As mentioned by @iamtankist in #793 , there is a potential problem if you are trying to update cookie parameters having an active session(https://secure.php.net/session_set_cookie_params) 

There are not much to do for a fix - I just put the call to `session_set_cookie_params` right after closing the previous session, not before as it was