### PR TITLE
translation: Use proper german wording for login header message

### DIFF
--- a/dictionaries/login.translation.json
+++ b/dictionaries/login.translation.json
@@ -42,7 +42,7 @@
 		"sv": "Ange ditt anv\u00e4ndarnamn och l\u00f6senord",
 		"es": "Introduzca su nombre de usuario y contrase\u00f1a",
 		"fr": "Entrez votre identifiant et votre mot de passe",
-		"de": "Bitten geben Sie ihren Nutzernamen und Passwort ein",
+		"de": "Bitte geben Sie Ihren Nutzernamen und Ihr Passwort ein",
 		"nl": "Geef je gebruikersnaam en wachtwoord",
 		"lb": "Gid w.e.g Aeren Benotzernumm an d Passwuert an",
 		"sl": "Vnesite svoje uporabni\u0161ko ime in geslo",

--- a/locales/de/LC_MESSAGES/messages.po
+++ b/locales/de/LC_MESSAGES/messages.po
@@ -465,7 +465,7 @@ msgid "{general:no_cancel}"
 msgstr "Nein, ich stimme nicht zu"
 
 msgid "{login:user_pass_header}"
-msgstr "Bitten geben Sie ihren Nutzernamen und Passwort ein"
+msgstr "Bitte geben Sie Ihren Nutzernamen und Ihr Passwort ein"
 
 msgid "{errors:report_explain}"
 msgstr "Erläutern Sie, wodurch der Fehler auftrat..."
@@ -978,7 +978,7 @@ msgstr ""
 "Kopfzeile der SAML-Entität."
 
 msgid "Enter your username and password"
-msgstr "Bitten geben Sie ihren Nutzernamen und Passwort ein"
+msgstr "Bitte geben Sie Ihren Nutzernamen und Ihr Passwort ein"
 
 msgid "Login at"
 msgstr "Login bei"


### PR DESCRIPTION
Just noticed this being wrongly. Not quite sure what your merge strategy is... should this go to master, potentially skipping the stable 1.16/next 1.17 channel? 