### PR TITLE
Allow configuration of database number for Redis store

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -1174,4 +1174,9 @@ $config = [
      * The prefix we should use on our Redis datastore.
      */
     'store.redis.prefix' => 'SimpleSAMLphp',
+
+    /*
+     * The database we should use on our Redis datastore.
+     */
+    'store.redis.database' => 0,
 ];

--- a/docs/simplesamlphp-maintenance.md
+++ b/docs/simplesamlphp-maintenance.md
@@ -161,7 +161,7 @@ The required tables are created automatically. If you are storing data from mult
 
 To store sessions in Redis, set the `store.type` option to `redis`.
 
-By default SimpleSAMLphp will attempt to connect to Redis on the `localhost` at port `6379`. These can be configured via the `store.redis.host` and `store.redis.port` options, respectively. You may also set a key prefix with the `store.redis.prefix` option. For Redis instances that [require authentication](https://redis.io/commands/auth), use the `store.redis.password` option.
+By default SimpleSAMLphp will attempt to connect to Redis on the `localhost` at port `6379`. These can be configured via the `store.redis.host` and `store.redis.port` options, respectively. You may also set a key prefix with the `store.redis.prefix` option and a database number with the `store.redis.database` option. For Redis instances that [require authentication](https://redis.io/commands/auth), use the `store.redis.password` option.
 
 ## Metadata storage
 

--- a/lib/SimpleSAML/Store/Redis.php
+++ b/lib/SimpleSAML/Store/Redis.php
@@ -36,6 +36,7 @@ class Redis extends Store
             $port = $config->getInteger('store.redis.port', 6379);
             $prefix = $config->getString('store.redis.prefix', 'SimpleSAMLphp');
             $password = $config->getString('store.redis.password', '');
+            $database = $config->getString('store.redis.database', 0);
 
             $redis = new Client(
                 [
@@ -45,6 +46,9 @@ class Redis extends Store
                 ] + (!empty($password) ? ['password' => $password] : []),
                 [
                     'prefix' => $prefix,
+                    'parameters' => [
+                        'database' => $database,
+                    ],
                 ]
             );
         }


### PR DESCRIPTION
This change adds a configuration option for Redis database number in `config/config.php`. See issue #1223