### PR TITLE
add store option to SQLPersistentNameID

### DIFF
--- a/modules/saml/docs/nameid.md
+++ b/modules/saml/docs/nameid.md
@@ -63,10 +63,11 @@ No extra options are available for this filter.
 `saml:SQLPersistentNameID`
 --------------------------
 
-Generates and stores persistent NameIDs in a SQL datastore.
+Generates and stores persistent NameIDs in a SQL database.
 
-This filter generates and stores a persistent NameID in a SQL datastore.
-To use this filter, SimpleSAMLphp must be configured to use a SQL datastore.
+This filter generates and stores a persistent NameID in a SQL database.
+To use this filter, either specify the `store` option and a database,
+or configure SimpleSAMLphp to use a SQL datastore.
 See the `store.type` configuration option in `config.php`.
 
 ### Options
@@ -85,6 +86,10 @@ See the `store.type` configuration option in `config.php`.
 `alwaysCreate`
 :   Whether to ignore an explicit `AllowCreate="false"` in the authentication request's NameIDPolicy.
     The default is `FALSE`, which will only create new NameIDs when the SP specifies `AllowCreate="true"` in the authentication request.
+
+`store`
+:   An array of database options passed to `\SimpleSAML\Database`, keys prefixed with `database.`.
+    The default is `[]`, which uses the global SQL datastore.
 
 Setting both `allowUnspecified` and `alwaysCreate` to `TRUE` causes `saml:SQLPersistentNameID` to behave like `saml:PersistentNameID` (and other NameID generation filters), at the expense of creating unnecessary entries in the SQL datastore.
 

--- a/modules/saml/lib/Auth/Process/SQLPersistentNameID.php
+++ b/modules/saml/lib/Auth/Process/SQLPersistentNameID.php
@@ -42,6 +42,13 @@ class SQLPersistentNameID extends \SimpleSAML\Module\saml\BaseNameIDGenerator
      */
     private $alwaysCreate = false;
 
+    /**
+     * Database store configuration.
+     *
+     * @var array
+     */
+    private $storeConfig = null;
+
 
     /**
      * Initialize this filter, parse configuration.
@@ -73,6 +80,10 @@ class SQLPersistentNameID extends \SimpleSAML\Module\saml\BaseNameIDGenerator
 
         if (isset($config['alwaysCreate'])) {
             $this->alwaysCreate = (bool) $config['alwaysCreate'];
+        }
+
+        if (isset($config['store'])) {
+            $this->storeConfig = (array) $config['store'];
         }
     }
 
@@ -148,7 +159,7 @@ class SQLPersistentNameID extends \SimpleSAML\Module\saml\BaseNameIDGenerator
             return null;
         }
 
-        $value = \SimpleSAML\Module\saml\IdP\SQLNameID::get($idpEntityId, $spEntityId, $uid);
+        $value = \SimpleSAML\Module\saml\IdP\SQLNameID::get($idpEntityId, $spEntityId, $uid, $this->storeConfig);
         if ($value !== null) {
             Logger::debug(
                 'SQLPersistentNameID: Found persistent NameID ' . var_export($value, true) . ' for user ' .
@@ -172,7 +183,7 @@ class SQLPersistentNameID extends \SimpleSAML\Module\saml\BaseNameIDGenerator
             'SQLPersistentNameID: Created persistent NameID ' . var_export($value, true) . ' for user ' .
             var_export($uid, true) . '.'
         );
-        \SimpleSAML\Module\saml\IdP\SQLNameID::add($idpEntityId, $spEntityId, $uid, $value);
+        \SimpleSAML\Module\saml\IdP\SQLNameID::add($idpEntityId, $spEntityId, $uid, $value, $this->storeConfig);
 
         return $value;
     }

--- a/modules/saml/lib/Auth/Process/SQLPersistentNameID.php
+++ b/modules/saml/lib/Auth/Process/SQLPersistentNameID.php
@@ -47,7 +47,7 @@ class SQLPersistentNameID extends \SimpleSAML\Module\saml\BaseNameIDGenerator
      *
      * @var array
      */
