### PR TITLE
Fixes #926: PDO Metadata Source Doesn't Load __DYNAMIC:1__ Metadata Sets

### DIFF
--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
@@ -68,7 +68,7 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
      *
      * @return array|null An associative array with the metadata, or null if we are unable to load metadata from the given
      *     file.
-     * @throws Exception If the metadata set cannot be loaded.
+     * @throws \Exception If the metadata set cannot be loaded.
      */
     private function load($set)
     {
@@ -113,38 +113,10 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
 
         // add the entity id of an entry to each entry in the metadata
         foreach ($metadataSet as $entityId => &$entry) {
-            if (preg_match('/__DYNAMIC(:[0-9]+)?__/', $entityId)) {
-                $entry['entityid'] = $this->generateDynamicHostedEntityID($set);
-            } else {
-                $entry['entityid'] = $entityId;
-            }
+            $entry = $this->updateEntityID($set, $entityId, $entry);
         }
 
         $this->cachedMetadata[$set] = $metadataSet;
         return $metadataSet;
-    }
-
-
-    /**
-     * @param string $set
-     * @throws \Exception
-     * @return string
-     */
-    private function generateDynamicHostedEntityID($set)
-    {
-        // get the configuration
-        $baseurl = \SimpleSAML\Utils\HTTP::getBaseURL();
-
-        if ($set === 'saml20-idp-hosted') {
-            return $baseurl.'saml2/idp/metadata.php';
-        } elseif ($set === 'shib13-idp-hosted') {
-            return $baseurl.'shib13/idp/metadata.php';
-        } elseif ($set === 'wsfed-sp-hosted') {
-            return 'urn:federation:'.\SimpleSAML\Utils\HTTP::getSelfHost();
-        } elseif ($set === 'adfs-idp-hosted') {
-            return 'urn:federation:'.\SimpleSAML\Utils\HTTP::getSelfHost().':idp';
-        } else {
-            throw new \Exception('Can not generate dynamic EntityID for metadata of this type: ['.$set.']');
-        }
     }
 }

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -75,7 +75,7 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
      * @return array|null $metadata Associative array with the metadata, or NULL if we are unable to load
      *     metadata from the given file.
      *
-     * @throws Exception If a database error occurs.
+     * @throws \Exception If a database error occurs.
      * @throws \SimpleSAML\Error\Exception If the metadata can be retrieved from the database, but cannot be decoded.
      */
     private function load($set)
@@ -129,14 +129,10 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
         if ($metadataSet === null) {
             $metadataSet = [];
         }
-        /** @var array $metadataSet */
 
+        /** @var array $metadataSet */
         foreach ($metadataSet as $entityId => &$entry) {
-            if (preg_match('/__DYNAMIC(:[0-9]+)?__/', $entityId)) {
-                $entry['entityid'] = $this->generateDynamicHostedEntityID($set);
-            } else {
-                $entry['entityid'] = $entityId;
-            }
+            $entry = $this->updateEntityID($set, $entityId, $entry);
         }
 
         $this->cachedMetadata[$set] = $metadataSet;
@@ -157,68 +153,61 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
         assert(is_string($entityId));
         assert(is_string($set));
 
-        $tableName = $this->getTableName($set);
-
+        // validate the metadata set is valid
         if (!in_array($set, $this->supportedSets, true)) {
             return null;
         }
 
-        $stmt = $this->db->read(
-            "SELECT entity_id, entity_data FROM $tableName WHERE entity_id=:entityId",
-            ['entityId' => $entityId]
-        );
-        if ($stmt->execute()) {
-            $rowCount = 0;
-            $data = null;
+        // support caching
+        if (isset($this->cachedMetadata[$entityId][$set])) {
+            return $this->cachedMetadata[$entityId][$set];
+        }
 
-            while ($d = $stmt->fetch()) {
-                if (++$rowCount > 1) {
-                    \SimpleSAML\Logger::warning("Duplicate match for $entityId in set $set");
-                    break;
-                }
-                $data = json_decode($d['entity_data'], true);
-                if ($data === null) {
-                    throw new \SimpleSAML\Error\Exception("Cannot decode metadata for entity '${d['entity_id']}'");
-                }
-                if (!array_key_exists('entityid', $data)) {
-                    $data['entityid'] = $d['entity_id'];
-                }
-            }
-            return $data;
-        } else {
+        $tableName = $this->getTableName($set);
+
+        // according to the docs, it looks like *-idp-hosted metadata are the types
+        // that allow the __DYNAMIC:*__ entity id.  with the current table design
+        // we need to lookup the specific metadata entry but also we need to lookup
+        // any dynamic entries to see if the dynamic hosted entity id matches
+        if (substr($set, -10) == 'idp-hosted') {
+            $stmt = $this->db->read(
+                "SELECT entity_id, entity_data FROM {$tableName} WHERE (entity_id LIKE :dynamicId OR entity_id = :entityId)",
+                ['dynamicId' => '__DYNAMIC%', 'entityId' => $entityId]
+            );
+        }
+        // other metadata types should be able to match on entity id
+        else {
+            $stmt = $this->db->read(
+                "SELECT entity_id, entity_data FROM {$tableName} WHERE entity_id = :entityId",
+                ['entityId' => $entityId]
+            );
+        }
+
+        // throw pdo exception upon execution failure
+        if (!$stmt->execute()) {
             throw new \Exception('PDO metadata handler: Database error: '.var_export($this->db->getLastError(), true));
         }
-    }
 
