### PR TITLE
Update SSOService.php

### DIFF
--- a/www/saml2/idp/SSOService.php
+++ b/www/saml2/idp/SSOService.php
@@ -11,11 +11,11 @@
 
 require_once('../../_include.php');
 
-\SimpleSAML\Logger::info('SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService');
-
 $metadata = \SimpleSAML\Metadata\MetaDataStorageHandler::getMetadataHandler();
 $idpEntityId = $metadata->getMetaDataCurrentEntityID('saml20-idp-hosted');
 $idp = \SimpleSAML\IdP::getById('saml2:'.$idpEntityId);
+
+\SimpleSAML\Logger::info('SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService');
 
 try {
     \SimpleSAML\Module\saml\IdP\SAML2::receiveAuthnRequest($idp);


### PR DESCRIPTION
The SSOService info log prints late (in Logger:flush()) because the Logger has no valid $trackid before \SimpleSAML\IdP:getById(). This caused me some confusion and head-scratching and can easily be remedied by logging the info after Session initialisation.