### PR TITLE
Filled in version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "simplesamlphp/simplesamlphp",
     "description": "A PHP implementation of a SAML 2.0 service provider and identity provider, also compatible with Shibboleth 1.3 and 2.0.",
     "type": "project",
+    "version": "1.17.1",
     "keywords": [ "saml2", "shibboleth","oauth","ws-federation","sp","idp" ],
     "homepage": "http://simplesamlphp.org",
     "license": "LGPL-2.1-or-later",


### PR DESCRIPTION
It's required, when you want to install some module which have dependency on 'simplesamlphp/simplesamlphp'