### PR TITLE
Allow StandardErrorLoggingHandler to be used

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -264,7 +264,7 @@ $config = [
      *
      * Choose logging handler.
      *
-     * Options: [syslog,file,errorlog]
+     * Options: [syslog,file,errorlog,stderr]
      *
      */
     'logging.level' => SimpleSAML\Logger::NOTICE,
@@ -800,7 +800,7 @@ $config = [
      * \SimpleSAML\XHTML\TemplateControllerInterface interface to use it.
      */
     //'theme.controller' => '',
-    
+
     /*
      * Templating options
      *

--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -356,6 +356,7 @@ class Logger
             'syslog'   => 'SimpleSAML\Logger\SyslogLoggingHandler',
             'file'     => 'SimpleSAML\Logger\FileLoggingHandler',
             'errorlog' => 'SimpleSAML\Logger\ErrorLogLoggingHandler',
+            'stderr' => 'SimpleSAML\Logger\StandardErrorLoggingHandler',
         ];
 
         // get the configuration


### PR DESCRIPTION
There is an existing StandardErrorLoggingHandler logging class, but no way to use it. Since logging to stderr is potentially useful to people trying to use SimpleSAMLphp in containers, this change makes the existing logging class usable.