### PR TITLE
Add support for RFC6265bis SameSite cookie attribute in 1.17

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -748,6 +748,7 @@ $config = [
     'language.cookie.secure' => false,
     'language.cookie.httponly' => false,
     'language.cookie.lifetime' => (60 * 60 * 24 * 900),
+    'language.cookie.samesite' => null,
 
     /**
      * Custom getLanguage function called from SimpleSAML\Locale\Language::getLanguage().

--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -545,6 +545,18 @@ $config = [
     'session.cookie.secure' => false,
 
     /*
+     * Set the SameSite attribute in the cookie.
+     *
+     * You can set this to the strings 'None', 'Lax', or 'Strict' to support
+     * the RFC6265bis SameSite cookie attribute. If set to null, no SameSite
+     * attribute will be sent.
+     *
+     * Example:
+     *  'session.cookie.samesite' => 'None',
+     */
+    'session.cookie.samesite' => null,
+
+    /*
      * Options to override the default settings for php sessions.
      */
     'session.phpsession.cookiename' => 'SimpleSAML',

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -419,6 +419,7 @@ class Language
             'path'     => ($config->getString('language.cookie.path', '/')),
             'secure'   => ($config->getBoolean('language.cookie.secure', false)),
             'httponly' => ($config->getBoolean('language.cookie.httponly', false)),
+            'samesite' => ($config->getBoolean('language.cookie.samesite', null)),
         ];
 
         HTTP::setCookie($name, $language, $params, false);

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -419,7 +419,7 @@ class Language
             'path'     => ($config->getString('language.cookie.path', '/')),
             'secure'   => ($config->getBoolean('language.cookie.secure', false)),
             'httponly' => ($config->getBoolean('language.cookie.httponly', false)),
-            'samesite' => ($config->getBoolean('language.cookie.samesite', null)),
+            'samesite' => ($config->getString('language.cookie.samesite', null)),
         ];
 
         HTTP::setCookie($name, $language, $params, false);

--- a/lib/SimpleSAML/SessionHandler.php
+++ b/lib/SimpleSAML/SessionHandler.php
@@ -154,6 +154,7 @@ abstract class SessionHandler
             'path'     => $config->getString('session.cookie.path', '/'),
             'domain'   => $config->getString('session.cookie.domain', null),
             'secure'   => $config->getBoolean('session.cookie.secure', false),
+            'samesite' => $config->getString('session.cookie.samesite', null),
             'httponly' => true,
         ];
     }

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -77,13 +77,28 @@ class SessionHandlerPHP extends SessionHandler
         $params = $this->getCookieParams();
 
         if (!headers_sent()) {
-            session_set_cookie_params(
-                $params['lifetime'],
-                $params['path'],
-                $params['domain'],
-                $params['secure'],
-                $params['httponly']
-            );
+            if (\PHP_VERSION_ID >= 70300) {
+                session_set_cookie_params([
+                    'lifetime' => $params['lifetime'],
+                    'path' => $params['path'],
+                    'domain' => $params['domain'],
+                    'secure' => $params['secure'],
+                    'httponly' => $params['httponly'],
+                    'samesite' => $params['samesite'],
+                ]);
+            } else {
+                /* in older versions of PHP we need a nasty hack to set RFC6265bis SameSite attribute required by Chrome >= 76 */
+                if ($params['samesite'] !== null and !preg_match('/;\s+samesite/i', $params['path'])) {
+                    $params['path'] .= '; SameSite='.$params['samesite'];
+                }
+                session_set_cookie_params(
+                    $params['lifetime'],
+                    $params['path'],
+                    $params['domain'],
+                    $params['secure'],
+                    $params['httponly']
+                );
+            }
         }
 
         $savepath = $config->getString('session.phpsession.savepath', null);
@@ -113,13 +128,17 @@ class SessionHandlerPHP extends SessionHandler
         session_write_close();
 
         session_name($this->previous_session['name']);
