### PR TITLE
Fix HVVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ php:
 - 7.1
 - 7.2
 - 7.3
+- hhvm
+matrix:
+  allow_failures:
+  - php: hhvm
 before_script:
 - composer update
 - if [[ "$TRAVIS_PHP_VERSION" == "7.0" ]]; then composer require --dev vimeo/psalm:0.3.92; fi

--- a/modules/oauth/lib/OAuthServer.php
+++ b/modules/oauth/lib/OAuthServer.php
@@ -11,7 +11,7 @@ require_once(dirname(dirname(__FILE__)).'/libextinc/OAuth.php');
  * @package SimpleSAMLphp
  */
 
-class OAuthServer extends OAuthServer
+class OAuthServer extends \OAuthServer
 {
     public function __construct($store)
     {


### PR DESCRIPTION
Tests for HVVM were removed recently because of continuous failure, but the fix was actually really simple.
Really surprised this even worked despite the namespace issue.
Because I like the strictness of HVVM I'm really in favour of restoring this. It may catch problems even before non-HVVM tests do