### PR TITLE
Moved phpunit.xml configuration file to root repository directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 - if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then composer require --dev php-coveralls/php-coveralls; fi
 script:
 - bin/check-syntax.sh
-- if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then php vendor/phpunit/phpunit/phpunit --configuration tools/phpunit; else php vendor/phpunit/phpunit/phpunit --configuration tools/phpunit --no-coverage; fi
+- if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then php vendor/phpunit/phpunit/phpunit; else php vendor/phpunit/phpunit/phpunit --no-coverage; fi
 - if [[ "$TRAVIS_PHP_VERSION" == "7.0" ]]; then vendor/bin/psalm; fi
 after_success:
 - if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then php vendor/bin/php-coveralls -v; fi

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,22 +8,22 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="./../../tests/bootstrap.php">
+         bootstrap="./tests/bootstrap.php">
     <testsuites>
         <testsuite name="Unit tests">
-            <directory>./../../tests/</directory>
+            <directory>./tests/</directory>
         </testsuite>
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./../../lib/</directory>
-            <directory suffix=".php">./../../modules/consent/lib/</directory>
-            <directory suffix=".php">./../../modules/core/lib/</directory>
-            <directory suffix=".php">./../../modules/saml/lib/</directory>
+            <directory suffix=".php">./lib/</directory>
+            <directory suffix=".php">./modules/consent/lib/</directory>
+            <directory suffix=".php">./modules/core/lib/</directory>
+            <directory suffix=".php">./modules/saml/lib/</directory>
             <exclude>
-                <directory>./../../vendor/</directory>
-                <directory>./../../tests/</directory>
-                <file>./../../lib/SimpleSAML/Utils/HttpAdapter.php</file>
+                <directory>./vendor/</directory>
+                <directory>./tests/</directory>
+                <file>./lib/SimpleSAML/Utils/HttpAdapter.php</file>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
From what I've seen, it's more common to have `phpunit.xml` in the root repository directory. I think this provides a few advantages:

- Developers can simply run `phpunit` instead of `phpunit -c /path/to/configuration`.
- Developers will be able to find the `phpunit.xml` configuration file more easily since it's in a more common spot.
- We don't have to specify `./../../` for all paths in `phpunit.xml`.
- We can delete the `tools` directory since it's no longer used for anything else.