### PR TITLE
Fix logic error in UIInfo generation

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -1089,8 +1089,8 @@ class SAMLParser
 
                     foreach ($e->getKeywords() as $uiItem) {
                         if (!($uiItem instanceof \SAML2\XML\mdui\Keywords)
-                            || ($uiItem->getKeywords() !== [])
-                            || ($uiItem->getLanguage() !== null)
+                            || ($uiItem->getKeywords() === [])
+                            || ($uiItem->getLanguage() === null)
                         ) {
                             continue;
                         }
@@ -1098,9 +1098,9 @@ class SAMLParser
                     }
                     foreach ($e->getLogo() as $uiItem) {
                         if (!($uiItem instanceof \SAML2\XML\mdui\Logo)
-                            || ($uiItem->getUrl() !== null)
-                            || ($uiItem->getHeight() !== null)
-                            || ($uiItem->getWidth() !== null)
+                            || ($uiItem->getUrl() === null)
+                            || ($uiItem->getHeight() === null)
+                            || ($uiItem->getWidth() === null)
                         ) {
                             continue;
                         }

--- a/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/lib/SimpleSAML/Metadata/SAMLParserTest.php
@@ -247,7 +247,7 @@ XML
                 'example.net',
             ],
             'UIInfo' => [
-                'DisplayName' => ['en' => 'DisplayName',],
+                'DisplayName' => ['en' => 'DisplayName', 'af' => 'VertoonNaam'],
                 'Description' => ['en' => 'Description',],
                 'InformationURL' => ['en' => 'https://localhost/information',],
                 'PrivacyStatementURL' => ['en' => 'https://localhost/privacypolicy',],
@@ -269,7 +269,7 @@ XML
                 'DomainHint' => ['example.net', 'example.org',],
                 'GeolocationHint' => ['geo:-29.00000,24.00000;u=830000',],
             ],
-            'name' => ['en' => 'DisplayName',],
+            'name' => ['en' => 'DisplayName', 'af' => 'VertoonNaam'],
         ];
 
         $document = \SAML2\DOMDocumentFactory::fromString(
@@ -282,6 +282,7 @@ XML
           <shibmd:Scope regexp="false">example.net</shibmd:Scope>
           <mdui:UIInfo>
             <mdui:DisplayName xml:lang="en">DisplayName</mdui:DisplayName>
+            <mdui:DisplayName xml:lang="af">VertoonNaam</mdui:DisplayName>
             <mdui:Description xml:lang="en">Description</mdui:Description>
             <mdui:PrivacyStatementURL xml:lang="en">https://localhost/privacypolicy</mdui:PrivacyStatementURL>
             <mdui:InformationURL xml:lang="en">https://localhost/information</mdui:InformationURL>


### PR DESCRIPTION
There is a simple boolean logic error in the handling of mdui:Keywords and mdui:Logo that results in those elements never being output into metadata.

This impacts any user interface that displays a logo for an entity (such as discovery interfaces). It is a regression that affects the 1.17.1 release.