### PR TITLE
Optional preselect in multiauth source config

### DIFF
--- a/modules/multiauth/docs/multiauth.md
+++ b/modules/multiauth/docs/multiauth.md
@@ -110,3 +110,27 @@ You can also use the multiauth:preselect parameter to the login call:
     $as->login(array(
         'multiauth:preselect' => 'default-sp',
     ));
+
+Or add the `preselect` option in the filter:
+
+    'example-multi' => array(
+        'multiauth:MultiAuth',
+
+        /*
+         * The available authentication sources.
+         * They must be defined in this authsources.php file.
+         */
+        'sources' => array(
+            'example-saml' => array(
+            // ...
+            ),
+            'example-admin' => array(
+            // ...
+            ),
+        ),
+        'preselect' => 'example-saml',
+    ),
+
+The order of priority, in case more than one option was used is: 
+`source` url parameter, `multiauth:preselect` login state and
+`preselect` filter option.

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -74,6 +74,8 @@ class MultiAuth extends \SimpleSAML\Auth\Source
 
             if (array_key_exists('help', $info)) {
                 $help = $info['help'];
+            } else {
+                $help = null;
             }
             if (array_key_exists('css-class', $info)) {
                 $css_class = $info['css-class'];

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -38,6 +38,11 @@ class MultiAuth extends \SimpleSAML\Auth\Source
     private $sources;
 
     /**
+     * @var string|null preselect source in filter module configuration
+     */
+    private $preselect;
+
+    /**
      * Constructor for this authentication source.
      *
      * @param array $info Information about this authentication source.
@@ -53,6 +58,14 @@ class MultiAuth extends \SimpleSAML\Auth\Source
 
         if (!array_key_exists('sources', $config)) {
             throw new \Exception('The required "sources" config option was not found');
+        }
+
+        if (array_key_exists('preselect', $config) && is_string($config['preselect'])) {
+            if (!array_key_exists($config['preselect'], $config['sources'])) {
+                throw new \Exception('The optional "preselect" config option must be present in "sources"');
+            }
+
+            $this->preselect = $config['preselect'];
         }
 
         $globalConfiguration = \SimpleSAML\Configuration::getInstance();
@@ -125,6 +138,10 @@ class MultiAuth extends \SimpleSAML\Auth\Source
          */
         $url = \SimpleSAML\Module::getModuleURL('multiauth/selectsource.php');
         $params = ['AuthState' => $id];
+
+        if (!\array_key_exists('multiauth:preselect', $state) && is_string($this->preselect)) {
+            $state['multiauth:preselect'] = $this->preselect;
+        }
 
         // Allowes the user to specify the auth souce to be used
         if (isset($_GET['source'])) {

--- a/tests/modules/multiauth/lib/Auth/Source/MultiAuthTest.php
+++ b/tests/modules/multiauth/lib/Auth/Source/MultiAuthTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace SimpleSAML\Test\Module\multiauth\Auth\Source;
+
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
+use SimpleSAML\Module\multiauth\Auth\Source\MultiAuth;
+
+class MultiAuthTest extends TestCase
+{
+    /** @var Configuration */
+    private $sourceConfig;
+
+    public function setUp()
+    {
+        $this->config = Configuration::loadFromArray(['module.enable' => ['multiauth' => true]], '[ARRAY]', 'simplesaml');
+        Configuration::setPreLoadedConfig($this->config, 'config.php');
+
+        $this->sourceConfig = Configuration::loadFromArray(array(
+            'example-multi' => array(
+                'multiauth:MultiAuth',
+
+                /*
+                 * The available authentication sources.
+                 * They must be defined in this authsources.php file.
+                 */
+                'sources' => array(
+                    'example-saml' => array(
+                        'text' => array(
+                            'en' => 'Log in using a SAML SP',
+                            'es' => 'Entrar usando un SP SAML',
+                        ),
+                        'css-class' => 'SAML',
+                    ),
+                    'example-admin' => array(
+                        'text' => array(
+                            'en' => 'Log in using the admin password',
+                            'es' => 'Entrar usando la contraseña de administrador',
+                        ),
+                    ),
+                ),
+                'preselect' => 'example-saml',
+            ),
+
+            'example-saml' => array(
+                'saml:SP',
+                'entityId' => 'my-entity-id',
+                'idp' => 'my-idp',
+            ),
+
+            'example-admin' => array(
+                'core:AdminPassword',
+            ),
+        ));
+        Configuration::setPreLoadedConfig($this->sourceConfig, 'authsources.php');
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage The required "sources" config option was not found
+     */
+    public function testSourcesMustBePresent()
+    {
+        $sourceConfig = Configuration::loadFromArray(array(
+            'example-multi' => array(
+                'multiauth:MultiAuth',
+            ),
+        ));
+
+        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
+
+        new MultiAuth(['AuthId' => 'example-multi'], $sourceConfig->getArray('example-multi'));
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage The optional "preselect" config option must be present in "sources"
+     */
+    public function testPreselectMustBeValid()
+    {
+        $sourceConfig = Configuration::loadFromArray(array(
+            'example-multi' => array(
+                'multiauth:MultiAuth',
+
+                /*
+                 * The available authentication sources.
+                 * They must be defined in this authsources.php file.
+                 */
+                'sources' => array(
+                    'example-saml' => array(
+                        'text' => array(
+                            'en' => 'Log in using a SAML SP',
+                            'es' => 'Entrar usando un SP SAML',
+                        ),
+                        'css-class' => 'SAML',
+                    ),
+                    'example-admin' => array(
+                        'text' => array(
+                            'en' => 'Log in using the admin password',
+                            'es' => 'Entrar usando la contraseña de administrador',
+                        ),
+                    ),
+                ),
+                'preselect' => 'other',
+            ),
+
+            'example-saml' => array(
+                'saml:SP',
+                'entityId' => 'my-entity-id',
+                'idp' => 'my-idp',
+            ),
+
+            'example-admin' => array(
+                'core:AdminPassword',
+            ),
+        ));
+
+        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
+        new MultiAuth(['AuthId' => 'example-multi'], $sourceConfig->getArray('example-multi'));
+    }
+
+    public function testPreselectIsOptional()
+    {
+        $sourceConfig = Configuration::loadFromArray(array(
+            'example-multi' => array(
+                'multiauth:MultiAuth',
+
+                /*
+                 * The available authentication sources.
+                 * They must be defined in this authsources.php file.
+                 */
+                'sources' => array(
+                    'example-saml' => array(
+                        'text' => array(
+                            'en' => 'Log in using a SAML SP',
+                            'es' => 'Entrar usando un SP SAML',
+                        ),
+                        'css-class' => 'SAML',
+                    ),
+                    'example-admin' => array(
+                        'text' => array(
+                            'en' => 'Log in using the admin password',
+                            'es' => 'Entrar usando la contraseña de administrador',
+                        ),
+                    ),
+                ),
+            ),
+
+            'example-saml' => array(
+                'saml:SP',
+                'entityId' => 'my-entity-id',
+                'idp' => 'my-idp',
+            ),
+
+            'example-admin' => array(
+                'core:AdminPassword',
+            ),
+        ));
+
+        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
+
+        $state = [];
+        $source = new MultiAuth(['AuthId' => 'example-multi'], $sourceConfig->getArray('example-multi'));
+
+        try {
+            $source->authenticate($state);
+        } catch (\Error $e) {
+        } catch (\Exception $e) {
+        }
+
+        $this->assertArrayNotHasKey('multiauth:preselect', $state);
+    }
+
+    public function testPreselectCanBeConfigured()
+    {
+        $state = [];
+
+        $source = new MultiAuth(['AuthId' => 'example-multi'], $this->sourceConfig->getArray('example-multi'));
+
+        try {
+            $source->authenticate($state);
+        } catch (\Exception $e) {
+        }
+
+        $this->assertArrayHasKey('multiauth:preselect', $state);
+        $this->assertEquals('example-saml', $state['multiauth:preselect']);
+    }
+
+    public function testStatePreselectHasPriority()
+    {
+        $state = ['multiauth:preselect' => 'example-admin'];
+
+        $source = new MultiAuth(['AuthId' => 'example-multi'], $this->sourceConfig->getArray('example-multi'));
+
+        try {
+            $source->authenticate($state);
+        } catch (\Exception $e) {
+        }
+
+        $this->assertArrayHasKey('multiauth:preselect', $state);
+        $this->assertEquals('example-admin', $state['multiauth:preselect']);
+    }
+}

--- a/tests/modules/multiauth/lib/Auth/Source/MultiAuthTest.php
+++ b/tests/modules/multiauth/lib/Auth/Source/MultiAuthTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
 use SimpleSAML\Module\multiauth\Auth\Source\MultiAuth;
 
-class MultiAuthTest extends TestCase
+class MultiAuthTest extends \SimpleSAML\Test\Utils\ClearStateTestCase
 {
     /** @var Configuration */
     private $sourceConfig;


### PR DESCRIPTION
The use case is: We want to use multiauth but without show the select source page. This a extra step than can confuse to our users.

So, if no `source` or `multiauth:preselect` option is present, the optional `preselect` value could be used to redirect directly to default source.

It is responsibility of the custom theme to detect than the request comes from 'multiauth' module and show a way to delegate the authentication to the others sources.

If no `preselect` option is added, the module works as usual.

The proposed config for this is:

```php
<?php
array(
    'example-multi' => array(
        'multiauth:MultiAuth',

        /*
         * The available authentication sources.
         * They must be defined in this authsources.php file.
         */
        'sources' => array(
            'example-saml' => array(
                // ...
            ),
            'example-admin' => array(
                // ...
            ),
        ),
        // New option (optional)
        'preselect' => 'example-saml',
    ),
);
```