### PR TITLE
consentAdmin: Add attributes.exclude option to correspond with the Consent module

### DIFF
--- a/modules/consent/docs/consent.md
+++ b/modules/consent/docs/consent.md
@@ -160,7 +160,7 @@ The following options can be used when configuring the Consent module:
     the attributes that should have their value hidden. Default behaviour is that 
     all attribute values are shown.
 
-`noconsentattributes`
+`attributes.exclude`
 :   Allows certain attributes to be excluded from the attribute hash when
     `includeValues` is `true` (and as a side effect, to be hidden from display
     as `hiddenAttributes` does). Set to an array of the attributes that should

--- a/modules/consent/docs/consent.md
+++ b/modules/consent/docs/consent.md
@@ -160,9 +160,15 @@ The following options can be used when configuring the Consent module:
     the attributes that should have their value hidden. Default behaviour is that 
     all attribute values are shown.
 
+`noconsentattributes`
+:   Allows certain attributes to be excluded from the attribute hash when
+    `includeValues` is `true` (and as a side effect, to be hidden from display
+    as `hiddenAttributes` does). Set to an array of the attributes that should
+    be excluded. Default behaviour is to include all values in the hash.
+
 `showNoConsentAboutService`
 :   Whether we will show a link to more information about the service from the
-    no consent page. Defaults to `TRUE`.
+    no consent page. Defaults to `true`.
 
 External options
 ----------------

--- a/modules/consent/lib/Auth/Process/Consent.php
+++ b/modules/consent/lib/Auth/Process/Consent.php
@@ -116,7 +116,15 @@ class sspmod_consent_Auth_Process_Consent extends SimpleSAML_Auth_ProcessingFilt
             $this->_hiddenAttributes = $config['hiddenAttributes'];
         }
 
-        if (array_key_exists('noconsentattributes', $config)) {
+        if (array_key_exists('attributes.exclude', $config)) {
+            if (!is_array($config['attributes.exclude'])) {
+                throw new SimpleSAML_Error_Exception(
+                    'Consent: attributes.exclude must be an array. '.
+                    var_export($config['attributes.exclude'], true).' given.'
+                );
+            }
+        } elseif (array_key_exists('noconsentattributes', $config)) {
+            SimpleSAML\Logger::warning("The 'noconsentattributes' option has been deprecated in favour of 'attributes.exclude'.");
             if (!is_array($config['noconsentattributes'])) {
                 throw new SimpleSAML_Error_Exception(
                     'Consent: noconsentattributes must be an array. '.

--- a/modules/consentAdmin/config-templates/module_consentAdmin.php
+++ b/modules/consentAdmin/config-templates/module_consentAdmin.php
@@ -6,23 +6,23 @@
  * @package SimpleSAMLphp
  */
 $config = array(
-	/*
-	 * Configuration for the database connection.
-	 */
-	'consentadmin'  => array(
-		'consent:Database',
-		'dsn'		=>	'mysql:host=DBHOST;dbname=DBNAME',
-		'username'	=>	'USERNAME', 
-		'password'	=>	'PASSWORD',
-	),
-	
-	// Hash attributes including values or not
-	'attributes.hash' => TRUE,
+    /*
+     * Configuration for the database connection.
+     */
+    'consentadmin'  => array(
+        'consent:Database',
+        'dsn'       =>  'mysql:host=DBHOST;dbname=DBNAME',
+        'username'  =>  'USERNAME',
+        'password'  =>  'PASSWORD',
+    ),
 
-	// Where to direct the user after logout
-    // REMEMBER to prefix with http:// otherwise the relaystate is only appended 
+    // Hash attributes including values or not
+    'attributes.hash' => true,
+
+    // Where to direct the user after logout
+    // REMEMBER to prefix with http:// otherwise the relaystate is only appended
     // to saml2 logout URL
-	'returnURL' => 'http://www.wayf.dk',
+    'returnURL' => 'http://www.wayf.dk',
 
     // Shows description of the services if set to true (defaults to true)
     'showDescription' => true,

--- a/modules/consentAdmin/config-templates/module_consentAdmin.php
+++ b/modules/consentAdmin/config-templates/module_consentAdmin.php
@@ -19,6 +19,9 @@ $config = array(
     // Hash attributes including values or not
     'attributes.hash' => true,
 
+    // If you set noconsentattributes in the consent module, this must match
+    // 'attributes.exclude' => array(),
+
     // Where to direct the user after logout
     // REMEMBER to prefix with http:// otherwise the relaystate is only appended
     // to saml2 logout URL

--- a/modules/consentAdmin/config-templates/module_consentAdmin.php
+++ b/modules/consentAdmin/config-templates/module_consentAdmin.php
@@ -19,7 +19,7 @@ $config = array(
     // Hash attributes including values or not
     'attributes.hash' => true,
 
-    // If you set noconsentattributes in the consent module, this must match
+    // If you set attributes.exclude in the consent module, this must match
     // 'attributes.exclude' => array(),
 
     // Where to direct the user after logout

--- a/modules/consentAdmin/docs/consentAdmin.md
+++ b/modules/consentAdmin/docs/consentAdmin.md
@@ -44,7 +44,9 @@ Setting optional parameters
 In order to make the consentAdmin module work together with the consent
 module correctly, you need to set the configuration 'attributes.hash'
 according to the value of 'includeValues' configuration in the consent
-module.
+module. Likewise, if you've used the 'noconsentattributes' configuration
+option in the consent module, you should also set the 'attributes.exclude'
+configuration option here to match.
 
 You should also set the 'returnURL' configuration in order to pass on your
 users when the press the 'Logout' link.

--- a/modules/consentAdmin/docs/consentAdmin.md
+++ b/modules/consentAdmin/docs/consentAdmin.md
@@ -44,7 +44,7 @@ Setting optional parameters
 In order to make the consentAdmin module work together with the consent
 module correctly, you need to set the configuration 'attributes.hash'
 according to the value of 'includeValues' configuration in the consent
-module. Likewise, if you've used the 'noconsentattributes' configuration
+module. Likewise, if you've used the 'attributes.exclude' configuration
 option in the consent module, you should also set the 'attributes.exclude'
 configuration option here to match.
 


### PR DESCRIPTION
The consent:Consent authproc filter has a (currently undocumented) noconsentattributes option that allows specified attributes to be removed from the consent hash calculation. This has no corresponding option in the consentAdmin module, so using the noconsentattribute option to remove attributes means the consentAdmin module will always show this as attribute values having been changed.

This patch changes that behaviour by adding a new 'attributes.exclude' configuration option in consentAdmin, that allows people to specify attributes that should not be used for hash calculation and match their corresponding option in consent:Consent. It also deprecates the noconsentattributes option in consent:Consent, replacing it with a similarly named 'attributes.exclude' option.

The default behaviour of the consentAdmin module should be unchanged for anyone who doesn't explicitly update their configuration.

Closes: #531 - this pull request is effectively a rebase of #531 which has got corrupted over time.