-        session_set_cookie_params(
-            $this->previous_session['cookie_params']['lifetime'],
-            $this->previous_session['cookie_params']['path'],
-            $this->previous_session['cookie_params']['domain'],
-            $this->previous_session['cookie_params']['secure'],
-            $this->previous_session['cookie_params']['httponly']
-        );
+        if (\PHP_VERSION_ID >= 70300) {
+            session_set_cookie_params($this->previous_session['cookie_params']);
+        } else {
+            session_set_cookie_params(
+                $this->previous_session['cookie_params']['lifetime'],
+                $this->previous_session['cookie_params']['path'],
+                $this->previous_session['cookie_params']['domain'],
+                $this->previous_session['cookie_params']['secure'],
+                $this->previous_session['cookie_params']['httponly']
+            );
+        }
         session_id($this->previous_session['id']);
         $this->previous_session = [];
         @session_start();
@@ -330,13 +349,17 @@ class SessionHandlerPHP extends SessionHandler
             session_write_close();
         }
 
-        session_set_cookie_params(
-            $cookieParams['lifetime'],
-            $cookieParams['path'],
-            $cookieParams['domain'],
-            $cookieParams['secure'],
-            $cookieParams['httponly']
-        );
+        if (\PHP_VERSION_ID >= 70300) {
+            session_set_cookie_params($cookieParams);
+        } else {
+            session_set_cookie_params(
+                $cookieParams['lifetime'],
+                $cookieParams['path'],
+                $cookieParams['domain'],
+                $cookieParams['secure'],
+                $cookieParams['httponly']
+            );
+        }
 
         session_id($sessionID);
         @session_start();

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -87,7 +87,7 @@ class SessionHandlerPHP extends SessionHandler
                     'samesite' => $params['samesite'],
                 ]);
             } else {
-                /* in older versions of PHP we need a nasty hack to set RFC6265bis SameSite attribute required by Chrome >= 76 */
+                /* in older versions of PHP we need a nasty hack to set RFC6265bis SameSite attribute */
                 if ($params['samesite'] !== null and !preg_match('/;\s+samesite/i', $params['path'])) {
                     $params['path'] .= '; SameSite='.$params['samesite'];
                 }

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -1184,7 +1184,7 @@ class HTTP
                 );
             }
         } else {
-            /* in older versions of PHP we need a nasty hack to set RFC6265bis SameSite attribute required by Chrome >= 76 */
+            /* in older versions of PHP we need a nasty hack to set RFC6265bis SameSite attribute */
             if ($params['samesite'] !== null and !preg_match('/;\s+samesite/i', $params['path'])) {
                 $params['path'] .= '; SameSite='.$params['samesite'];
             }

--- a/tests/lib/SimpleSAML/SessionHandlerPHPTest.php
+++ b/tests/lib/SimpleSAML/SessionHandlerPHPTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace SimpleSAML\Test\Utils;
+
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Test\Utils\ClearStateTestCase;
+use SimpleSAML\SessionHandlerPHP;
+use SimpleSAML\Configuration;
+
+class SessionHandlerPHPTest extends ClearStateTestCase
+{
+    protected $sessionConfig = [
+        'session.cookie.name' => 'SimpleSAMLSessionID',
+        'session.cookie.lifetime' => 100,
+        'session.cookie.path' => '/ourPath',
+        'session.cookie.domain' => 'example.com',
+        'session.cookie.secure' => true,
+        'session.phpsession.cookiename' => 'SimpleSAML',
+    ];
+    protected $original;
+
+    protected function setUp()
+    {
+        $this->original = $_SERVER;
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['SERVER_NAME'] = 'example.com';
+        $_SERVER['HTTPS'] = 'on';
+        $_SERVER['SERVER_PORT'] = 443;
+        $_SERVER['REQUEST_URI'] = '/simplesaml';
+    }
+
+    protected function tearDown()
+    {
+        $_SERVER = $this->original;
+    }
+
+    /**
+     * @covers SimpleSAML\SessionHandlerPHP::__construct()
+     * @covers SimpleSAML\SessionHandlerPHP::getSessionHandler()
+     * @covers SimpleSAML\SessionHandler::getSessionHandler()
+     */
+    public function testGetSessionHandler()
+    {
+        Configuration::loadFromArray($this->sessionConfig, '[ARRAY]', 'simplesaml');
+        $sh = SessionHandlerPHP::getSessionHandler();
+        $this->assertInstanceOf('\SimpleSAML\SessionHandlerPHP', $sh);
+    }
+
+    /**
+     * @covers SimpleSAML\SessionHandlerPHP::setCookie()
+     * @runInSeparateProcess
+     */
+    public function testSetCookie()
+    {
+        Configuration::loadFromArray($this->sessionConfig, '[ARRAY]', 'simplesaml');
+        $sh = SessionHandlerPHP::getSessionHandler();
+        $sh->setCookie('SimpleSAMLSessionID', 1);
+
+        $headers = xdebug_get_headers();
+        $this->assertContains('SimpleSAML=1;', $headers[0]);
+        $this->assertRegExp('/\b[Ee]xpires=([Mm]on|[Tt]ue|[Ww]ed|[Tt]hu|[Ff]ri|[Ss]at|[Ss]un)/', $headers[0]);
+        $this->assertRegExp('/\b[Pp]ath=\/ourPath(;|$)/', $headers[0]);
+        $this->assertRegExp('/\b[Dd]omain=example.com(;|$)/', $headers[0]);
+        $this->assertRegExp('/\b[Ss]ecure(;|$)/', $headers[0]);
+        $this->assertRegExp('/\b[Hh]ttp[Oo]nly(;|$)/', $headers[0]);
+    }
+
+    /**
+     * @covers SimpleSAML\SessionHandlerPHP::setCookie()
+     * @runInSeparateProcess
+     */
+    public function testSetCookieSameSiteNone()
+    {
+        Configuration::loadFromArray(array_merge($this->sessionConfig, ['session.cookie.samesite' => 'None']), '[ARRAY]', 'simplesaml');
+        $sh = SessionHandlerPHP::getSessionHandler();
+        $sh->setCookie('SimpleSAMLSessionID', 'None');
+
+        $headers = xdebug_get_headers();
+        $this->assertContains('SimpleSAML=None;', $headers[0]);
+        $this->assertRegExp('/\b[Ss]ame[Ss]ite=None(;|$)/', $headers[0]);
+    }
+
+    /**
+     * @covers SimpleSAML\SessionHandlerPHP::setCookie()
+     * @runInSeparateProcess
+     */
+    public function testSetCookieSameSiteLax()
+    {
+        Configuration::loadFromArray(array_merge($this->sessionConfig, ['session.cookie.samesite' => 'Lax']), '[ARRAY]', 'simplesaml');
+        $sh = SessionHandlerPHP::getSessionHandler();
+        $sh->setCookie('SimpleSAMLSessionID', 'Lax');
+
+        $headers = xdebug_get_headers();
+        $this->assertContains('SimpleSAML=Lax;', $headers[0]);
+        $this->assertRegExp('/\b[Ss]ame[Ss]ite=Lax(;|$)/', $headers[0]);
+    }
+
+    /**
+     * @covers SimpleSAML\SessionHandlerPHP::setCookie()
+     * @runInSeparateProcess
+     */
+    public function testSetCookieSameSiteStrict()
+    {
+        Configuration::loadFromArray(array_merge($this->sessionConfig, ['session.cookie.samesite' => 'Strict']), '[ARRAY]', 'simplesaml');
+        $sh = SessionHandlerPHP::getSessionHandler();
+        $sh->setCookie('SimpleSAMLSessionID', 'Strict');
+
+        $headers = xdebug_get_headers();
+        $this->assertContains('SimpleSAML=Strict;', $headers[0]);
+        $this->assertRegExp('/\b[Ss]ame[Ss]ite=Strict(;|$)/', $headers[0]);
+    }
+
+    /**
+     * @covers SimpleSAML\SessionHandlerPHP::restorePrevious()
+     * @runInSeparateProcess
+     */
+    public function testRestorePrevious()
+    {
+        session_name('PHPSESSID');
+        $sid = session_id();
+        session_start();
+
+        Configuration::loadFromArray($this->sessionConfig, '[ARRAY]', 'simplesaml');
+        $sh = SessionHandlerPHP::getSessionHandler();
+        $sh->setCookie('SimpleSAMLSessionID', 'Restore');
+        $oldSh = $sh->restorePrevious();
+
+        $headers = xdebug_get_headers();
+        $this->assertContains('PHPSESSID='.$sid, $headers[0]);
+        $this->assertContains('SimpleSAML=Restore;', $headers[1]);
+        $this->assertContains('PHPSESSID='.$sid, $headers[2]);
+        $this->assertEquals($headers[0], $headers[2]);
+    }
+
+    /**
+     * @covers SimpleSAML\SessionHandlerPHP::newSessionId()
+     */
+    public function testNewSessionId()
+    {
+        Configuration::loadFromArray($this->sessionConfig, '[ARRAY]', 'simplesaml');
+        $sh = SessionHandlerPHP::getSessionHandler();
+        $sid = $sh->newSessionId();
+        $this->assertStringMatchesFormat('%x', $sid);
+    }
+}

--- a/tests/lib/SimpleSAML/SessionHandlerPHPTest.php
+++ b/tests/lib/SimpleSAML/SessionHandlerPHPTest.php
@@ -140,6 +140,6 @@ class SessionHandlerPHPTest extends ClearStateTestCase
         Configuration::loadFromArray($this->sessionConfig, '[ARRAY]', 'simplesaml');
         $sh = SessionHandlerPHP::getSessionHandler();
         $sid = $sh->newSessionId();
-        $this->assertStringMatchesFormat('%x', $sid);
+        $this->assertStringMatchesFormat('%s', $sid);
     }
 }

