### PR TITLE
Allow themes to inherit module templates

### DIFF
--- a/docs/simplesamlphp-theming.md
+++ b/docs/simplesamlphp-theming.md
@@ -131,6 +131,8 @@ If you need to make more extensive customizations to the base template, you shou
 
 Any references to `$this->data['baseurlpath']` in old-style templates can be replaced with `{{baseurlpath}}` in Twig templates. Likewise, references to `\SimpleSAML\Module::getModuleURL()` can be replaced with `{{baseurlpath}}module.php/mymodule/...`
 
+Within templates each module is defined as a separate namespace matching the module name. This allows one template to reference templates from other modules using Twig's `@namespace_name/template_path` notation. For instance, a template in `mymodule` can include the widget template from the `yourmodule` module using the notation `@yourmodule/widget.twig`.
+
 Even more advanced changes can be made by defining a theme controller in `config.php`:
 
     'theme.controller' => '\SimpleSAML\Module\mymodule\FancyThemeController',

--- a/docs/simplesamlphp-theming.md
+++ b/docs/simplesamlphp-theming.md
@@ -131,7 +131,7 @@ If you need to make more extensive customizations to the base template, you shou
 
 Any references to `$this->data['baseurlpath']` in old-style templates can be replaced with `{{baseurlpath}}` in Twig templates. Likewise, references to `\SimpleSAML\Module::getModuleURL()` can be replaced with `{{baseurlpath}}module.php/mymodule/...`
 
-Within templates each module is defined as a separate namespace matching the module name. This allows one template to reference templates from other modules using Twig's `@namespace_name/template_path` notation. For instance, a template in `mymodule` can include the widget template from the `yourmodule` module using the notation `@yourmodule/widget.twig`.
+Within templates each module is defined as a separate namespace matching the module name. This allows one template to reference templates from other modules using Twig's `@namespace_name/template_path` notation. For instance, a template in `mymodule` can include the widget template from the `yourmodule` module using the notation `@yourmodule/widget.twig`. A special namespace, `__parent__`, exists to allow theme developers to more easily extend a module's stock template.
 
 Even more advanced changes can be made by defining a theme controller in `config.php`:
 

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -244,6 +244,7 @@ class Template extends Response
                 $templateDirs[] = [
                     $this->theme['module'] => TemplateLoader::getModuleTemplateDir($this->theme['module'])
                 ];
+                $templateDirs[] = ['__parent__' => TemplateLoader::getModuleTemplateDir($this->module)];
             } catch (\InvalidArgumentException $e) {
                 // either the module is not enabled or it has no "templates" directory, ignore
             }
@@ -524,7 +525,7 @@ class Template extends Response
     public function show()
     {
         if ($this->useNewUI) {
-            echo $this->getContents();            
+            echo $this->getContents();
         } else {
             require($this->findTemplatePath($this->template));
         }


### PR DESCRIPTION
When developing themes it is common to want to make only minor cosmetic changes to the existing template, such as adding additional CSS. Under the old theming system it was possible to inherit the stock theme and alter it by simply include()ing the PHP.

Similar functionality doesn't exist in Twig, but arguably makes more sense here where we can now override a single block. This functionality is already used by themes to override the default theme, but the model doesn't extend to modules. Thus this commit introduces a special `__parent__` namespace in Twig to allow theme developers to reference the original module templates from within their own theme's template.

E.g if I wanted to inheret the entire discopower module's template save for injecting one additional script into it, rather than copying the whole `disco.twig` template to my theme and editing it, I can merely override the postload block by creating a new `mymodule/themes/mytheme/discopower/disco.twig` like this:
```
{% extends "@__parent__/disco.twig" %}
{% block postload %}
{{ parent() }}{# include the paren't postload block #}
<!-- this is all we're changing -->
<script src="/path/to/extra/javascript.js"></script>
{% endblock %}
```
That's a whole lot less maintenance for me as a theme developer when the module's template changes.