### PR TITLE
Update OpenSSL RSA bit length in docs

### DIFF
--- a/docs/simplesamlphp-artifact-sp.md
+++ b/docs/simplesamlphp-artifact-sp.md
@@ -11,7 +11,7 @@ This is used for SSL client authentication when contacting the IdP.
 
 To generate a private key and certificate, you may use the `openssl` commandline utility:
 
-    openssl req -newkey rsa:2048 -new -x509 -days 3652 -nodes -out sp.example.org.crt -keyout sp.example.org.pem
+    openssl req -newkey rsa:3072 -new -x509 -days 3652 -nodes -out sp.example.org.crt -keyout sp.example.org.pem
 
 You can then add the private key and certificate to the SP configuration.
 When this is done, you can add the metadata of your SP to the IdP, and test the authentication.

--- a/docs/simplesamlphp-googleapps.md
+++ b/docs/simplesamlphp-googleapps.md
@@ -42,7 +42,7 @@ Edit `config.php`, and enable the SAML 2.0 IdP:
 You must generate a certificate for your IdP.
 Here is an example of an openssl command to generate a new key and a self signed certificate to use for signing SAML messages:
 
-    openssl req -newkey rsa:2048 -new -x509 -days 3652 -nodes -out googleappsidp.crt -keyout googleappsidp.pem
+    openssl req -newkey rsa:3072 -new -x509 -days 3652 -nodes -out googleappsidp.crt -keyout googleappsidp.pem
 
 The certificate above will be valid for 10 years.
 

--- a/docs/simplesamlphp-idp.md
+++ b/docs/simplesamlphp-idp.md
@@ -127,7 +127,7 @@ Here is an example of an `openssl`-command which can be used to generate a new p
 
 This key and certificate can be used to sign SAML messages:
 
-    openssl req -newkey rsa:2048 -new -x509 -days 3652 -nodes -out example.org.crt -keyout example.org.pem
+    openssl req -newkey rsa:3072 -new -x509 -days 3652 -nodes -out example.org.crt -keyout example.org.pem
 
 The certificate above will be valid for 10 years.
 

--- a/docs/simplesamlphp-sp.md
+++ b/docs/simplesamlphp-sp.md
@@ -50,7 +50,7 @@ Some Identity Providers / Federations may require that your Service Providers ho
 Create a self-signed certificate in the `cert/` directory.
 
 	cd cert
-	openssl req -newkey rsa:2048 -new -x509 -days 3652 -nodes -out saml.crt -keyout saml.pem
+	openssl req -newkey rsa:3072 -new -x509 -days 3652 -nodes -out saml.crt -keyout saml.pem
 
 
 Then edit your `authsources.php` entry, and add references to your certificate:

--- a/modules/saml/docs/keyrollover.md
+++ b/modules/saml/docs/keyrollover.md
@@ -11,7 +11,7 @@ First you must create the new key that you are going to use.
 To create a self signed certificate, you may use the following command:
 
     cd cert
-    openssl req -newkey rsa:2048 -new -x509 -days 3652 -nodes -out new.crt -keyout new.pem
+    openssl req -newkey rsa:3072 -new -x509 -days 3652 -nodes -out new.crt -keyout new.pem
 
 
 Add the new key to SimpleSAMLphp


### PR DESCRIPTION
Change documentation from recommending 2048 bit keys to using 3072 bit
keys.

Given that we're recommending people generate ten-year keys, 2048 bit
keys are probably a bit short. Almost all commercial certificate
authorities now recommend 4096 bit keys, and eduGAIN requires 3072 bit
keys for new federations.

This change aligns the SimpleSAMLphp documentation with the lower
eduGAIN requirement, since that still meets most standards bodies
recommendations for 2028 (ten years from now). cf
https://www.keylength.com/