### PR TITLE
Handle untranslated tabs more gracefully in discopower-module

### DIFF
--- a/modules/discopower/lib/PowerIdPDisco.php
+++ b/modules/discopower/lib/PowerIdPDisco.php
@@ -281,6 +281,9 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
         $t->data['rememberchecked'] = $this->config->getBoolean('idpdisco.rememberchecked', false);
         $t->data['jquery'] = ['core' => true, 'ui' => true];
         foreach(array_keys($idpList) as $tab) {
+            if ($t->getTag('{discopower:tabs:' . $tab . '}') === null) {
+                $t->includeInlineTranslation('{discopower:tabs:'. $tab. '}', $tab);
+            }
             $t->data['tabNames'][$tab] = \SimpleSAML\Locale\Translate::noop('{discopower:tabs:' . $tab . '}');
         }
         $t->show();


### PR DESCRIPTION
Following on from #1081, this changes the behaviour of tabs for which there is no translation available. Instead of displaying "not translated ({discopower:tabs:foo})", it will fail to the more graceful and less ugly behaviour of simply displaying the tab's original untranslatable name.