### PR TITLE
core/show_metadata: changed => to =

### DIFF
--- a/modules/core/templates/show_metadata.tpl.php
+++ b/modules/core/templates/show_metadata.tpl.php
@@ -7,7 +7,7 @@ $this->includeAtTemplateBase('includes/header.php');
              alt="Copy to clipboard" />
     </button>
     <pre id="metadata">
-$metadata['<?php echo $this->data['m']['metadata-index']; unset($this->data['m']['metadata-index']) ?>'] => <?php
+$metadata['<?php echo $this->data['m']['metadata-index']; unset($this->data['m']['metadata-index']) ?>'] = <?php
     echo htmlspecialchars(var_export($this->data['m'], true));
 ?>
     </pre>


### PR DESCRIPTION
The code generated: `$metadata['idp'] => array();` causing an error when I used this to copy the metadata and pasted it in the `metadata/saml20-idp-remote.php` file of another server.