### PR TITLE
prefill username supplied in initial request into forcedUsername

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -829,7 +829,29 @@ $config = [
      */
     'production' => true,
 
+    /*
+     * Set this option to true to force username when present in GET or POST
+     * in the initial request.
+     *
+     * Defaults to false.
+     */
+    //'forced_username_enabled' => false,
 
+    /*
+     * This option allows you to specify the field of GEST or POST
+     * which holds the forced username.
+     *
+     * Defaults to 'username'.
+     */
+    //'forced_username_field' => 'username',
+
+    /*
+     * This option allows you to specify a regular expression
+     * for the forced username. The RE must contain a named group username.
+     *
+     * Defaults to '/^(?<username>.*)$/' (the entire string).
+     */
+    //'forced_username_pattern' => '/^(?<username>.*)$/',
 
     /*********************
      | DISCOVERY SERVICE |

--- a/lib/SimpleSAML/Auth/Source.php
+++ b/lib/SimpleSAML/Auth/Source.php
@@ -184,6 +184,14 @@ abstract class Source
             ],
         ]);
 
+        $config = SimpleSAML_Configuration::getConfig('config.php');
+        $forcedUsernameEnabled = $config->getBoolean('forced_username_enabled', false);
+        $forcedUsernameField = $config->getString('forced_username_field', 'username');
+        $forcedUsernamePattern = $config->getString('forced_username_pattern', '/^(?<username>.*)$/');
+        if ($forcedUsernameEnabled && !empty($_REQUEST[$forcedUsernameField]) && preg_match($forcedUsernamePattern, $_REQUEST[$forcedUsernameField], $username)) {
+            $state['forcedUsername'] = $username['username'];
+        }
+
         if (is_string($return)) {
             $state['\SimpleSAML\Auth\DefaultAuth.ReturnURL'] = $return; // TODO: remove in 2.0
             $state['\SimpleSAML\Auth\Source.ReturnURL'] = $return;

--- a/tests/lib/SimpleSAML/Auth/SourceTest.php
+++ b/tests/lib/SimpleSAML/Auth/SourceTest.php
@@ -4,6 +4,7 @@ namespace SimpleSAML\Test\Auth;
 
 use SimpleSAML\Auth\SourceFactory;
 use SimpleSAML\Test\Utils\ClearStateTestCase;
+use \SimpleSAML\Configuration;
 
 /**
  * Tests for \SimpleSAML\Auth\Source
@@ -24,6 +25,44 @@ class SourceTest extends ClearStateTestCase
         // test instantiation via an auth source factory
         $authSource = $method->invokeArgs(null, ['test', ['SimpleSAML\Test\Auth\TestAuthSourceFactory']]);
         $this->assertInstanceOf('SimpleSAML\Test\Auth\TestAuthSource', $authSource);
+    }
+
+    public function testInitLoginForceUsernameDefault()
+    {
+        $_POST['username'] = 'test_username';
+
+        $this->config = Configuration::loadFromArray(['forced_username_enabled' => true], '[ARRAY]', 'simplesaml');
+        Configuration::setPreLoadedConfig($this->config, 'config.php');
+
+        $mock = $this->getMockBuilder('\SimpleSAML\Auth\Source')->setMethods(array('authenticate', 'loginCompleted'))->disableOriginalConstructor()->getMock();
+        $mock->expects($this->once())
+            ->method('authenticate')
+            ->with($this->callback(function($state){
+                return isset($state['forcedUsername']) && $state['forcedUsername'] === 'test_username';
+            }));
+
+        $mock->initLogin(null);
+    }
+
+    public function testInitLoginForceUsername()
+    {
+        $_POST['prefill'] = '12345@example.com';
+
+        $this->config = Configuration::loadFromArray([
+            'forced_username_enabled' => true,
+            'forced_username_field' => 'prefill',
+            'forced_username_pattern' => '/^(?<username>.*)@example\.com$/'
+        ], '[ARRAY]', 'simplesaml');
+        Configuration::setPreLoadedConfig($this->config, 'config.php');
+
+        $mock = $this->getMockBuilder('\SimpleSAML\Auth\Source')->setMethods(array('authenticate', 'loginCompleted'))->disableOriginalConstructor()->getMock();
+        $mock->expects($this->once())
+            ->method('authenticate')
+            ->with($this->callback(function($state){
+                return isset($state['forcedUsername']) && $state['forcedUsername'] === '12345';
+            }));
+
+        $mock->initLogin(null);
     }
 }
 


### PR DESCRIPTION
O365 includes the supplied username (e.g. "username@example.com") in POST data. This feature can extract the username (e.g. "username") and fill it into `forcedUsername`.

The feature is off by default and can be configured in `config.php`:
- boolean `forced_username_enabled` - controls this feature, default `false`
- string `forced_username_field` - the name of GET/POST field, default `'username'`
- string `forced_username_pattern` - regular expression with a named group username, default `'/^(?<username>.*)$/'`