### PR TITLE
look it up from the metadatadir from configuration variable

### DIFF
--- a/bin/importPdoMetadata.php
+++ b/bin/importPdoMetadata.php
@@ -13,7 +13,8 @@ foreach ($config['metadata.sources'] as $s) {
         $mdshp = new \SimpleSAML\Metadata\MetaDataStorageHandlerPdo($s);
         $mdshp->initDatabase();
 
-        foreach (glob("metadata/*.php") as $filename) {
+        $metadataDir = rtrim(\SimpleSAML\Configuration::getInstance()->getString('metadatadir'), '/');
+        foreach (glob("{$metadataDir}/*.php") as $filename) {
             $metadata = [];
             require_once $filename;
             $set = basename($filename, ".php");


### PR DESCRIPTION
Fixes #1109

Instead of using a hardcoded "metadata" folder, use the metadatadir to import metadata from flatfile into a database.