### PR TITLE
Fixes cardinality auth filter unit tests (#860)

### DIFF
--- a/lib/SimpleSAML/Utils/HttpAdapter.php
+++ b/lib/SimpleSAML/Utils/HttpAdapter.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace SimpleSAML\Utils;
+
+/**
+ * Provides a non-static wrapper for the HTTP utility class.
+ *
+ * @package SimpleSAML\Utils
+ */
+class HttpAdapter
+{
+    /**
+     * @see HTTP::getServerHTTPS()
+     */
+    public function getServerHTTPS()
+    {
+        return HTTP::getServerHTTPS();
+    }
+
+    /**
+     * @see HTTP::getServerPort()
+     */
+    public function getServerPort()
+    {
+        return HTTP::getServerPort();
+    }
+
+    /**
+     * @see HTTP::addURLParameters()
+     */
+    public function addURLParameters($url, $parameters)
+    {
+        return HTTP::addURLParameters($url, $parameters);
+    }
+
+    /**
+     * @see HTTP::checkSessionCookie()
+     */
+    public function checkSessionCookie($retryURL = null)
+    {
+        HTTP::checkSessionCookie($retryURL);
+    }
+
+    /**
+     * @see HTTP::checkURLAllowed()
+     */
+    public function checkURLAllowed($url, array $trustedSites = null)
+    {
+        return HTTP::checkURLAllowed($url, $trustedSites);
+    }
+
+    /**
+     * @see HTTP::fetch()
+     */
+    public function fetch($url, $context = array(), $getHeaders = false)
+    {
+        return HTTP::fetch($url, $context, $getHeaders);
+    }
+
+    /**
+     * @see HTTP::getAcceptLanguage()
+     */
+    public function getAcceptLanguage()
+    {
+        return HTTP::getAcceptLanguage();
+    }
+
+    /**
+     * @see HTTP::guessBasePath()
+     */
+    public function guessBasePath()
+    {
+        return HTTP::guessBasePath();
+    }
+
+    /**
+     * @see HTTP::getBaseURL()
+     */
+    public function getBaseURL()
+    {
+        return HTTP::getBaseURL();
+    }
+
+    /**
+     * @see HTTP::getFirstPathElement()
+     */
+    public function getFirstPathElement($trailingslash = true)
+    {
+        return HTTP::getFirstPathElement($trailingslash);
+    }
+
+    /**
+     * @see HTTP::getPOSTRedirectURL()
+     */
+    public function getPOSTRedirectURL($destination, $data)
+    {
+        return HTTP::getPOSTRedirectURL($destination, $data);
+    }
+
+    /**
+     * @see HTTP::getSelfHost()
+     */
+    public function getSelfHost()
+    {
+        return HTTP::getSelfHost();
+    }
+
+    /**
+     * @see HTTP::getSelfHostWithNonStandardPort()
+     */
+    public function getSelfHostWithNonStandardPort()
+    {
+        return HTTP::getSelfHostWithNonStandardPort();
+    }
+
+    /**
+     * @see HTTP::getSelfHostWithPath()
+     */
+    public function getSelfHostWithPath()
+    {
+        return HTTP::getSelfHostWithPath();
+    }
+
+    /**
+     * @see HTTP::getSelfURL()
+     */
+    public function getSelfURL()
+    {
+        return HTTP::getSelfURL();
+    }
+
+    /**
+     * @see HTTP::getSelfURLHost()
+     */
+    public function getSelfURLHost()
+    {
+        return HTTP::getSelfURLHost();
+    }
+
+    /**
+     * @see HTTP::getSelfURLNoQuery()
+     */
+    public function getSelfURLNoQuery()
+    {
+        return HTTP::getSelfURLNoQuery();
+    }
+
+    /**
+     * @see HTTP::isHTTPS()
+     */
+    public function isHTTPS()
+    {
+        return HTTP::isHTTPS();
+    }
+
+    /**
+     * @see HTTP::normalizeURL()
+     */
+    public function normalizeURL($url)
+    {
+        return HTTP::normalizeURL($url);
+    }
+
+    /**
+     * @see HTTP::parseQueryString()
+     */
+    public function parseQueryString($query_string)
+    {
+        return HTTP::parseQueryString($query_string);
+    }
+
+    /**
+     * @see HTTP::redirectTrustedURL()
+     */
+    public function redirectTrustedURL($url, $parameters = array())
+    {
+        HTTP::redirectTrustedURL($url, $parameters);
+    }
+
+    /**
+     * @see HTTP::redirectUntrustedURL()
+     */
+    public function redirectUntrustedURL($url, $parameters = array())
+    {
+        HTTP::redirectUntrustedURL($url, $parameters);
+    }
+
+    /**
+     * @see HTTP::resolveURL()
+     */
+    public function resolveURL($url, $base = null)
+    {
+        return HTTP::resolveURL($url, $base);
+    }
+
+    /**
+     * @see HTTP::setCookie()
+     */
+    public function setCookie($name, $value, $params = null, $throw = true)
+    {
+        HTTP::setCookie($name, $value, $params, $throw);
+    }
+
+    /**
+     * @see HTTP::submitPOSTData()
+     */
+    public function submitPOSTData($destination, $data)
+    {
+        HTTP::submitPOSTData($destination, $data);
+    }
+}

--- a/modules/core/lib/Auth/Process/Cardinality.php
+++ b/modules/core/lib/Auth/Process/Cardinality.php
@@ -1,5 +1,7 @@
 <?php
 
+use SimpleSAML\Utils\HTTPAdapter;
+
 /**
  * Filter to ensure correct cardinality of attributes
  *
@@ -14,17 +16,23 @@ class sspmod_core_Auth_Process_Cardinality extends SimpleSAML_Auth_ProcessingFil
     /** @var array Entities that should be ignored */
     private $ignoreEntities = array();
 
+    /** @var HTTP */
+    private $http;
+
     /**
      * Initialize this filter, parse configuration.
      *
      * @param array $config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @param HTTPAdapter $http  HTTP utility service (handles redirects).
      * @throws SimpleSAML_Error_Exception
      */
-    public function __construct($config, $reserved)
+    public function __construct($config, $reserved, HTTPAdapter $http = null)
     {
         parent::__construct($config, $reserved);
         assert(is_array($config));
+
+        $this->http = $http ?: new HTTPAdapter();
 
         foreach ($config as $attribute => $rules) {
             if ($attribute === '%ignoreEntities') {
@@ -157,7 +165,7 @@ class sspmod_core_Auth_Process_Cardinality extends SimpleSAML_Auth_ProcessingFil
         if (array_key_exists('core:cardinality:errorAttributes', $request)) {
             $id = SimpleSAML_Auth_State::saveState($request, 'core:cardinality');
             $url = SimpleSAML\Module::getModuleURL('core/cardinality_error.php');
-            \SimpleSAML\Utils\HTTP::redirectTrustedURL($url, array('StateId' => $id));
+            $this->http->redirectTrustedURL($url, array('StateId' => $id));
             return;
         }
     }

--- a/modules/core/lib/Auth/Process/CardinalitySingle.php
+++ b/modules/core/lib/Auth/Process/CardinalitySingle.php
@@ -1,5 +1,7 @@
 <?php
 
+use SimpleSAML\Utils\HttpAdapter;
+
 /**
  * Filter to ensure correct cardinality of single-valued attributes
  *
@@ -26,16 +28,22 @@ class sspmod_core_Auth_Process_CardinalitySingle extends SimpleSAML_Auth_Process
     /** @var array Entities that should be ignored */
     private $ignoreEntities = array();
 
+    /** @var HTTP */
+    private $http;
+
     /**
      * Initialize this filter, parse configuration.
      *
      * @param array $config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @param HTTPAdapter $http  HTTP utility service (handles redirects).
      */
-    public function __construct($config, $reserved)
+    public function __construct($config, $reserved, HTTPAdapter $http = null)
     {
         parent::__construct($config, $reserved);
         assert(is_array($config));
+
+        $this->http = $http ?: new HTTPAdapter();
 
         if (array_key_exists('singleValued', $config)) {
             $this->singleValued = $config['singleValued'];
@@ -102,7 +110,7 @@ class sspmod_core_Auth_Process_CardinalitySingle extends SimpleSAML_Auth_Process
         if (array_key_exists('core:cardinality:errorAttributes', $request)) {
             $id = SimpleSAML_Auth_State::saveState($request, 'core:cardinality');
             $url = SimpleSAML\Module::getModuleURL('core/cardinality_error.php');
-            \SimpleSAML\Utils\HTTP::redirectTrustedURL($url, array('StateId' => $id));
+            $this->http->redirectTrustedURL($url, array('StateId' => $id));
             return;
         }
     }

--- a/tools/phpunit/phpunit.xml
+++ b/tools/phpunit/phpunit.xml
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./../../vendor/</directory>
                 <directory>./../../tests/</directory>
+                <file>./../../lib/SimpleSAML/Utils/HttpAdapter.php</file>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
This fixes the unit tests for the Cardinality/CardinalitySingle auth process filters.

The intention is to assert that certain requests result in a redirect.  In order to do this, we need to mock the HTTP helper class, and in order to do that we need to create a non-static HTTP wrapper which we can inject into the cardinality filter instances.