### PR TITLE
Fix raw template being returned by SingleLogoutResponse.php

### DIFF
--- a/lib/SimpleSAML/IdP/IFrameLogoutHandler.php
+++ b/lib/SimpleSAML/IdP/IFrameLogoutHandler.php
@@ -115,12 +115,13 @@ class IFrameLogoutHandler implements LogoutHandlerInterface
             $t->data['errorMsg'] = $error->getMessage();
         }
 
+        // Remove the if-clause in 2.0, leave the else-part
         if ($usenewui === false) {
             $twig = $t->getTwig();
             if (!isset($twig)) {
                 throw new \Exception('Even though we explicitly configure that we want Twig, the Template class does not give us Twig. This is a bug.');
             }
-            $result = $twig->render($template, $t->data);
+            $result = $twig->render('IFrameLogoutHandler.twig', $t->data);
             echo $result;
         } else {
             $t->show();


### PR DESCRIPTION
We need a little hack to enforce the use of Twig, even if newui is set to false.
It's either this, or revert to inline HTML in our PHP-files..

Fixes #1191 