### PR TITLE
Add Password Support to Redis library

### DIFF
--- a/docs/simplesamlphp-maintenance.md
+++ b/docs/simplesamlphp-maintenance.md
@@ -161,7 +161,7 @@ The required tables are created automatically. If you are storing data from mult
 
 To store sessions in Redis, set the `store.type` option to `redis`.
 
-By default SimpleSAMLphp will attempt to connect to Redis on the `localhost` at port `6379`. These can be configured via the `store.redis.host` and `store.redis.port` options, respectively. You may also set a key prefix with the `store.redis.prefix` option.
+By default SimpleSAMLphp will attempt to connect to Redis on the `localhost` at port `6379`. These can be configured via the `store.redis.host` and `store.redis.port` options, respectively. You may also set a key prefix with the `store.redis.prefix` option. For Redis instances that [require authentication](https://redis.io/commands/auth), use the `store.redis.password` option.
 
 ## Metadata storage
 

--- a/lib/SimpleSAML/Store/Redis.php
+++ b/lib/SimpleSAML/Store/Redis.php
@@ -31,13 +31,14 @@ class Redis extends Store
             $host = $config->getString('store.redis.host', 'localhost');
             $port = $config->getInteger('store.redis.port', 6379);
             $prefix = $config->getString('store.redis.prefix', 'SimpleSAMLphp');
+            $password = $config->getString('store.redis.password', '');
 
             $redis = new \Predis\Client(
                 [
                     'scheme' => 'tcp',
                     'host' => $host,
                     'port' => $port,
-                ],
+                ] + (!empty($password) ? ['password' => $password] : []),
                 [
                     'prefix' => $prefix,
                 ]

--- a/tests/lib/SimpleSAML/Store/RedisTest.php
+++ b/tests/lib/SimpleSAML/Store/RedisTest.php
@@ -89,6 +89,27 @@ class RedisTest extends TestCase
     }
 
     /**
+     * @covers \SimpleSAML\Store::getInstance
+     * @covers \SimpleSAML\Store\Redis::__construct
+     * @test
+     */
+    public function testRedisInstanceWithPassword()
+    {
+        $config = Configuration::loadFromArray([
+            'store.type' => 'redis',
+            'store.redis.prefix' => 'phpunit_',
+            'store.redis.password' => 'password',
+        ], '[ARRAY]', 'simplesaml');
+
+        $store = Store::getInstance();
+
+        $this->assertInstanceOf('SimpleSAML\Store\Redis', $store);
+
+        $this->clearInstance($config, '\SimpleSAML\Configuration');
+        $this->clearInstance($store, '\SimpleSAML\Store');
+    }
+
+    /**
      * @covers \SimpleSAML\Store\Redis::get
      * @covers \SimpleSAML\Store\Redis::set
      * @test


### PR DESCRIPTION
For Redis instances that require authentication, the current Redis store does not work.  So, this commit adds optional support for utilizing the Predis password option.  It will pick up the password from the config file and pass it along when it instantiates the Predis client.

The test simply checks that adding the password option doesn't break the constructor. Since Predis parameters end up as protected, we can't verify that the instance contains the password.