### PR TITLE
Initial tests for authorize:authorize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,12 @@
         },
         "files": ["lib/_autoload_modules.php"]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "SimpleSAML\\Test\\": "tests"
+        },
+        "files": ["tests/_autoload_modules.php"]
+    },
     "require": {
         "php": ">=5.5",
         "ext-SPL": "*",

--- a/modules/authorize/docs/authorize.md
+++ b/modules/authorize/docs/authorize.md
@@ -50,14 +50,17 @@ Note: If regex is enabled, you must use the preg_match format, i.e. you have to 
    (as far as I know), you have to close the browser.
 
 ### Examples ###
-To use this filter configure it in `config/config.php`:
+To use this filter configure it in `config/config.php`.
+For unstructured attributes use `^` and `$` to anchor your regex as necessary:
+
 ```php
 'authproc.sp' => [
     60 => [
         'class' => 'authorize:Authorize',
         'uid'   =>  [
-            '/.*@example.com/',
-            '/(user1|user2|user3)@example.edu/',
+            '/^.*@example.com$/',
+            // Use anchors to prevent matching 'wronguser1@exampled.edu.attacker.com'
+            '/^(user1|user2|user3)@example.edu$/',
         ],
         'schacUserStatus' => '@urn:mace:terena.org:userStatus:' .
         'example.org:service:active.*@',
@@ -72,10 +75,10 @@ An alternate way of using this filter is to deny certain users. Or even use mult
 'authproc.sp' => [
     60 => array[
         'class' => 'authorize:Authorize',
-        'deny'  => TRUE,
+        'deny'  => true,
         'uid'   =>  [
-            '/.*@students.example.edu/',
-            '/(stu1|stu2|stu3)@example.edu/',
+            '/.*@students.example.edu$/',
+            '/^(stu1|stu2|stu3)@example.edu$/',
         ]
     ]
 ]
@@ -89,7 +92,7 @@ Additionally, some helpful instructions are shown.
 'authproc.sp' => [
     60 => [
         'class' => 'authorize:Authorize',
-        'regex' => FALSE,
+        'regex' => false,
         'group' => [
             'CN=SimpleSAML Students,CN=Users,DC=example,DC=edu',
             'CN=All Teachers,OU=Staff,DC=example,DC=edu',

--- a/tests/_autoload_modules.php
+++ b/tests/_autoload_modules.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file registers an autoloader for test classes used by SimpleSAMLphp modules unit tests.
+ */
+
+/**
+ * Autoload function for SimpleSAMLphp modules test classes following PSR-4.
+ * Module test classes have namespaces like SimpleSAML\Test\Module\<moduleName>\Auth\Process
+ *
+ * @param string $className Name of the class.
+ */
+function sspmodTestClassAutoloadPSR4($className)
+{
+    $elements = explode('\\', $className);
+    if ($elements[0] === '') {
+        // class name starting with /, ignore
+        array_shift($elements);
+    }
+    if (count($elements) < 5) {
+        return; // it can't be a module test class
+    }
+    if (array_shift($elements) !== 'SimpleSAML') {
+        return; // the first element is not "SimpleSAML"
+    }
+    if (array_shift($elements) !== 'Test') {
+        return; // the second element is not "test"
+    }
+    if (array_shift($elements) !== 'Module') {
+        return; // the second element is not "module"
+    }
+
+    // this is a SimpleSAMLphp module test class following PSR-4
+    $module = array_shift($elements);
+    $moduleTestDir = __DIR__ .'/modules/'.$module;
+    $file = $moduleTestDir .'/lib/'.implode('/', $elements).'.php';
+
+    if (file_exists($file)) {
+        require_once($file);
+    }
+}
+
+spl_autoload_register('sspmodTestClassAutoloadPSR4');

--- a/tests/modules/authorize/lib/Auth/Process/AuthorizeTest.php
+++ b/tests/modules/authorize/lib/Auth/Process/AuthorizeTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Test for the authorize:Authorize authproc filter.
+ */
+
+namespace SimpleSAML\Test\Module\consent\Auth\Process;
+
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Module\authorize\Auth\Process\Authorize;
+use SimpleSAML\Utils\Attributes;
+
+class AuthorizeTest extends TestCase
+{
+
+    /**
+     * Helper function to run the filter with a given configuration.
+     *
+     * @param array $config The filter configuration.
+     * @param array $request The request state.
+     * @return array  The state array after processing.
+     */
+    private function processFilter(array $config, array $request)
+    {
+        $filter = new TestableAuthorize($config, null);
+        $filter->process($request);
+        return $request;
+    }
+
+    /**
+     * Test that having a matching attribute grants access
+     * @dataProvider allowScenarioProvider
+     * @param array $userAttributes The attributes to test
+     * @param bool $isAuthorized Should the user be authorized
+     */
+    public function testAllowScenarios($userAttributes, $isAuthorized)
+    {
+        $userAttributes = Attributes::normalizeAttributesArray($userAttributes);
+        $config = [
+            'uid' => [
+                '/^.*@example.com$/',
+                '/^(user1|user2|user3)@example.edu$/',
+            ],
+            'schacUserStatus' => '@urn:mace:terena.org:userStatus:example.org:service:active.*@',
+        ];
+
+        $resultState = $this->processFilter($config, ['Attributes' => $userAttributes]);
+
+        $resultAuthorized = isset($resultState['NOT_AUTHORIZED']) ? false : true;
+        $this->assertEquals($isAuthorized, $resultAuthorized);
+    }
+
+    public function allowScenarioProvider()
+    {
+        return [
+            // Should be allowed
+            [['uid' => 'anything@example.com'], true],
+            [['uid' => 'user2@example.edu'], true],
+            [['schacUserStatus' => 'urn:mace:terena.org:userStatus:example.org:service:active.my.service'], true],
+            [
+                [
+                    'uid' => ['wrongValue', 'user2@example.edu', 'wrongValue2'],
+                    'schacUserStatus' => 'incorrectstatus'
+                ],
+                true
+            ],
+
+            //Should be denied
+            [['wrongAttributes' => ['abc']], false],
+            [
+                [
+                    'uid' => [
+                        'anything@example.com.wrong',
+                        'wronguser@example.edu',
+                        'user2@example.edu.wrong',
+                        'prefixuser2@example.edu'
+                    ]
+                ],
+                false
+            ],
+        ];
+    }
+
+    /**
+     * Test that having a matching attribute prevents access
+     * @dataProvider invertScenarioProvider
+     * @param array $userAttributes The attributes to test
+     * @param bool $isAuthorized Should the user be authorized
+     */
+    public function testInvertAllowScenarios($userAttributes, $isAuthorized)
+    {
+        $userAttributes = Attributes::normalizeAttributesArray($userAttributes);
+        $config = [
+            'deny' => true,
+            'uid' => [
+                '/.*@students.example.edu$/',
+                '/^(stu1|stu2|stu3)@example.edu$/',
+            ],
+            'schacUserStatus' => '@urn:mace:terena.org:userStatus:example.org:service:blocked.*@',
+        ];
+
+        $resultState = $this->processFilter($config, ['Attributes' => $userAttributes]);
+
+        $resultAuthorized = isset($resultState['NOT_AUTHORIZED']) ? false : true;
+        $this->assertEquals($isAuthorized, $resultAuthorized);
+    }
+
+    public function invertScenarioProvider()
+    {
+        return [
+            // Should be allowed
+            [['noMatch' => 'abc'], true],
+            [['uid' => 'anything@example.edu'], true],
+
+            //Should be denied
+            [['uid' => 'anything@students.example.edu'], false],
+            [['uid' => 'stu3@example.edu'], false],
+            [['schacUserStatus' => 'urn:mace:terena.org:userStatus:example.org:service:blocked'], false],
+            // Matching any of the attributes results in denial
+            [
+                [
+                    'uid' => ['noMatch', 'abc@students.example.edu', 'noMatch2'],
+                    'schacUserStatus' => 'noMatch'
+                ],
+                false
+            ],
+        ];
+    }
+
+    /**
+     * Test that having a matching attribute prevents access
+     * @dataProvider noregexScenarioProvider
+     * @param array $userAttributes The attributes to test
+     * @param bool $isAuthorized Should the user be authorized
+     */
+    public function testDisableRegex($userAttributes, $isAuthorized)
+    {
+        $userAttributes = Attributes::normalizeAttributesArray($userAttributes);
+        $config = [
+            'regex' => false,
+            'group' => [
+                'CN=SimpleSAML Students,CN=Users,DC=example,DC=edu',
+                'CN=All Teachers,OU=Staff,DC=example,DC=edu',
+            ],
+        ];
+
+        $resultState = $this->processFilter($config, ['Attributes' => $userAttributes]);
+
+        $resultAuthorized = isset($resultState['NOT_AUTHORIZED']) ? false : true;
+        $this->assertEquals($isAuthorized, $resultAuthorized);
+    }
+
+    public function noregexScenarioProvider()
+    {
+        return [
+            // Should be allowed
+            [['group' => 'CN=SimpleSAML Students,CN=Users,DC=example,DC=edu'], true],
+
+            //Should be denied
+            [['wrongAttribute' => 'CN=SimpleSAML Students,CN=Users,DC=example,DC=edu'], false],
+            [['group' => 'CN=wrongCN=SimpleSAML Students,CN=Users,DC=example,DC=edu'], false],
+        ];
+    }
+}
+// phpcs:ignore
+class TestableAuthorize extends Authorize
+{
+    /**
+     * Override the redirect behavior since its difficult to test
+     * @param array $request the state
+     */
+    protected function unauthorized(&$request)
+    {
+        $request['NOT_AUTHORIZED'] = true;
+    }
+}

--- a/tests/modules/authorize/lib/Auth/Process/AuthorizeTest.php
+++ b/tests/modules/authorize/lib/Auth/Process/AuthorizeTest.php
@@ -3,7 +3,7 @@
  * Test for the authorize:Authorize authproc filter.
  */
 
-namespace SimpleSAML\Test\Module\consent\Auth\Process;
+namespace SimpleSAML\Test\Module\authorize\Auth\Process;
 
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Utils\Attributes;

--- a/tests/modules/authorize/lib/Auth/Process/AuthorizeTest.php
+++ b/tests/modules/authorize/lib/Auth/Process/AuthorizeTest.php
@@ -6,7 +6,6 @@
 namespace SimpleSAML\Test\Module\consent\Auth\Process;
 
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\Module\authorize\Auth\Process\Authorize;
 use SimpleSAML\Utils\Attributes;
 
 class AuthorizeTest extends TestCase
@@ -159,17 +158,5 @@ class AuthorizeTest extends TestCase
             [['wrongAttribute' => 'CN=SimpleSAML Students,CN=Users,DC=example,DC=edu'], false],
             [['group' => 'CN=wrongCN=SimpleSAML Students,CN=Users,DC=example,DC=edu'], false],
         ];
-    }
-}
-// phpcs:ignore
-class TestableAuthorize extends Authorize
-{
-    /**
-     * Override the redirect behavior since its difficult to test
-     * @param array $request the state
-     */
-    protected function unauthorized(&$request)
-    {
-        $request['NOT_AUTHORIZED'] = true;
     }
 }

--- a/tests/modules/authorize/lib/Auth/Process/TestableAuthorize.php
+++ b/tests/modules/authorize/lib/Auth/Process/TestableAuthorize.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Subclass authorize filter to make it unit testable.
+ */
+
+namespace SimpleSAML\Test\Module\consent\Auth\Process;
+
+use SimpleSAML\Module\authorize\Auth\Process\Authorize;
+
+class TestableAuthorize extends Authorize
+{
+    /**
+     * Override the redirect behavior since its difficult to test
+     * @param array $request the state
+     */
+    protected function unauthorized(&$request)
+    {
+        $request['NOT_AUTHORIZED'] = true;
+    }
+}

--- a/tests/modules/authorize/lib/Auth/Process/TestableAuthorize.php
+++ b/tests/modules/authorize/lib/Auth/Process/TestableAuthorize.php
@@ -3,7 +3,7 @@
  * Subclass authorize filter to make it unit testable.
  */
 
-namespace SimpleSAML\Test\Module\consent\Auth\Process;
+namespace SimpleSAML\Test\Module\authorize\Auth\Process;
 
 use SimpleSAML\Module\authorize\Auth\Process\Authorize;
 


### PR DESCRIPTION
Let me know if you have a recommended way for testing code that calls out `HTTP::redirectTrustedURL`. I avoided that code path in those tests.  For our internal modules we use the technique outlined in https://github.com/cirrusidentity/simplesamlphp-test-utils#mock-redirects