### PR TITLE
Enabeling the handling of unhandled exceptions

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -238,6 +238,13 @@ $config = [
      *   'errors.show_function' => ['SimpleSAML\Module\example\Error', 'show'],
      */
 
+    /*
+     * Custom handling function for unhandled SimpleSAML exceptions called from _include.php.
+     * See docs/simplesamlphp-errorhandling.txt for function code example.
+     *
+     * Example:
+     *   'errors.unhandled_exception_handler' => ['SimpleSAML\Module\example\Exception', 'handle'],
+     */
 
 
     /**************************

--- a/docs/simplesamlphp-errorhandling.md
+++ b/docs/simplesamlphp-errorhandling.md
@@ -240,3 +240,16 @@ Example code for this function, which implements the same functionality as \Simp
         exit;
     }
 
+
+Custom handling function for unhandled SimpleSAML exceptions
+------------------------------------------------------------
+
+Optional custom handling function for unhandled SimpleSAML exceptions, called from _include.php::SimpleSAML_exception_handler, is defined with 'errors.unhandled_exception_handler' in config.php.
+
+Example code for this function, which implements the same functionality as \SimpleSAML\Error\Error::show, looks something like:
+
+    public static function handle(\SimpleSAML\Error\Exception $exception) {
+
+        /* Handle things that should not be happening */
+    }
+

--- a/www/_include.php
+++ b/www/_include.php
@@ -15,7 +15,8 @@ function SimpleSAML_exception_handler($exception)
         $exception->show();
     } elseif ($exception instanceof \Exception) {
         try {
-            $unhandled_exception_handler = (\SimpleSAML\Configuration::getInstance())->getArray('errors.unhandled_exception_handler', null);
+            $config = \SimpleSAML\Configuration::getInstance();
+            $unhandled_exception_handler = $config->getArray('errors.unhandled_exception_handler', null);
         } catch (\Exception $e) {
             $unhandled_exception_handler = null;
         }

--- a/www/_include.php
+++ b/www/_include.php
@@ -14,8 +14,17 @@ function SimpleSAML_exception_handler($exception)
     if ($exception instanceof \SimpleSAML\Error\Error) {
         $exception->show();
     } elseif ($exception instanceof \Exception) {
-        $e = new \SimpleSAML\Error\Error('UNHANDLEDEXCEPTION', $exception);
-        $e->show();
+        try {
+            $unhandled_exception_handler = (\SimpleSAML\Configuration::getInstance())->getArray('errors.unhandled_exception_handler', null);
+        } catch (\Exception $e) {
+            $unhandled_exception_handler = null;
+        }
+        if (is_callable($unhandled_exception_handler)) {
+            call_user_func_array($unhandled_exception_handler, [$exception]);
+        } else {
+            $e = new \SimpleSAML\Error\Error('UNHANDLEDEXCEPTION', $exception);
+            $e->show();
+        }
     } elseif (class_exists('Error') && $exception instanceof \Error) {
         $code = $exception->getCode();
         $errno = ($code > 0) ? $code : E_ERROR;


### PR DESCRIPTION
Sometimes there are unhandled exceptions within simplesaml, the end-user gets a default "simplesaml error screen" which confuses them.
This expansion allows us to display an application-matching error and trigger things like Bugsnag.