### PR TITLE
Make the module-discopower twig template usable

### DIFF
--- a/modules/discopower/locales/en/LC_MESSAGES/discopower.po
+++ b/modules/discopower/locales/en/LC_MESSAGES/discopower.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: SimpleSAMLphp 1.15\n"
 "Report-Msgid-Bugs-To: simplesamlphp-translation@googlegroups.com\n"
 "POT-Creation-Date: 2016-10-12 09:23+0200\n"
-"PO-Revision-Date: 2016-10-14 12:14+0200\n"
+"PO-Revision-Date: 2019-03-20 15:27+0200\n"
 "Last-Translator: \n"
 "Language: en\n"
 "Language-Team: \n"
@@ -92,4 +92,7 @@ msgstr "Europe (eduGAIN)"
 
 msgid "InCommon"
 msgstr "InCommon"
+
+msgid "{discopower:tabs:incremental_search}"
+msgstr "Incremental search..."
 

--- a/modules/discopower/templates/disco.twig
+++ b/modules/discopower/templates/disco.twig
@@ -3,13 +3,14 @@
 
 {% block preload %}
     <link rel="stylesheet" media="screen" href="/{{ baseurlpath }}resources/uitheme1.8/jquery-ui.css">
+    <link rel="stylesheet" media="screen" href="/{{ baseurlpath }}module.php/discopower/assets/css/disco.css">
 {% endblock %}
 {% block postload %}
     <script src="/{{ baseurlpath }}resources/jquery-1.8.js"></script>
     <script src="/{{ baseurlpath }}resources/jquery-ui-1.8.js"></script>
-    <script src="/{{ baseurlpath }}module.php/discopower/js/jquery.livesearch.js"></script>
-    <script src="/{{ baseurlpath }}module.php/discopower/js/{{ score }}.js"></script>
-    <script src="/{{ baseurlpath }}module.php/discopower/js/tablist.js"></script>
+    <script src="/{{ baseurlpath }}module.php/discopower/assets/js/jquery.livesearch.js"></script>
+    <script src="/{{ baseurlpath }}module.php/discopower/assets/js/{{ score }}.js"></script>
+    <script src="/{{ baseurlpath }}module.php/discopower/assets/js/tablist.js"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
simplesamlphp@b3ee105e720a3d243c1a7c8247b4687816542e03 undid simplesamlphp@d13304e8cbc8ecdb83315f8118e4b4dc88d05912

This is a regression that makes the twig template in 1.17.1 unusable. However, the change below is against master and thus incorporates the change from #1079 too.