### PR TITLE
clarify where certs go in IdP quick start docs

### DIFF
--- a/docs/simplesamlphp-idp.md
+++ b/docs/simplesamlphp-idp.md
@@ -123,7 +123,7 @@ The attributes will be returned by the IdP when the user logs on.
 Creating a self signed certificate
 ----------------------------------
 
-The IdP needs a certificate to sign its SAML assertions with. Here is an example of an `openssl`-command which can be used to generate a new private key key and the corresponding self-signed certificate. The private key and certificate normally go in the `cert/` directory.
+The IdP needs a certificate to sign its SAML assertions with. Here is an example of an `openssl`-command which can be used to generate a new private key key and the corresponding self-signed certificate. The private key and certificate go into the directory defined in the certdir setting (defaults to `cert/`)
 
 This key and certificate can be used to sign SAML messages:
 

--- a/docs/simplesamlphp-idp.md
+++ b/docs/simplesamlphp-idp.md
@@ -123,7 +123,7 @@ The attributes will be returned by the IdP when the user logs on.
 Creating a self signed certificate
 ----------------------------------
 
-The IdP needs a certificate to sign its SAML assertions with. Here is an example of an `openssl`-command which can be used to generate a new private key key and the corresponding self-signed certificate.
+The IdP needs a certificate to sign its SAML assertions with. Here is an example of an `openssl`-command which can be used to generate a new private key key and the corresponding self-signed certificate. The private key and certificate normally go in the `cert/` directory.
 
 This key and certificate can be used to sign SAML messages:
 


### PR DESCRIPTION
It wasn't immediately clear to me where to put the cert and private key when I went through these instructions recently, so I thought I'd propose a change to make the destination explicit.