-    /**
-     * @param string $set
-     * @throws \Exception
-     * @return string
-     */
-    private function generateDynamicHostedEntityID($set)
-    {
-        assert(is_string($set));
+        // load the metadata into an array
+        $metadataSet = [];
+        while ($d = $stmt->fetch()) {
+            $data = json_decode($d['entity_data'], true);
+            if (json_last_error() != JSON_ERROR_NONE) {
+                throw new \SimpleSAML\Error\Exception("Cannot decode metadata for entity '${d['entity_id']}'");
+            }
 
-        // get the configuration
-        $baseurl = \SimpleSAML\Utils\HTTP::getBaseURL();
-
-        if ($set === 'saml20-idp-hosted') {
-            return $baseurl.'saml2/idp/metadata.php';
-        } elseif ($set === 'saml20-sp-hosted') {
-            return $baseurl.'saml2/sp/metadata.php';
-        } elseif ($set === 'shib13-idp-hosted') {
-            return $baseurl.'shib13/idp/metadata.php';
-        } elseif ($set === 'shib13-sp-hosted') {
-            return $baseurl.'shib13/sp/metadata.php';
-        } elseif ($set === 'wsfed-sp-hosted') {
-            return 'urn:federation:'.\SimpleSAML\Utils\HTTP::getSelfHost();
-        } elseif ($set === 'adfs-idp-hosted') {
-            return 'urn:federation:'.\SimpleSAML\Utils\HTTP::getSelfHost().':idp';
-        } else {
-            throw new \Exception('Can not generate dynamic EntityID for metadata of this type: ['.$set.']');
+            // update the entity id to either the key (if not dynamic or generate the dynamic hosted url)
+            $metadataSet[$d['entity_id']] = $this->updateEntityID($set, $entityId, $data);
         }
-    }
 
+        $indexLookup = $this->lookupIndexFromEntityId($entityId, $metadataSet);
+        if (isset($indexLookup) && array_key_exists($indexLookup, $metadataSet)) {
+            $this->cachedMetadata[$indexLookup][$set] = $metadataSet[$indexLookup];
+            return $this->cachedMetadata[$indexLookup][$set];
+        }
+
+        return null;
+    }
 
     /**
      * Add metadata to the configured database


### PR DESCRIPTION
Fixes #926

I recently ran into the issue outlined in #926 and upon doing some research this bug was introduced in commit 7dc9d91403c00b5b2cada54ac6dea14ff01baa6a when optimizations were made to the PDO Metadata Storage Handler to improve performance by using a WHERE clause to lookup a specific metadata entry by entity id.  This obviously doesn’t work with __DYNAMIC:*__ entries because dynamic entity ids are generated and merged into the metadata array when the metadata is fetched.

Rather than rollback these changes and lose the full benefit of the optimizations (I see why the change was made, as the load method fetches all metadata from a given table and then processes it all at once), when an idp_hosted metadata set is queried, I changed the query to use a wildcard to lookup rows that match __DYNAMIC%.  This way, when idp_hosted metadata entries are fetched from the database they always include the dynamic ones as well.  Then it is the responsiblity of the lookupIndexFromEntityId method to select the appropriate metadata entry to return.  The solution to this issue could be handled in a couple of ways, I chose a way that didn’t require schema changes to the overall SQL tables.  Instead of using a LIKE statement we could add a discrete boolean column to flag whether an entry is dynamic or not and tweak the query.

As a part of this fix, I also tried to clean0up some duplicate code and push it into the base class rather than having it copy and pasted in the FlatFile and Pdo handler classes.