### PR TITLE
Getting Signature algorithm from SP and overriding default SHA256

### DIFF
--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -199,7 +199,7 @@ class Message
 
         $lastException = null;
         foreach ($pemKeys as $i => $pem) {
-            $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
+            $key = new XMLSecurityKey($element->getSignatureMethod() ? $element->getSignatureMethod() : XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
             $key->loadKey($pem);
 
             try {


### PR DESCRIPTION
XMLSecurityKey::RSA_SHA256 algorithm is hardcoded in current master for SP signature verification. Got a case when SP sends RSA1 in response and it fails. 