### PR TITLE
Supress warning on absent NameIDFormat

### DIFF
--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -1194,17 +1194,17 @@ class SAML2
             $a->setAttributes($attributes);
         }
 
+        $nameIdFormat = null;
+
         // generate the NameID for the assertion
         if (isset($state['saml:NameIDFormat'])) {
             $nameIdFormat = $state['saml:NameIDFormat'];
-        } else {
-            $nameIdFormat = null;
         }
 
         if ($nameIdFormat === null || !isset($state['saml:NameID'][$nameIdFormat])) {
             // either not set in request, or not set to a format we supply. Fall back to old generation method
             $nameIdFormat = current($spMetadata->getArrayizeString('NameIDFormat', []));
-            if ($nameIdFormat === null) {
+            if ($nameIdFormat === false) {
                 $nameIdFormat = current($idpMetadata->getArrayizeString('NameIDFormat', [\SAML2\Constants::NAMEID_TRANSIENT]));
             }
         }


### PR DESCRIPTION
After updating to 1.17 I started noticing a lot of warnings in the log:
\Mar  4 12:47:16 sv1810934 IDP-BZK[5791]: 3 [c11b0ed290] Unable to generate NameID. Check the userid.attribute option.

SP doesn't ask for a specific NameIDFormat and none is set in the metadata...
current([]) would return false, but we never catch that, so it falls through,..