### PR TITLE
Add note about upgrading third party modules

### DIFF
--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -77,6 +77,9 @@ keep reading for other alternatives):
     cp -rv ../simplesamlphp/metadata metadata
 ```
 
+If you have installed any [third-party modules](https://simplesamlphp.org/modules) or [customised the theme](simplesamlphp-theming.md), 
+you should check whether your third-party modules need upgrading and then copy or replace those directories too.
+
 Replace the old version with the new version:
 
 ```


### PR DESCRIPTION
The current upgrade instructions don't mention that people need to preserve themes or third-party modules, and this has confused some people I've tried to help. Thus I'm proposing adding a note about that.

The second patch is more controversial and had been done separately do it can be discarded if necessary. At the moment the theme on https://simplesamlphp.org/ is not rendering markdown preformatted blocks properly, and the shell script entries are being munged into one line. That means that a copy-and-paste doesn't work. We can fix this by adding semicolons, which usefully doesn't break things later if the theme works again.  (Alternatively someone could fix the theme :-))