### PR TITLE
Disabled unnecessary issuer check as proposed in issue #975

### DIFF
--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -280,9 +280,6 @@ class SP extends Source
             $ar->setExtensions($state['saml:Extensions']);
         }
 
-        // save IdP entity ID as part of the state
-        $state['ExpectedIssuer'] = $idpMetadata->getString('entityid');
-
         $id = State::saveState($state, 'saml:sp:sso', true);
         $ar->setId($id);
 

--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -95,18 +95,6 @@ if ($state) {
             'The authentication source id in the URL does not match the authentication source which sent the request.'
         );
     }
-
-    // check that the issuer is the one we are expecting
-    assert(array_key_exists('ExpectedIssuer', $state));
-    if ($state['ExpectedIssuer'] !== $idp) {
-        $idpMetadata = $source->getIdPMetadata($idp);
-        $idplist = $idpMetadata->getArrayize('IDPList', []);
-        if (!in_array($state['ExpectedIssuer'], $idplist, true)) {
-            throw new \SimpleSAML\Error\Exception(
-                'The issuer of the response does not match to the identity provider we sent the request to.'
-            );
-        }
-    }
 } else {
     // this is an unsolicited response
     $state = [


### PR DESCRIPTION
As described in https://github.com/simplesamlphp/simplesamlphp/issues/975 this removes the issuer check, which is not needed as it does not provide any extra security because SSP also supports Unsolicited/IdP-initated login.