### PR TITLE
Make metarefresh work in 1.17.0 rc1

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -1044,7 +1044,7 @@ class SAMLParser
                             $attrNameFormat = $attr->getNameFormat();
                             $attrValue = $attr->getAttributeValue();
 
-                            if ($attrName() === null || $attrValue === []) {
+                            if ($attrName === null || $attrValue === []) {
                                 continue;
                             }
 

--- a/modules/metarefresh/lib/MetaLoader.php
+++ b/modules/metarefresh/lib/MetaLoader.php
@@ -431,7 +431,7 @@ class MetaLoader
 
                 foreach ($elements as $m) {
                     $entityID = $m['metadata']['entityid'];
-                    $content .= "\n".'$metadata[\''.
+                    $content .= "\n".'$metadata[\'';
                     $content .= addslashes($entityID).'\'] = '.var_export($m['metadata'], true).';'."\n";
                 }
 


### PR DESCRIPTION
It turns out that in addition to what's described in #1032 and simplesamlphp/saml2#151, there are a couple of minor typos introduced by recent changes that prevent metarefresh from outputting syntactically valid PHP when the flatfile metadata source is configured.

The typo in `lib/SimpleSAML/Metadata/SAMLParser.php` causes metarefresh to crash with an exception in the logs like this:

```
[b28306d351] SimpleSAML\Error\Exception: Error 1 - Call to undefined function http://macedir.org/entity-category-support() at /srv/simplesamlphp-1.17.0-rc1/lib/SimpleSAML/Metadata/SAMLParser.php:1050
[b28306d351] Backtrace:
[b28306d351] 2 /srv/simplesamlphp-1.17.0-rc1/www/_include.php:48 (SimpleSAML_error_handler)
[b28306d351] 1 /srv/simplesamlphp-1.17.0-rc1/www/_include.php:25 (SimpleSAML_exception_handler)
[b28306d351] 0 [builtin] (N/A)
```

The typo in `modules/metarefresh/lib/MetaLoader.php` causes metarefresh to complete successfully, but then subsequent attempts to read the new metadata written by the module result in errors like this:

```
[b28306d351] SimpleSAML\Error\Exception: Error 1 - syntax error, unexpected '=>' (T_DOUBLE_ARROW) at /srv/simplesamlphp-1.17.0-rc1/metadata/safire-consuming/saml20-idp-remote.php:6
[b28306d351] Backtrace:
[b28306d351] 2 /srv/simplesamlphp-1.17.0-rc1/www/_include.php:48 (SimpleSAML_error_handler)
[b28306d351] 1 /srv/simplesamlphp-1.17.0-rc1/www/_include.php:25 (SimpleSAML_exception_handler)
[b28306d351] 0 [builtin] (N/A)
```

due to the fact that each entity is written without the leading `$metadata['`, thus:
```php
https://login.aaiedu.hr/edugain/saml2/idp/metadata.php'] = array (
```

Together with the patches in simplesamlphp/saml2#151 this pull request gets me to a point where I can successfully load eduGAIN's metadata into SimpleSAMLphp 1.17.0-rc1 using metarefresh.

This probably closes #1032