### PR TITLE
Per-IDP configurable AuthnContextClassRef/AuthnContextComparison

### DIFF
--- a/docs/simplesamlphp-reference-idp-remote.md
+++ b/docs/simplesamlphp-reference-idp-remote.md
@@ -104,6 +104,26 @@ SAML 2.0 options
 
 The following SAML 2.0 options are available:
 
+`AuthnContextClassRef`
+:    The AuthnContextClassRef that will be sent in the login request.
+
+:   Note that this option also exists in the SP configuration. This
+    entry in the IdP-remote metadata overrides the option in the
+    [SP configuration](./saml:sp).
+
+`AuthnContextComparison`
+
+:    The Comparison attribute of the AuthnContext that will be sent in the login request. This parameter won't be used unless AuthnContextClassRef is set and contains one or more values. Possible values:
+
+        SAML2\Constants::COMPARISON_EXACT (default)
+        SAML2\Constants::COMPARISON_BETTER
+        SAML2\Constants::COMPARISON_MINIMUM
+        SAML2\Constants::COMPARISON_MAXIMUM
+
+:   Note that this option also exists in the SP configuration. This
+    entry in the IdP-remote metadata overrides the option in the
+    [SP configuration](./saml:sp).
+
 `disable_scoping`
 :    Whether sending of samlp:Scoping elements in authentication requests should be suppressed. The default value is `FALSE`.
      When set to `TRUE`, no scoping elements will be sent. This does not comply with the SAML2 specification, but allows 

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -499,10 +499,18 @@ class SP extends Source
             $ar->setRelayState($state['\SimpleSAML\Auth\Source.ReturnURL']);
         }
 
-        if (isset($state['saml:AuthnContextClassRef'])) {
+        $accr = null;
+        if ($idpMetadata->getString('AuthnContextClassRef', false)) {
+            $accr = \SimpleSAML\Utils\Arrays::arrayize($idpMetadata->getString('AuthnContextClassRef'));
+        } else if (isset($state['saml:AuthnContextClassRef'])) {
             $accr = \SimpleSAML\Utils\Arrays::arrayize($state['saml:AuthnContextClassRef']);
+        }
+
+        if ($accr !== null) {
             $comp = \SAML2\Constants::COMPARISON_EXACT;
-            if (isset($state['saml:AuthnContextComparison'])
+            if ($idpMetadata->getString('AuthnContextComparison', false)) {
+                $comp = $idpMetadata->getString('AuthnContextComparison');
+            } else if (isset($state['saml:AuthnContextComparison'])
                 && in_array($state['AuthnContextComparison'], [
                     \SAML2\Constants::COMPARISON_EXACT,
                     \SAML2\Constants::COMPARISON_MINIMUM,


### PR DESCRIPTION
Allows to set a different authnContextClassRef per IDP.
Can be used in cases where one SP has multiple IDP's and one-or-more IDP's require specific non-default values (i.e. Dutch eHerkenning).

It would be very desirable if we can backport this to 1.17