### PR TITLE
Prevent SP Metadata to be saved in Session

### DIFF
--- a/lib/SimpleSAML/IdP.php
+++ b/lib/SimpleSAML/IdP.php
@@ -167,16 +167,14 @@ class SimpleSAML_IdP
         return $this->config;
     }
 
-
     /**
-     * Get SP name.
+     * Get SP object.
      *
      * @param string $assocId The association identifier.
      *
-     * @return array|null The name of the SP, as an associative array of language => text, or null if this isn't an SP.
+     * @return SimpleSAML_Configuration The SP, as a configuration object or null if this isn't an SP.
      */
-    public function getSPName($assocId)
-    {
+    public static function getSP($assocId) {
         assert('is_string($assocId)');
 
         $prefix = substr($assocId, 0, 4);
@@ -200,6 +198,25 @@ class SimpleSAML_IdP
                 return null;
             }
         }
+
+        return $spMetadata;
+    }
+
+
+    /**
+     * Get SP name.
+     *
+     * @param string $assocId The association identifier.
+     *
+     * @return array|null The name of the SP, as an associative array of language => text, or null if this isn't an SP.
+     */
+    public function getSPName($assocId)
+    {
+        assert('is_string($assocId)');
+        $prefix = substr($assocId, 0, 4);
+        $spEntityId = substr($assocId, strlen($prefix) + 1);
+
+        $spMetadata = self::getSP($assocId);
 
         if ($spMetadata->hasValue('name')) {
             return $spMetadata->getLocalizedString('name');
@@ -308,6 +325,10 @@ class SimpleSAML_IdP
 
         if (isset($state['SPMetadata'])) {
             $spMetadata = $state['SPMetadata'];
+        } elseif (isset($state['SPAssocId'])) {
+            $spMetadata = self::getSP($state['SPAssocId'])->toArray();
+            // rehydrate state for authproc
+            $state['SPMetadata'] = $spMetadata;
         } else {
             $spMetadata = array();
         }

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -411,7 +411,7 @@ class sspmod_saml_IdP_SAML2
             SimpleSAML_Auth_State::EXCEPTION_HANDLER_FUNC => array('sspmod_saml_IdP_SAML2', 'handleAuthError'),
             SimpleSAML_Auth_State::RESTART                => $sessionLostURL,
 
-            'SPMetadata'                  => $spMetadata->toArray(),
+            'SPAssocId'                   => 'saml:' . $spEntityId,
             'saml:RelayState'             => $relayState,
             'saml:RequestId'              => $requestId,
             'saml:IDPList'                => $IDPList,


### PR DESCRIPTION
Currently SP Metadata is saved in the session for every AuthN request. This can lead to heavily polluted sessions in case of unprocessed AuthN requests (in my case some services frontend trying to access protected data once every 5 seconds).
Combine this with the default configured `session.state.timeout` of 60 minutes and we had to face sessions of ~72mb size for every user per 100kb of SP metadata.

This patch prevents saving the whole SP Metadata and only saves the EntityId.