### PR TITLE
Updated Dutch Translation (Spelling mistake table_caption)

### DIFF
--- a/modules/consent/dictionaries/consent.translation.json
+++ b/modules/consent/dictionaries/consent.translation.json
@@ -640,7 +640,7 @@
 		"sv": "Anv\u00e4ndarinformation",
 		"es": "Informaci\u00f3n del usuario",
 		"de": "Benutzerdaten",
-		"nl": "Gerbuikersinformatie",
+		"nl": "Gebruikersinformatie",
 		"sl": "Podatki o uporabniku",
 		"da": "Bruger information",
 		"hu": "Felhaszn\u00e1l\u00f3i inform\u00e1ci\u00f3k",


### PR DESCRIPTION
Small spelling mistake in consent module.

"Gerbuikersinformatie" to "Gebruikersinformatie"