### PR TITLE
Fix typo

### DIFF
--- a/modules/exampleauth/lib/Auth/Process/RedirectTest.php
+++ b/modules/exampleauth/lib/Auth/Process/RedirectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSAML\Module\exampleautth\Auth\Process;
+namespace SimpleSAML\Module\exampleauth\Auth\Process;
 
 use SimpleSAML\Auth;
 use SimpleSAML\Module;


### PR DESCRIPTION
correct exampleauth namespace name