### PR TITLE
NameIDFormat as array (#91)

### DIFF
--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -986,9 +986,9 @@ class SAML2
 
         if ($nameIdFormat === null || !isset($state['saml:NameID'][$nameIdFormat])) {
             // either not set in request, or not set to a format we supply. Fall back to old generation method
-            $nameIdFormat = $spMetadata->getString('NameIDFormat', null);
+            $nameIdFormat = (string)$spMetadata->getArrayizeString('NameIDFormat', null);
             if ($nameIdFormat === null) {
-                $nameIdFormat = $idpMetadata->getString('NameIDFormat', \SAML2\Constants::NAMEID_TRANSIENT);
+                $nameIdFormat = (string)$idpMetadata->getArrayizeString('NameIDFormat', \SAML2\Constants::NAMEID_TRANSIENT);
             }
         }
 

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -986,9 +986,9 @@ class SAML2
 
         if ($nameIdFormat === null || !isset($state['saml:NameID'][$nameIdFormat])) {
             // either not set in request, or not set to a format we supply. Fall back to old generation method
-            $nameIdFormat = (string)$spMetadata->getArrayizeString('NameIDFormat', null);
+            $nameIdFormat = array_values($spMetadata->getArrayizeString('NameIDFormat', null))[0];
             if ($nameIdFormat === null) {
-                $nameIdFormat = (string)$idpMetadata->getArrayizeString('NameIDFormat', \SAML2\Constants::NAMEID_TRANSIENT);
+                $nameIdFormat = array_values($idpMetadata->getArrayizeString('NameIDFormat', \SAML2\Constants::NAMEID_TRANSIENT))[0];
             }
         }
 

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -134,7 +134,7 @@ try {
         );
     }
 
-    $metaArray['NameIDFormat'] = $idpmeta->getString(
+    $metaArray['NameIDFormat'] = $idpmeta->getArrayizeString(
         'NameIDFormat',
         'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
     );

--- a/www/shib13/idp/metadata.php
+++ b/www/shib13/idp/metadata.php
@@ -51,7 +51,7 @@ try {
         $metaArray['keys'] = $keys;
     }
 
-    $metaArray['NameIDFormat'] = $idpmeta->getString('NameIDFormat', 'urn:mace:shibboleth:1.0:nameIdentifier');
+    $metaArray['NameIDFormat'] = $idpmeta->getArrayizeString('NameIDFormat', 'urn:mace:shibboleth:1.0:nameIdentifier');
 
     if ($idpmeta->hasValue('OrganizationName')) {
         $metaArray['OrganizationName'] = $idpmeta->getLocalizedString('OrganizationName');


### PR DESCRIPTION
This patch allows for the NameIDFormat in SSP's metadata format to be either an array or a string, thus facilitating the generation of multiple <NameIDFormat> elements in XML metadata. This, in turn, allows IdPs to advertise support for zero or more NameIDFormats, in line with SAML2Meta. 

Background:

In issue #91, @id812510 requested that NameIDFormat become an array. We encountered the same issue when initially setting up our federation hub in that we wanted the generated metadata to include both a transient and a persistent NameIDFormat, since the hub has authproc filters for both.

I developed a patch for this in 2016, but at the time I was not confident enough in my understanding of SSP's internals to convert that into a pull request. I instead left the branch in my own fork and referenced the issue.  However, we've been running this patch in production for well over a year over several version changes of SSP and we've fixed the only bug we ever encountered.

Realising this might still be an issue for other people, I'm now converting that into a pull request :)