### PR TITLE
Modification to checkURLAllowed

### DIFF
--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -328,7 +328,7 @@ class HTTP
         $url = self::normalizeURL($url);
 
         // check the validity of the URL
-	if (parse_url($url,PHP_URL_HOST) === false) {
+        if (parse_url($url,PHP_URL_HOST) === false) {
             throw new \SimpleSAML_Error_Exception('Invalid URL: '.$url);
         }
 

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -327,8 +327,9 @@ class HTTP
         }
         $url = self::normalizeURL($url);
 
-        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
-            throw new Error\Exception('Invalid URL: '.$url);
+        // check the validity of the URL
+	if (parse_url($url,PHP_URL_HOST) === false) {
+            throw new \SimpleSAML_Error_Exception('Invalid URL: '.$url);
         }
 
         // get the white list of domains


### PR DESCRIPTION
Hello,

I hit a problem connecting my IDP to a remote SP that had an underscore in the host name.
The following stackoverflow article provided an alternate method (using parse_url rather than filter_var) for checking domain validity.
https://stackoverflow.com/questions/39539468/php-filter-validate-url-not-finding-subdomains-with-underscore