### PR TITLE
Add support for "rewritten urls" in module detection

### DIFF
--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -106,21 +106,28 @@ class Module
         return self::isModuleEnabledWithConf($module, $config->getArray('module.enable', []));
     }
 
-
+    /**
+     * Performs module detection from a given url
+     * @param $url url to detect module from
+     * @return array , associative array with the following keys:
+     *          - module : name of module
+     *          - isvalid : the module above is a valid module
+     *          - url : part of url that is found after module
+     * @throws Error\NotFound
+     */
     public static function getModuleInfoFromRequest($url)
     {
         assert(substr($url, 0, 1) === '/');
-
+        $module=substr($url,1);
         /* clear the PATH_INFO option, so that a script can detect whether it is called with anything following the
          *'.php'-ending.
          */
         $modEnd = strpos($url, '/', 1);
-        if ($modEnd === false) {
+        if ($modEnd !== false) {
             // the path must always be on the form /module/
-            throw new Error\NotFound('The URL must at least contain a module name followed by a slash.');
+            $module = substr($url, 1, $modEnd - 1);
         }
 
-        $module = substr($url, 1, $modEnd - 1);
         return array("module" => $module, "isvalid" => self::isModuleEnabled($module), "url" => substr($url, $modEnd));
     }
 
@@ -156,7 +163,7 @@ class Module
         }
         $module = $moduleinfo["module"];
         $url = $moduleinfo["url"];
-        if ($moduleinfo["isValid"] === false) {
+        if ($moduleinfo["isvalid"] === false) {
             throw new Error\NotFound('The module \'' . $module . '\' was either not found, or wasn\'t enabled.');
         }
 

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  */
 class Module
 {
-
     /**
      * Index pages: file names to attempt when accessing directories.
      *
@@ -118,9 +117,9 @@ class Module
     public static function getModuleInfoFromRequest($url)
     {
         assert(substr($url, 0, 1) === '/');
-        $module=substr($url,1);
+        $module = substr($url, 1);
         /* clear the PATH_INFO option, so that a script can detect whether it is called with anything following the
-         *'.php'-ending.
+         * '.php'-ending.
          */
         $modEnd = strpos($url, '/', 1);
         if ($modEnd !== false) {
@@ -128,7 +127,7 @@ class Module
             $module = substr($url, 1, $modEnd - 1);
         }
 
-        return array("module" => $module, "isvalid" => self::isModuleEnabled($module), "url" => substr($url, $modEnd));
+        return ["module" => $module, "isvalid" => self::isModuleEnabled($module), "url" => substr($url, $modEnd)];
     }
 
     /**

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -163,7 +163,7 @@ class Module
         $module = $moduleinfo["module"];
         $url = $moduleinfo["url"];
         if ($moduleinfo["isvalid"] === false) {
-            throw new Error\NotFound('The module \'' . $module . '\' was either not found, or wasn\'t enabled.');
+            throw new Error\NotFound('The module \''.$module.'\' was either not found, or wasn\'t enabled.');
         }
 
         /* Make sure that the request isn't suspicious (contains references to current directory or parent directory or


### PR DESCRIPTION
This is a fix for issue #1023 & duplicated #1093

The code adds a new method to get module information from url.
This method is first used on the actual symfony request pathinfo
if no valid module is found, then the same method is applied on the real 'PATH_INFO' (which will be the rewritten on) .

The last commit is now supporting urls without trailiing slash (/register) 