### PR TITLE
SAML: Configurable SLO and ACS metadata

### DIFF
--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -109,6 +109,11 @@ Options
 
 :   *Note*: SAML 2 specific.
 
+`AssertionConsumerService`
+:   List of Assertion Consumer Services in the generated metadata. Specified in the array of
+    arrays format as seen in the [Metadata endpoints](./simplesamlphp-metadata-endpoints)
+    documentation.
+
 `attributes`
 :   List of attributes this SP requests from the IdP.
     This list will be added to the generated metadata.
@@ -395,6 +400,9 @@ Options
     * `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect`
     * `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST`
 	* `urn:oasis:names:tc:SAML:2.0:bindings:SOAP`
+
+`SingleLogoutServiceLocation`
+:   The Single Logout Service URL published in the generated metadata.
 
 `url`
 :   A URL to your service provider. Will be added as an OrganizationURL-element in the metadata.

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -42,7 +42,7 @@ foreach ($slob as $binding) {
     }
     $metaArray20['SingleLogoutService'][] = [
         'Binding'  => $binding,
-        'Location' => $slol,
+        'Location' => $spconfig->getString('SingleLogoutService.Location', $slol),
     ];
 }
 
@@ -106,7 +106,7 @@ foreach ($assertionsconsumerservices as $services) {
     $index++;
 }
 
-$metaArray20['AssertionConsumerService'] = $eps;
+$metaArray20['AssertionConsumerService'] = $spconfig->getArray('AssertionConsumerService', $eps);
 
 $keys = [];
 $certInfo = \SimpleSAML\Utils\Crypto::loadPublicKey($spconfig, false, 'new_');

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -42,7 +42,7 @@ foreach ($slob as $binding) {
     }
     $metaArray20['SingleLogoutService'][] = [
         'Binding'  => $binding,
-        'Location' => $spconfig->getString('SingleLogoutService.Location', $slol),
+        'Location' => $spconfig->getString('SingleLogoutServiceLocation', $slol),
     ];
 }
 


### PR DESCRIPTION
This commit adds the ability to override the defaults in the generated SP metadata for SLO Location and ACS endpoints. This is necessary for my use case as I have additional ACS endpoints to publish in my metadata beyond the generated ones as well as a custom SLO handler that I need to direct my users to. If unset in the config, it uses the defaults as before.

This addresses #954.

