### PR TITLE
Set max Twig-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "symfony/http-kernel": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
         "symfony/yaml": "^3.4 || ^4.0",
-        "twig/twig": "~1.0 || ~2.0",
+        "twig/twig": "<1.38 || >2.0 <2.7",
         "whitehat101/apr1-md5": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
It appears that Twig 2.7 has a bc-breaking change that breaks our unit tests:

Fatal error: Declaration of Twig_Extensions_TokenParser_Trans::parse(Twig_Token $token) must be compatible with Twig\TokenParser\TokenParserInterface::parse(Twig\Token $token) in /home/travis/build/simplesamlphp/simplesamlphp/vendor/twig/extensions/lib/Twig/Extensions/TokenParser/Trans.php on line 86

This PR locks the max version to 2.6.x.
Needs backporting to 1.17 & 1.16-branch as well