### PR TITLE
Rewrite Crypto::passwordHash() to use BCRYPT instead of unsafe algorithms

### DIFF
--- a/bin/pwgen.php
+++ b/bin/pwgen.php
@@ -21,27 +21,4 @@ if (empty($password)) {
     exit(1);
 }
 
-$table = '';
-foreach (array_chunk(hash_algos(), 6) as $chunk) {
-    foreach ($chunk as $algo) {
-        $table .= sprintf('%-13s', $algo);
-    }
-    $table .= "\n";
-}
-
-echo "The following hashing algorithms are available:\n".$table."\n";
-echo "Which one do you want? [sha256] ";
-$algo = trim(fgets(STDIN));
-if (empty($algo)) {
-    $algo = 'sha256';
-}
-
-if (!in_array(strtolower($algo), hash_algos(), true)) {
-    echo "Hashing algorithm '$algo' is not supported\n";
-    exit(1);
-}
-
-echo "Do you want to use a salt? (yes/no) [yes] ";
-$s = (trim(fgets(STDIN)) == 'no') ? '' : 'S';
-
-echo "\n  ".SimpleSAML\Utils\Crypto::pwHash($password, strtoupper($s.$algo))."\n\n";
+echo "\n  ".SimpleSAML\Utils\Crypto::pwHash($password)."\n\n";

--- a/lib/SimpleSAML/Utils/Crypto.php
+++ b/lib/SimpleSAML/Utils/Crypto.php
@@ -398,7 +398,7 @@ class Crypto
                 throw new \InvalidArgumentException('Invalid input parameter.');
             }
 
-            return password_hash($password, PASSWORD_BCRYPT);
+            return password_hash($password, PASSWORD_DEFAULT);
         }
     }
 

--- a/modules/authcrypt/lib/Auth/Source/Htpasswd.php
+++ b/modules/authcrypt/lib/Auth/Source/Htpasswd.php
@@ -105,12 +105,9 @@ class Htpasswd extends \SimpleSAML\Module\core\Auth\UserPassBase
                     return $attributes;
                 }
 
-                // SHA1 or plain-text
+                // PASSWORD_BCRYPT
                 if (\SimpleSAML\Utils\Crypto::pwValid($crypted, $password)) {
                     \SimpleSAML\Logger::debug('User '.$username.' authenticated successfully');
-                    \SimpleSAML\Logger::warning(
-                        'SHA1 and PLAIN TEXT authentication are insecure. Please consider using something else.'
-                    );
                     return $attributes;
                 }
                 throw new \SimpleSAML\Error\Error('WRONGUSERPASS');

--- a/tests/lib/SimpleSAML/Utils/CryptoTest.php
+++ b/tests/lib/SimpleSAML/Utils/CryptoTest.php
@@ -157,6 +157,7 @@ PHP;
 
     /**
      * @covers \SimpleSAML\Utils\Crypto::pwHash
+     * @deprecated To be removed for 2.0
      */
     public function testGoodPwHash()
     {
@@ -174,8 +175,10 @@ PHP;
         $this->assertEquals($expected, $res);
     }
 
+
     /**
      * @covers \SimpleSAML\Utils\Crypto::pwHash
+     * @deprecated To be removed for 2.0
      */
     public function testGoodSaltedPwHash()
     {
@@ -196,6 +199,7 @@ PHP;
 
     /**
      * @expectedException \SimpleSAML\Error\Exception
+     * @deprecated To be removed for 2.0
      *
      * @covers \SimpleSAML\Utils\Crypto::pwHash
      */
@@ -213,6 +217,21 @@ PHP;
     public function testGoodPwValid()
     {
         $pw = "password";
+
+        $hash = Crypto::pwHash($pw);
+        $res = Crypto::pwValid($hash, $pw);
+
+        $this->assertTrue($res);
+    }
+
+
+    /**
+     * @covers \SimpleSAML\Utils\Crypto::pwValid
+     * @deprecated To be removed for 2.0
+     */
+    public function testGoodPwValidOld()
+    {
+        $pw = "password";
         $algorithm = "SHA1";
 
         $hash = Crypto::pwHash($pw, $algorithm);
@@ -223,6 +242,7 @@ PHP;
 
     /**
      * @covers \SimpleSAML\Utils\Crypto::pwValid
+     * @deprecated To be removed for 2.0
      */
     public function testGoodSaltedPwValid()
     {
@@ -238,6 +258,7 @@ PHP;
 
     /**
      * @expectedException \SimpleSAML\Error\Exception
+     * @deprecated To be removed for 2.0
      *
      * @covers \SimpleSAML\Utils\Crypto::pwValid
      */


### PR DESCRIPTION
As discussed during the hackathon;  closes #602

It is fully backwards compatible with current hashes, so it's safe to merge. Will only affect newly generated hashes with `bin/pwgen.php`