### PR TITLE
PasswordProtectedTransport authncontext when HTTPS

### DIFF
--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -897,6 +897,8 @@ class SAML2
 
         if (isset($state['saml:AuthnContextClassRef'])) {
             $a->setAuthnContextClassRef($state['saml:AuthnContextClassRef']);
+        } elseif (\SimpleSAML\Utils\HTTP::isHTTPS()) {
+            $a->setAuthnContextClassRef(\SAML2\Constants::AC_PASSWORD_PROTECTED_TRANSPORT);
         } else {
             $a->setAuthnContextClassRef(\SAML2\Constants::AC_PASSWORD);
         }


### PR DESCRIPTION
Following up on the idea mentioned in #937: If the transport is secure fall back to the `PasswordProtectedTransport` authn context class ref, otherwise keep the current default of `Password`.

Requires a version of the SAML2 library with simplesamlphp/saml2#129 merged due to referencing a newly defined Constant.