### PR TITLE
discopower module tabs don't work

### DIFF
--- a/modules/discopower/templates/disco.tpl.php
+++ b/modules/discopower/templates/disco.tpl.php
@@ -7,9 +7,10 @@ $this->data['head'] = '<link rel="stylesheet" media="screen" type="text/css" hre
     SimpleSAML\Module::getModuleURL('discopower/assets/css/disco.css').'" />';
 
 $this->data['head'] .= '<script type="text/javascript" src="'.
-    SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery.livesearch.js').'"></script>';
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery.livesearch.js').'"></script>'."\n";
 $this->data['head'] .= '<script type="text/javascript" src="'.
-    SimpleSAML\Module::getModuleURL('discopower/assets/js/quicksilver.js').'"></script>';
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/quicksilver.js"></script>'."\n";
+$this->data['head'] .= $this->data['search'];
 
 if (!empty($this->data['faventry'])) {
     $this->data['autofocus'] = 'favouritesubmit';
@@ -128,19 +129,6 @@ foreach ($this->data['idplist'] as $tab => $slist) {
 ?>
 
 </div>
-
-<script type="text/javascript">
-$(document).ready(function () {
-<?php
-$i = 0;
-foreach ($this->data['idplist'] as $tab => $slist) {
-    echo "\n".'$("#query_'.$tab.'").liveUpdate("#list_'.$tab.'")'.
-        (($i++ == 0) && (empty($this->data['faventry'])) ? '.focus()' : '').';';
-}
-?>
-});
-
-</script>
 
 <?php
 $this->data['head'] .= '<script type="text/javascript" src="'.

--- a/modules/discopower/templates/disco.tpl.php
+++ b/modules/discopower/templates/disco.tpl.php
@@ -9,7 +9,7 @@ $this->data['head'] = '<link rel="stylesheet" media="screen" type="text/css" hre
 $this->data['head'] .= '<script type="text/javascript" src="'.
     SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery.livesearch.js').'"></script>'."\n";
 $this->data['head'] .= '<script type="text/javascript" src="'.
-    SimpleSAML\Module::getModuleURL('discopower/assets/js/quicksilver.js"></script>'."\n";
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/'.$this->data['score'].'.js').'"></script>'."\n";
 $this->data['head'] .= $this->data['search'];
 
 if (!empty($this->data['faventry'])) {
@@ -131,6 +131,4 @@ foreach ($this->data['idplist'] as $tab => $slist) {
 </div>
 
 <?php
-$this->data['head'] .= '<script type="text/javascript" src="'.
-    SimpleSAML\Module::getModuleURL('discopower/assets/js/suggest.js').'"></script>';
 $this->includeAtTemplateBase('includes/footer.php');


### PR DESCRIPTION
The template for discopower ends up with broken tabs because the call to
```javascript
$("#tabdiv").tabs
```
is missing.

Looking through the equivalent twig template, the whole function has migrated to [PowerIdPDisco.php](https://github.com/simplesamlphp/simplesamlphp/blob/master/modules/discopower/lib/PowerIdPDisco.php#L288), so rather than fixing it in this template, it makes sense to duplicate what's happening in the twig template. Thus the first commit removes the javascript references to liveUpdate at the bottom in favour of simply including `$this->data['search']` which produces the same result albeit with the tabs call.

At the same time I noticed that both `String.prototype.score` functions were being included (quicksilver and suggest) rather than honouring the one selected in the config file. The second commit removes the duplication and replaces the hardcoded quicksilver.js with the configured version.

Although my patches are against master, this affects the released 1.17.1.