### PR TITLE
Auth:LDAP: Add method getResourceLink

### DIFF
--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -838,3 +838,13 @@ class LDAP
         return $dn;
     }
 }
+
+/**
+ * Get LDAP resource link
+ *
+ * @return resource
+ */
+public function getResourcelink()
+{
+    return $this->ldap;
+}


### PR DESCRIPTION
This would add a method in SimpleSAML_Auth_LDAP that can be used in custom authentication module to do additional operation, returning the LDAP resource link. This can be used using ldap_modify to update some attribute value (like zimbraLastLogonTimestamp) or another operation