### PR TITLE
Auth:LDAP: Add setAttributes to allow attribute value modifications

### DIFF
--- a/lib/SimpleSAML/Auth/LDAP.php
+++ b/lib/SimpleSAML/Auth/LDAP.php
@@ -838,3 +838,57 @@ class LDAP
         return $dn;
     }
 }
+
+/**
+ * Set for a given DN attributes
+ *
+ * @param string $dn
+ * The DN of an element.
+ * @param array $attributes
+ * The names and value of the attribute(s) to set using ldap_modify structure;
+ * @return bool
+ * Result of operation
+ */
+public function setAttributes($dn, $attributes)
+{
+    if (is_array($attributes)) {
+        // Log each attribute write
+        foreach ($attributes AS $attribute=>$attribute_data)
+        {
+            if ( is_array($attribute_data))
+            {
+                // Set Value
+                if ( sizeof($attribute_data) > 0 )
+                {
+                    foreach($attribute_data AS $attribute_entry=>$attribute_value)
+                    {
+                        SimpleSAML\Logger::debug('Library - LDAP setAttributes(): Setting \''.$attribute.'\' value \'' .
+                            $attribute_value.'\' to DN \''.$dn.'\'');
+                    }
+                }
+                // Delete all value
+                else
+                {
+                    SimpleSAML\Logger::debug('Library - LDAP setAttributes(): Deleting all \''.$attribute.'\' value to DN \''.$dn.'\'');
+                }
+            }
+            // Set value if not array
+            else
+            {
+                SimpleSAML\Logger::debug('Library - LDAP setAttributes(): Setting \''.$attribute.'\' value \'' .
+                    $attribute_data.'\' to DN \''.$dn.'\'');
+            }
+        }
+    } else {
+        SimpleSAML\Logger::debug('Library - LDAP setAttributes(): Setting NONE attribute to DN \''.$dn.'\'');
+        return false;
+    }
+
+    // Attempt to set attributes
+    $result = @ldap_modify($this->ldap, $dn, $attributes);
+    if ( ($result === false) ) {
+        throw $this->makeException('Library - LDAP setAttributes(): Failed to set attributes from DN \''.$dn.'\'');
+    }
+
+    return $result;
+}


### PR DESCRIPTION
This would add a method in SimpleSAML_Auth_LDAP that can be used in custom authentication module to modify LDAP values, for example, LastLogin, Account block operation, etc...

An example code (Fron ConfigHelper, using the module ldap:LDAP as sample)

$ldap_write = new SimpleSAML_Auth_LDAP($this->hostname, $this->enableTLS, $this->debug, $this->timeout, $this->port, $this->referrals);
$ldap_write->bind($this->searchUsername, $this->searchPassword)
$ldap_data_modify['zimbraLastLogonTimestamp'][0]=sprintf("%sZ",date("YmdHis"));
$ldap_data_modify['zimbraPasswordLockoutFailureTime']=[];
$ldap_write->setAttributes($dn, $ldap_data_modify);
