### PR TITLE
#655 allow core:php to manipulate all of the state

### DIFF
--- a/modules/core/lib/Auth/Process/PHP.php
+++ b/modules/core/lib/Auth/Process/PHP.php
@@ -49,7 +49,7 @@ class PHP extends \SimpleSAML\Auth\ProcessingFilter
         assert(is_array($request));
         assert(array_key_exists('Attributes', $request));
 
-        $function = function(/** @scrutinizer ignore-unused */ &$attributes) { eval($this->code); };
-        $function($request['Attributes']);
+        $function = function(/** @scrutinizer ignore-unused */ &$attributes, &$state) { eval($this->code); };
+        $function($request['Attributes'], $request);
     }
 }

--- a/tests/modules/core/lib/Auth/Process/PHPTest.php
+++ b/tests/modules/core/lib/Auth/Process/PHPTest.php
@@ -111,4 +111,42 @@ class Test_Core_Auth_Process_PHP extends TestCase
         );
         $this->processFilter($config, $request);
     }
+
+    /**
+     * Check that the entire state can be adjusted.
+     */
+    public function testStateCanBeModified()
+    {
+
+        $config = array(
+            'code' => '
+                $attributes["orig2"] = array("value0");
+                $state["newKey"] = ["newValue"];
+                $state["Destination"]["attributes"][] = "givenName";
+            ',
+        );
+        $request = array(
+            'Attributes' => array(
+                'orig1' => array('value1', 'value2'),
+                'orig2' => array('value3'),
+                'orig3' => array('value4')
+            ),
+            'Destination' => [
+                'attributes' => ['eduPersonPrincipalName']
+            ],
+        );
+        $expected = array(
+            'Attributes' => array(
+                'orig1' => array('value1', 'value2'),
+                'orig2' => array('value0'),
+                'orig3' => array('value4')
+            ),
+            'Destination' => [
+                'attributes' => ['eduPersonPrincipalName', 'givenName']
+            ],
+            'newKey' => ['newValue']
+        );
+
+        $this->assertEquals($expected, $this->processFilter($config, $request));
+    }
 }


### PR DESCRIPTION
#655 has the initial discussion on allowing more functionality from the core:php module.

I think some things to consider:
1.  Should I call the variable $state or $request when passing to function?  I generally think of it as $state though the `process` method signature calls in`$request`
2. How much should we worry about backwards compatibility? In theory someone could already have code using core:php that declares a variable $state. With this change their code would now interact with the authproc $state instead of a locally defined $state. 

I'll update the documentation once we decide on the above 2 things.