-    private $storeConfig = null;
+    private $storeConfig = [];
 
 
     /**

--- a/modules/saml/lib/IdP/SQLNameID.php
+++ b/modules/saml/lib/IdP/SQLNameID.php
@@ -19,6 +19,13 @@ class SQLNameID
     const DEFAULT_TABLE_PREFIX = '';
     const TABLE_SUFFIX = '_saml_PersistentNameID';
 
+
+    /**
+     * @param string $query
+     * @param array $params
+     * @param array $config
+     * @return \PDOStatement
+     */
     private static function query($query, array $params = [], array $config = []) {
         if (!empty($config)) {
             $database = Database::getInstance(Configuration::loadFromArray($config));
@@ -35,6 +42,11 @@ class SQLNameID
         return $stmt;
     }
 
+
+    /**
+     * @param array $config
+     * @return string
+     */
     private static function tableName(array $config = []) {
         $store = empty($config) ? self::getStore() : null;
         $prefix = $store === null ? self::DEFAULT_TABLE_PREFIX : $store->prefix;
@@ -42,6 +54,13 @@ class SQLNameID
         return $table;
     }
 
+
+    /**
+     * @param string $query
+     * @param array $params
+     * @param array $config
+     * @return \PDOStatement
+     */
     private static function createAndQuery($query, array $params = [], array $config = []) {
         $store = empty($config) ? self::getStore() : null;
         $table = self::tableName($config);
@@ -67,6 +86,7 @@ class SQLNameID
      * Create NameID table in SQL.
      *
      * @param string $table  The table name.
+     * @param array $config
      * @return void
      */
     private static function createTable($table, array $config = [])
@@ -112,6 +132,7 @@ class SQLNameID
      * @param string $spEntityId  The SP entityID.
      * @param string $user  The user's unique identificator (e.g. username).
      * @param string $value  The NameID value.
+     * @param array $config
      * @return void
      */
     public static function add($idpEntityId, $spEntityId, $user, $value, array $config = [])
@@ -140,6 +161,7 @@ class SQLNameID
      * @param string $idpEntityId  The IdP entityID.
      * @param string $spEntityId  The SP entityID.
      * @param string $user  The user's unique identificator (e.g. username).
+     * @param array $config
      * @return string|null $value  The NameID value, or NULL of no NameID value was found.
      */
     public static function get($idpEntityId, $spEntityId, $user, array $config = [])
@@ -174,6 +196,7 @@ class SQLNameID
      * @param string $idpEntityId  The IdP entityID.
      * @param string $spEntityId  The SP entityID.
      * @param string $user  The user's unique identificator (e.g. username).
+     * @param array $config
      * @return void
      */
     public static function delete($idpEntityId, $spEntityId, $user, array $config = [])
@@ -199,6 +222,7 @@ class SQLNameID
      *
      * @param string $idpEntityId  The IdP entityID.
      * @param string $spEntityId  The SP entityID.
+     * @param array $config
      * @return array  Array of userid => NameID.
      */
     public static function getIdentities($idpEntityId, $spEntityId, array $config = [])

--- a/modules/saml/lib/IdP/SQLNameID.php
+++ b/modules/saml/lib/IdP/SQLNameID.php
@@ -26,7 +26,8 @@ class SQLNameID
      * @param array $config
      * @return \PDOStatement
      */
-    private static function query($query, array $params = [], array $config = []) {
+    private static function query($query, array $params = [], array $config = [])
+    {
         if (!empty($config)) {
             $database = Database::getInstance(Configuration::loadFromArray($config));
             if (stripos($query, 'SELECT') === 0) {
@@ -47,7 +48,8 @@ class SQLNameID
      * @param array $config
      * @return string
      */
-    private static function tableName(array $config = []) {
+    private static function tableName(array $config = [])
+    {
         $store = empty($config) ? self::getStore() : null;
         $prefix = $store === null ? self::DEFAULT_TABLE_PREFIX : $store->prefix;
         $table = $prefix . self::TABLE_SUFFIX;
@@ -61,13 +63,14 @@ class SQLNameID
      * @param array $config
      * @return \PDOStatement
      */
-    private static function createAndQuery($query, array $params = [], array $config = []) {
+    private static function createAndQuery($query, array $params = [], array $config = [])
+    {
         $store = empty($config) ? self::getStore() : null;
         $table = self::tableName($config);
         if ($store === null) {
             $stmt = self::query(
                 'SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME=:tablename',
-                ['tablename'=>$table],
+                ['tablename' => $table],
                 $config
             );
             if ($stmt !== false && $stmt->fetchColumn() !== '1') {

--- a/modules/saml/lib/IdP/SQLNameID.php
+++ b/modules/saml/lib/IdP/SQLNameID.php
@@ -79,7 +79,8 @@ class SQLNameID
      * @param array $config
      * @return void
      */
-    private static function create(array $config = []) {
+    private static function create(array $config = [])
+    {
         $store = empty($config) ? self::getStore() : null;
         $table = self::tableName($config);
         if ($store === null) {

--- a/modules/saml/lib/IdP/SQLNameID.php
+++ b/modules/saml/lib/IdP/SQLNameID.php
@@ -19,7 +19,7 @@ class SQLNameID
     const DEFAULT_TABLE_PREFIX = '';
     const TABLE_SUFFIX = '_saml_PersistentNameID';
 
-    private static function query($query, $params = [], $config = []) {
+    private static function query($query, array $params = [], array $config = []) {
         if (!empty($config)) {
             $database = Database::getInstance(Configuration::loadFromArray($config));
             if (stripos($query, 'SELECT') === 0) {
@@ -35,14 +35,14 @@ class SQLNameID
         return $stmt;
     }
 
-    private static function tableName($config = []) {
+    private static function tableName(array $config = []) {
         $store = empty($config) ? self::getStore() : null;
         $prefix = $store === null ? self::DEFAULT_TABLE_PREFIX : $store->prefix;
         $table = $prefix . self::TABLE_SUFFIX;
         return $table;
     }
 
-    private static function createAndQuery($query, $params = [], $config = []) {
+    private static function createAndQuery($query, array $params = [], array $config = []) {
         $store = empty($config) ? self::getStore() : null;
         $table = self::tableName($config);
         if ($store === null) {
@@ -69,7 +69,7 @@ class SQLNameID
      * @param string $table  The table name.
      * @return void
      */
-    private static function createTable($table, $config = [])
+    private static function createTable($table, array $config = [])
     {
         $query = 'CREATE TABLE ' . $table . ' (
             _idp VARCHAR(256) NOT NULL,
@@ -114,7 +114,7 @@ class SQLNameID
      * @param string $value  The NameID value.
      * @return void
      */
-    public static function add($idpEntityId, $spEntityId, $user, $value, $config = [])
+    public static function add($idpEntityId, $spEntityId, $user, $value, array $config = [])
     {
         assert(is_string($idpEntityId));
         assert(is_string($spEntityId));
@@ -142,7 +142,7 @@ class SQLNameID
      * @param string $user  The user's unique identificator (e.g. username).
      * @return string|null $value  The NameID value, or NULL of no NameID value was found.
      */
-    public static function get($idpEntityId, $spEntityId, $user, $config = [])
+    public static function get($idpEntityId, $spEntityId, $user, array $config = [])
     {
         assert(is_string($idpEntityId));
         assert(is_string($spEntityId));
@@ -176,7 +176,7 @@ class SQLNameID
      * @param string $user  The user's unique identificator (e.g. username).
      * @return void
      */
-    public static function delete($idpEntityId, $spEntityId, $user, $config = [])
+    public static function delete($idpEntityId, $spEntityId, $user, array $config = [])
     {
         assert(is_string($idpEntityId));
         assert(is_string($spEntityId));
@@ -201,7 +201,7 @@ class SQLNameID
      * @param string $spEntityId  The SP entityID.
      * @return array  Array of userid => NameID.
      */
-    public static function getIdentities($idpEntityId, $spEntityId, $config = [])
+    public static function getIdentities($idpEntityId, $spEntityId, array $config = [])
     {
         assert(is_string($idpEntityId));
         assert(is_string($spEntityId));

--- a/modules/saml/lib/IdP/SQLNameID.php
+++ b/modules/saml/lib/IdP/SQLNameID.php
@@ -84,13 +84,10 @@ class SQLNameID
         $store = empty($config) ? self::getStore() : null;
         $table = self::tableName($config);
         if ($store === null) {
-            $stmt = self::read(
-                'SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME=:tablename',
-                ['tablename' => $table],
-                $config
-            );
-            if ($stmt !== false && $stmt->fetchColumn() !== '1') {
+            try {
                 self::createTable($table, $config);
+            } catch (\Exception $e) {
+                \SimpleSAML\Logger::debug('SQL persistent NameID table already exists.');
             }
         } elseif ($store->getTableVersion('saml_PersistentNameID') !== self::TABLE_VERSION) {
             self::createTable($table);
@@ -170,7 +167,6 @@ class SQLNameID
     /**
      * Add a NameID into the database.
      *
-     * @param \SimpleSAML\Store\SQL $store  The data store.
      * @param string $idpEntityId  The IdP entityID.
      * @param string $spEntityId  The SP entityID.
      * @param string $user  The user's unique identificator (e.g. username).

--- a/tests/modules/saml/lib/IdP/SQLNameIDTest.php
+++ b/tests/modules/saml/lib/IdP/SQLNameIDTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SimpleSAML\Test\Module\saml\IdP;
+
+/**
+ * Test for the SQLNameID helper class.
+ *
+ * @author Pavel Brousek <brousek@ics.muni.cz>
+ * @package SimpleSAMLphp
+ */
+
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error;
+use SimpleSAML\Module\saml\IdP\SQLNameID;
+use SimpleSAML\Store;
+
+class SQLNameIDTest extends TestCase
+{
+    /**
+     * @param array $config
+     * @return void
+     */
+    private function addGetDelete(array $config = [])
+    {
+        SQLNameID::add('idp', 'sp', 'user', 'value', $config);
+        $this->assertEquals('value', SQLNameID::get('idp', 'sp', 'user', $config));
+        SQLNameID::delete('idp', 'sp', 'user', $config);
+        $this->assertNull(SQLNameID::get('idp', 'sp', 'user', $config));
+    }
+
+    /**
+     * Test Store.
+     * @test
+     * @return void
+     */
+    public function testSQLStore()
+    {
+        Configuration::loadFromArray([
+            'store.type'                    => 'sql',
+            'store.sql.dsn'                 => 'sqlite::memory:',
+            'store.sql.prefix'              => 'phpunit_',
+        ], '[ARRAY]', 'simplesaml');
+        $this->addGetDelete();
+        $config = Configuration::getInstance();
+        /** @var \SimpleSAML\Store $store */
+        $store = Store::getInstance();
+        $this->clearInstance($config, Configuration::class);
+        $this->clearInstance($store, Store::class);
+    }
+
+    /**
+     * Test incompatible Store.
+     * @test
+     * @return void
+     */
+    public function testIncompatibleStore()
+    {
+        Configuration::loadFromArray([
+            'store.type'                    => 'memcache',
+        ], '[ARRAY]', 'simplesaml');
+        $store = Store::getInstance();
+        $this->assertInstanceOf(Store\Memcache::class, $store);
+        $this->expectException(Error\Exception::class);
+        $this->addGetDelete();
+        $config = Configuration::getInstance();
+        /** @var \SimpleSAML\Store $store */
+        $store = Store::getInstance();
+        $this->clearInstance($config, Configuration::class);
+        $this->clearInstance($store, Store::class);
+    }
+
+    /**
+     * Test Database.
+     * @test
+     * @return void
+     */
+    public function testDatabase()
+    {
+        $config = [
+            'database.dsn'        => 'sqlite::memory:',
+            'database.username'   => null,
+            'database.password'   => null,
+            'database.prefix'     => 'phpunit_',
+            'database.persistent' => true,
+            'database.slaves'     => [
+                [
+                    'dsn'      => 'sqlite::memory:',
+                    'username' => null,
+                    'password' => null,
+                ],
+            ],
+        ];
+        $this->addGetDelete($config);
+    }
+
+    /**
+     * @param \SimpleSAML\Configuration|\SimpleSAML\Store $service
+     * @param string $className
+     * @return void
+     */
+    protected function clearInstance($service, $className)
+    {
+        $reflectedClass = new \ReflectionClass($className);
+        $reflectedInstance = $reflectedClass->getProperty('instance');
+        $reflectedInstance->setAccessible(true);
+        $reflectedInstance->setValue($service, null);
+        $reflectedInstance->setAccessible(false);
+    }
+}


### PR DESCRIPTION
SQLPersistentNameID only allowed the global datastore to be used when it is of type SQL. This filter could not be used when the global datastore is for example memcache.

After this change, SQLPersistentNameID can be used with any database (specified by dsn, username, password). The change is backward compatible; without using the new option, it falls back to the SQL datastore and behaves like it did before.

This option is similar as in the Consent module.