### PR TITLE
Add docs for saml:AuthnContextClassRef filter

### DIFF
--- a/docs/simplesamlphp-authproc.md
+++ b/docs/simplesamlphp-authproc.md
@@ -145,6 +145,7 @@ The following filters are included in the SimpleSAMLphp distribution:
 - [`expirycheck:ExpiryDate`](./expirycheck:expirycheck): Block access to accounts that have expired.
 - [`preprodwarning:Warning`](./preprodwarning:warning): Warn the user about accessing a test IdP.
 - [`saml:AttributeNameID`](./saml:nameid): Generate custom NameID with the value of an attribute.
+- [`saml:AuthnContextClassRef`](./saml:authproc_authncontextclassref): Set the authentication context in the response.
 - [`saml:ExpectedAuthnContextClassRef`](./saml:authproc_expectedauthncontextclassref): Verify the user's authentication context.
 - [`saml:FilterScopes`](./saml:filterscopes): Filter attribute values with scopes forbidden for an IdP.
 - [`saml:NameIDAttribute`](./saml:nameidattribute): Create an attribute based on the NameID we receive from the IdP.

--- a/modules/saml/docs/authproc_authncontextclassref.md
+++ b/modules/saml/docs/authproc_authncontextclassref.md
@@ -1,0 +1,14 @@
+`saml:AuthnContextClassRef`
+===========================
+
+IDP-side filter for setting the `AuthnContextClassRef` element in the authentication response.
+
+Examples
+--------
+
+    'authproc.idp' => array(
+      92 => array(
+        'class' => 'saml:AuthnContextClassRef',
+        'AuthnContextClassRef' => 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+      ),
+    ),


### PR DESCRIPTION
Found existing code when trying to correct the default AuthnContextClassRef value sent, noticed it was undocumented.

Context (no pun intended), since it may suggest another change:

SSP by default sets an `AuthnContextClassRef` of `urn:oasis:names:tc:SAML:2.0:ac:classes:Password`, of which the SAML spec says:

> The Password class is applicable when a principal authenticates to an authentication authority through the presentation of a password over an unprotected HTTP session.

I'd claim (and hope) that most deployers will only ever be running an IDP over TLS (in which case `AC_PASSWORD` doesn't seem appropriate), but I understand SSP cannot blindly default to `PasswordProtectedTransport` either.

Maybe check `SimpleSAML\Utils\HTTP::isHTTPS()` instead and switch to `PasswordProtectedTransport` iff true? (Would also need an addition to the [constants provided in the saml2 library](https://github.com/simplesamlphp/saml2/blob/master/src/SAML2/Constants.php).)