### PR TITLE
Create a setting for the allowed assertion offset

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -176,6 +176,15 @@ $config = [
      */
     'enable.http_post' => false,
 
+    /*
+     * Set the allowed time difference between encrypting/decrypting assertions
+     *
+     * If you have an server that is constantly out of sync, this option
+     * allows you to adjust the allowed time-frame.
+     *
+     * Defaults to 60.
+     */
+    'assertion.allowed_offset' => 60,
 
 
     /************************

--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -177,14 +177,15 @@ $config = [
     'enable.http_post' => false,
 
     /*
-     * Set the allowed time difference between encrypting/decrypting assertions
+     * Set the allowed clock skew between encrypting/decrypting assertions
      *
      * If you have an server that is constantly out of sync, this option
-     * allows you to adjust the allowed time-frame.
+     * allows you to adjust the allowed clock-skew.
      *
-     * Defaults to 60.
+     * Allowed range: 180 - 300
+     * Defaults to 180.
      */
-    'assertion.allowed_offset' => 60,
+    'assertion.allowed_clock_skew' => 180,
 
 
     /************************

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -658,6 +658,15 @@ class Message
         // check various properties of the assertion
         $config = \SimpleSAML\Configuration::getInstance();
         $allowed_assertion_offset = $config->getInteger('assertion.allowed_offset', 60);
+        $options = [
+            'options' => [
+                'default' => 60, // value to return if the filter fails
+                // other options here
+                'min_range' => 0,
+                'max_range' => 300,
+            ],
+        ];
+        $allowed_assertion_offset = filter_var($allowed_assertion_offset, FILTER_VALIDATE_INT, $options);
         $notBefore = $assertion->getNotBefore();
         if ($notBefore !== null && $notBefore > time() + $allowed_assertion_offset) {
             throw new \SimpleSAML\Error\Exception(

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -657,30 +657,29 @@ class Message
 
         // check various properties of the assertion
         $config = \SimpleSAML\Configuration::getInstance();
-        $allowed_assertion_offset = $config->getInteger('assertion.allowed_offset', 60);
+        $allowed_clock_skew = $config->getInteger('assertion.allowed_clock_skew', 180);
         $options = [
             'options' => [
-                'default' => 60, // value to return if the filter fails
-                // other options here
-                'min_range' => 0,
+                'default' => 180,
+                'min_range' => 180,
                 'max_range' => 300,
             ],
         ];
-        $allowed_assertion_offset = filter_var($allowed_assertion_offset, FILTER_VALIDATE_INT, $options);
+        $allowed_clock_skew = filter_var($allowed_clock_skew, FILTER_VALIDATE_INT, $options);
         $notBefore = $assertion->getNotBefore();
-        if ($notBefore !== null && $notBefore > time() + $allowed_assertion_offset) {
+        if ($notBefore !== null && $notBefore > time() + $allowed_clock_skew) {
             throw new \SimpleSAML\Error\Exception(
                 'Received an assertion that is valid in the future. Check clock synchronization on IdP and SP.'
             );
         }
         $notOnOrAfter = $assertion->getNotOnOrAfter();
-        if ($notOnOrAfter !== null && $notOnOrAfter <= time() - $allowed_assertion_offset) {
+        if ($notOnOrAfter !== null && $notOnOrAfter <= time() - $allowed_clock_skew) {
             throw new \SimpleSAML\Error\Exception(
                 'Received an assertion that has expired. Check clock synchronization on IdP and SP.'
             );
         }
         $sessionNotOnOrAfter = $assertion->getSessionNotOnOrAfter();
-        if ($sessionNotOnOrAfter !== null && $sessionNotOnOrAfter <= time() - $allowed_assertion_offset) {
+        if ($sessionNotOnOrAfter !== null && $sessionNotOnOrAfter <= time() - $allowed_clock_skew) {
             throw new \SimpleSAML\Error\Exception(
                 'Received an assertion with a session that has expired. Check clock synchronization on IdP and SP.'
             );

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -656,20 +656,22 @@ class Message
         $currentURL = \SimpleSAML\Utils\HTTP::getSelfURLNoQuery();
 
         // check various properties of the assertion
+        $config = \SimpleSAML\Configuration::getInstance();
+        $allowed_assertion_offset = $config->getInteger('assertion.allowed_offset', 60);
         $notBefore = $assertion->getNotBefore();
-        if ($notBefore !== null && $notBefore > time() + 60) {
+        if ($notBefore !== null && $notBefore > time() + $allowed_assertion_offset) {
             throw new \SimpleSAML\Error\Exception(
                 'Received an assertion that is valid in the future. Check clock synchronization on IdP and SP.'
             );
         }
         $notOnOrAfter = $assertion->getNotOnOrAfter();
-        if ($notOnOrAfter !== null && $notOnOrAfter <= time() - 60) {
+        if ($notOnOrAfter !== null && $notOnOrAfter <= time() - $allowed_assertion_offset) {
             throw new \SimpleSAML\Error\Exception(
                 'Received an assertion that has expired. Check clock synchronization on IdP and SP.'
             );
         }
         $sessionNotOnOrAfter = $assertion->getSessionNotOnOrAfter();
-        if ($sessionNotOnOrAfter !== null && $sessionNotOnOrAfter <= time() - 60) {
+        if ($sessionNotOnOrAfter !== null && $sessionNotOnOrAfter <= time() - $allowed_assertion_offset) {
             throw new \SimpleSAML\Error\Exception(
                 'Received an assertion with a session that has expired. Check clock synchronization on IdP and SP.'
             );


### PR DESCRIPTION
This was an hardcoded setting that we would like to change. Therefore making it configurable seems the right thing.

We have a customer with an Microsoft ADFS server that's about one minute ahead of time a few times per day. With this setting, we can allow them to be ahead instead of having the customers of the customers complain.