### PR TITLE
Support for AudienceRestriction in SAML2 request

### DIFF
--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -74,6 +74,12 @@ All these parameters override the equivalent option from the configuration.
 
 :   *Note*: SAML 2 specific.
 
+`saml:Audience`
+:   Add a Conditions element to the SAML AuthnRequest containing an
+    AudienceRestriction with one or more audiences.
+
+:   *Note*: SAML 2 specific.
+
 
 Authentication data
 -------------------

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -220,6 +220,10 @@ class SP extends Source
             $ar->setRequestedAuthnContext(['AuthnContextClassRef' => $accr, 'Comparison' => $comp]);
         }
 
+        if (isset($state['saml:Audience'])) {
+            $ar->setAudiences($state['saml:Audience']);
+        }
+
         if (isset($state['ForceAuthn'])) {
             $ar->setForceAuthn((bool) $state['ForceAuthn']);
         }


### PR DESCRIPTION
My implementation of Conditions/AudienceRestriction/Audience support in SAML2 AuthnRequest, as requested in https://github.com/simplesamlphp/simplesamlphp/issues/201

Requeries updated saml2 library: https://github.com/simplesamlphp/saml2/pull/137