### PR TITLE
core/show-metadata: added a semicolon at the end of the metadata

### DIFF
--- a/modules/core/templates/show_metadata.tpl.php
+++ b/modules/core/templates/show_metadata.tpl.php
@@ -9,7 +9,7 @@ $this->includeAtTemplateBase('includes/header.php');
     <pre id="metadata">
 $metadata['<?php echo $this->data['m']['metadata-index']; unset($this->data['m']['metadata-index']) ?>'] = <?php
     echo htmlspecialchars(var_export($this->data['m'], true));
-?>
+?>;
     </pre>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
Terribly sorry I did not include this one in my pull request from yesterday. As it turned out I added the missing semicolon automatically, but to be correct and allow brainless copy-pasting of this metadata, you'll need the semicolon on the end of the metadata.

PS: Just some background information: I ran into this issue when I tried to copy-paste the metadata for my IdP from another SP that was already using it, to a new SP I was configuring. When you go straight to the IdP and ask the metadata there you use `/www/saml2/idp/metadata.php` and that one is working fine, so that might explain why it took so long to be discovered.