--- a/tests/lib/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/lib/SimpleSAML/Utils/HTTPTest.php
@@ -3,10 +3,11 @@
 namespace SimpleSAML\Test\Utils;
 
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Test\Utils\ClearStateTestCase;
 use SimpleSAML\Utils\HTTP;
 use SimpleSAML\Configuration;
 
-class HTTPTest extends TestCase
+class HTTPTest extends ClearStateTestCase
 {
     /**
      * Set up the environment ($_SERVER) populating the typical variables from a given URL.
@@ -441,12 +442,14 @@ class HTTPTest extends TestCase
         ], '[ARRAY]', 'simplesaml');
         $url = 'https://example.com/a?b=c';
         $this->setupEnvFromURL($url);
+
         HTTP::setCookie('TestCookie', 'value%20', ['expires'=>1, 'path'=>'/path', 'domain'=>'example.com', 'secure'=>true, 'httponly'=>true]);
         HTTP::setCookie('RawCookie', 'value%20', ['expires'=>1, 'path'=>'/path', 'domain'=>'example.com', 'secure'=>true, 'httponly'=>true, 'raw'=>true]);
         $this->assertEquals(xdebug_get_headers(), [
             'Set-Cookie: TestCookie=value%2520; path=/path; domain=example.com; secure; HttpOnly',
             'Set-Cookie: RawCookie=value%20; path=/path; domain=example.com; secure; HttpOnly'
         ]);
+
         $_SERVER = $original;
     }
 
@@ -462,7 +465,9 @@ class HTTPTest extends TestCase
         ], '[ARRAY]', 'simplesaml');
         $url = 'http://example.com/a?b=c';
         $this->setupEnvFromURL($url);
+
         HTTP::setCookie('testCookie', 'value', ['secure' => true], true);
+
         $_SERVER = $original;
     }
 


### PR DESCRIPTION
Chrome 76 [changes the behaviour of cookies](https://blog.chromium.org/2019/05/improving-privacy-and-security-on-web.html) in a way that breaks SimpleSAMLphp's session cookie. There has been [discussion of this on the REFEDS list](https://lists.refeds.org/sympa/arc/refeds/2019-06/msg00005.html), and my own testing confirms it is a problem in SSP 1.17.x.

In order to work around this problem, we need to allow people to set the SameSite=None attribute on session cookies. This patch introduces a new config option `session.cookie.samesite` that allows people to specify how this should be treated. It defaults to reproducing the existing behaviour of not setting the SameSite attribute at all, but can be set to `'None'` if people need to work around the Chrome 76 problem.

Unfortunately, PHP only introduced native support for this in the setcookie() function [in version 7.3](https://www.php.net/manual/en/function.setcookie.php#refsect1-function.setcookie-changelog). However, [I managed to find](https://stackoverflow.com/questions/39750906/php-setcookie-samesite-strict) a somewhat ugly workaround for versions < 7.3 (tested against 7.0.33 that ships with Ubuntu 16.04LTS). Thus the patch special cases for the two different versions of PHP.

The patch is against the simplesamlphp-1.17 branch, since that's what I need in our environment.