### PR TITLE
Improve MetaDataStorageHandlerPdo::getMetaData() performance

### DIFF
--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -153,8 +153,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
      */
     public function getMetaData($entityId, $set)      
     {       
-        assert('is_string($entityId)');
-        assert('is_string($set)');
+        assert(is_string($entityId));
+        assert(is_string($set));
 
         $tableName = $this->getTableName($set);
 

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -168,7 +168,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
 
             while ($d = $stmt->fetch()) {
                 if (++$rowCount > 1) {
-                    SimpleSAML\Logger::warning("Dulicate match for $entityId in set $set");
+                    SimpleSAML\Logger::warning("Duplicate match for $entityId in set $set");
                     break;
                 }
                 $data = json_decode($d['entity_data'], true);

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -168,8 +168,8 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerPdo extends SimpleSAML_Metadata_
 
             while ($d = $stmt->fetch()) {
                 if (++$rowCount > 1) {
-		    SimpleSAML\Logger::warning("Dulicate match for $entityId in set $set");
-		    break;
+                    SimpleSAML\Logger::warning("Dulicate match for $entityId in set $set");
+                    break;
                 }
                 $data = json_decode($d['entity_data'], true);
                 if ($data === null) {


### PR DESCRIPTION
By using an appropriate WHERE clause in the SQL statement,
we can avoid loading the whole dataset in getMetaData(),
which brings an welcome performance improvement with large
Metadata sets.