### PR TITLE
Fix header warnings from log flushing

### DIFF
--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -386,7 +386,9 @@ class Logger
     private static function defer($level, $message, $stats)
     {
         // save the message for later
-        self::$earlyLog[] = ['level' => $level, 'string' => $message, 'statsLog' => $stats];
+        self::$earlyLog[] = [
+            'level' => $level, 'string' => $message, 'statsLog' => $stats
+        ];
 
         // register a shutdown handler if needed
         if (!self::$shutdownRegistered) {

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -68,7 +68,7 @@ class SessionHandlerPHP extends SessionHandler
         }
 
         if (!empty($this->cookie_name)) {
-            session_name($this->cookie_name);
+            @session_name($this->cookie_name);
         } else {
             $this->cookie_name = session_name();
         }


### PR DESCRIPTION
See #1168 
There are warnings about headers being sent by the `Logger::flush` function when the loglevel is set to DEBUG, for example on the IDP metadata page.