### PR TITLE
allow paths to use stream wrappers

### DIFF
--- a/lib/SimpleSAML/Utils/System.php
+++ b/lib/SimpleSAML/Utils/System.php
@@ -107,7 +107,9 @@ class System
     /**
      * Resolve a (possibly) relative path from the given base path.
      *
-     * A path which starts with a '/' is assumed to be absolute, all others are assumed to be
+     * A path which starts with a stream wrapper pattern (e.g. s3://) will not be touched
+     * and returned as is - regardles of the value given as base path.
+     * If it starts with a '/' it is assumed to be absolute, all others are assumed to be
      * relative. The default base path is the root of the SimpleSAMLphp installation.
      *
      * @param string      $path The path we should resolve.
@@ -144,17 +146,21 @@ class System
             $ret = $base;
         }
 
-        $path = explode('/', $path);
-        foreach ($path as $d) {
-            if ($d === '.') {
-                continue;
-            } elseif ($d === '..') {
-                $ret = dirname($ret);
-            } else {
-                if ($ret && substr($ret, -1) !== '/') {
-                    $ret .= '/';
+        if (static::pathContainsStreamWrapper($path)){
+            $ret = $path;
+        } else {
+            $path = explode('/', $path);
+            foreach ($path as $d) {
+                if ($d === '.') {
+                    continue;
+                } elseif ($d === '..') {
+                    $ret = dirname($ret);
+                } else {
+                    if ($ret && substr($ret, -1) !== '/') {
+                        $ret .= '/';
+                    }
+                    $ret .= $d;
                 }
-                $ret .= $d;
             }
         }
 
@@ -238,5 +244,15 @@ class System
         $letterAsciiValue = ord(strtoupper(substr($path, 0, 1)));
         return substr($path, 1, 1) === ':'
                 && $letterAsciiValue >= 65 && $letterAsciiValue <= 90;
+    }
+
+    /**
+     * Check if the supplied path contains a stream wrapper
+     * @param string $path
+     * @return bool
+     */
+    private static function pathContainsStreamWrapper(string $path)
+    {
+        return preg_match('/^[\w\d]*:\/{2}/', $path) === 1;
     }
 }

--- a/lib/SimpleSAML/Utils/System.php
+++ b/lib/SimpleSAML/Utils/System.php
@@ -251,7 +251,7 @@ class System
      * @param string $path
      * @return bool
      */
-    private static function pathContainsStreamWrapper(string $path)
+    private static function pathContainsStreamWrapper($path)
     {
         return preg_match('/^[\w\d]*:\/{2}/', $path) === 1;
     }

--- a/tests/lib/SimpleSAML/Utils/SystemTest.php
+++ b/tests/lib/SimpleSAML/Utils/SystemTest.php
@@ -100,6 +100,36 @@ class SystemTest extends TestCase
     }
 
     /**
+     * @covers \SimpleSAML\Utils\System::resolvePath
+     * @test
+     */
+    public function testResolvePathAllowsStreamWrappers()
+    {
+        $base = '/base/';
+        $path = 'vfs://simplesaml';
+
+        $res = System::resolvePath($path, $base);
+        $expected = $path;
+
+        $this->assertEquals($expected, $res);
+    }
+
+    /**
+     * @covers \SimpleSAML\Utils\System::resolvePath
+     * @test
+     */
+    public function testResolvePathAllowsAwsS3StreamWrappers()
+    {
+        $base = '/base/';
+        $path = 's3://bucket-name/key-name';
+
+        $res = System::resolvePath($path, $base);
+        $expected = $path;
+
+        $this->assertEquals($expected, $res);
+    }
+
+    /**
      * @covers \SimpleSAML\Utils\System::writeFile
      * @test
      */
@@ -230,7 +260,6 @@ class SystemTest extends TestCase
 
         $this->clearInstance($config, '\SimpleSAML\Configuration');
     }
-
     private function setConfigurationTempDir($directory)
     {
         $config = Configuration::loadFromArray([


### PR DESCRIPTION
Currently the function `System::resolvePath` assumes paths, which are using stream wrappers like `s3://` to be relative to a base path.

To allow the usage of stream wrappers the `System` class has been extended. This gives the ability to store **certificates** and **private keys** in a different location than the server's filesystem but can also be used for other scenarios where configured paths are used (e.g. logdir, datadir, tempdir). 