### PR TITLE
Improve documentation for cardinality authproc filter

### DIFF
--- a/docs/simplesamlphp-authproc.md
+++ b/docs/simplesamlphp-authproc.md
@@ -132,6 +132,8 @@ The following filters are included in the SimpleSAMLphp distribution:
 - [`core:AttributeLimit`](./core:authproc_attributelimit): Limit the attributes in the response.
 - [`core:AttributeMap`](./core:authproc_attributemap): Change the name of the attributes.
 - [`core:AttributeRealm`](./core:authproc_attributerealm): (deprecated) Create an attribute with the realm of the user.
+- [`core:Cardinality`](./core:authproc_cardinality): Ensure the number of attribute values is within the specified multiplicity.
+- [`core:CardinalitySingle`](./core:authproc_cardinalitysingle): Ensure the correct cardinality of single-valued attributes.
 - [`core:GenerateGroups`](./core:authproc_generategroups): Generate a `group` attribute for the user.
 - [`core:LanguageAdaptor`](./core:authproc_languageadaptor): Transfering language setting from IdP to SP.
 - [`core:PHP`](./core:authproc_php): Modify attributes with custom PHP code.

--- a/modules/core/docs/authproc_cardinality.md
+++ b/modules/core/docs/authproc_cardinality.md
@@ -7,6 +7,8 @@ This filter should contain a set of attribute name => rule pairs describing the 
 
 The special parameter `%ignoreEntities` can be used to give an array of entity IDs that should be ignored for testing, etc purposes.
 
+A separate [`core:CardinalitySingle`](./core:authproc_cardinalitysingle) authproc filter provides additional functionality for the special case where attributes are single valued.
+
 Specifying Rules
 ----------------
 

--- a/modules/core/docs/authproc_cardinalitysingle.md
+++ b/modules/core/docs/authproc_cardinalitysingle.md
@@ -2,7 +2,7 @@
 ========================
 
 Ensure the correct cardinality of single-valued attributes. This filter is a special case
-of the more generic [core:Cardinality] filter that allows for optional corrective measures
+of the more generic [`core:Cardinality`](./core:authproc_cardinality) filter that allows for optional corrective measures
 when multi-valued attributes are received where single-valued ones are expected.
 
 Parameters


### PR DESCRIPTION
It seems we forgot to link the core:Cardinality* authproc filters into the list of included filters. This fixes that, and also gets the crosslinking between the two working.