### PR TITLE
Add Sesotho translation

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -737,6 +737,8 @@ $config = [
             'se' => ['nb', 'no', 'nn', 'en'],
             'nr' => ['zu', 'en'],
             'nd' => ['zu', 'en'],
+            'tw' => ['st', 'en'],
+            'nso' => ['st', 'en'],
         ],
     ],
 
@@ -746,7 +748,7 @@ $config = [
     'language.available' => [
         'en', 'no', 'nn', 'se', 'da', 'de', 'sv', 'fi', 'es', 'ca', 'fr', 'it', 'nl', 'lb',
         'cs', 'sl', 'lt', 'hr', 'hu', 'pl', 'pt', 'pt-br', 'tr', 'ja', 'zh', 'zh-tw', 'ru',
-        'et', 'he', 'id', 'sr', 'lv', 'ro', 'eu', 'el', 'af', 'zu', 'xh',
+        'et', 'he', 'id', 'sr', 'lv', 'ro', 'eu', 'el', 'af', 'zu', 'xh', 'st',
     ],
     'language.rtl' => ['ar', 'dv', 'fa', 'ur', 'he'],
     'language.default' => 'en',

--- a/dictionaries/attributes.translation.json
+++ b/dictionaries/attributes.translation.json
@@ -37,6 +37,7 @@
 		"el": "\u0399\u03b4\u03b9\u03cc\u03c4\u03b7\u03c4\u03b1\u002f\u03b5\u03c2",
 		"xh": "Indima",
 		"zu": "Indima",
+		"st": "Kamano",
 		"ca": "Afiliació"
 	},
 	"attribute_title": {
@@ -76,6 +77,7 @@
 		"el": "\u03a4\u03af\u03c4\u03bb\u03bf\u03c2",
 		"xh": "Isibizo",
 		"zu": "Isiqu",
+		"st": "Thaetlele",
 		"ca": "Tractament"
 	},
 	"attribute_uid": {
@@ -116,6 +118,7 @@
 		"el": "\u0391\u03bd\u03b1\u03b3\u03bd\u03c9\u03c1\u03b9\u03c3\u03c4\u03b9\u03ba\u03cc \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7",
 		"xh": "I-ID yomsebenzisi",
 		"zu": "I-ID yomsebenzisi",
+		"st": "ID ya Mosebedisi",
 		"ca": "Identificador d'usuari"
 	},
 	"attribute_sn": {
@@ -156,6 +159,7 @@
 		"el": "\u0395\u03c0\u03ce\u03bd\u03c5\u03bc\u03bf",
 		"zu": "Isibongo",
 		"xh": "Ifani",
+		"st": "Difane",
 		"ca": "Cognoms"
 	},
 	"attribute_givenname": {
@@ -196,6 +200,7 @@
 		"el": "\u038c\u03bd\u03bf\u03bc\u03b1",
 		"xh": "Igama elinikiweyo",
 		"zu": "Igama lokuzalwa",
+		"st": "Lebitso le fanweng",
 		"ca": "Nom"
 	},
 	"attribute_cn": {
@@ -236,6 +241,7 @@
 		"el": "\u039a\u03bf\u03b9\u03bd\u03cc \u03cc\u03bd\u03bf\u03bc\u03b1 (CN)",
 		"zu": "Igama elivamile",
 		"xh": "Igama eliqhelekileyo",
+		"st": "Lebitso le tlwaelehileng",
 		"ca": "Nom comú (CN)"
 	},
 	"attribute_mail": {
@@ -276,6 +282,7 @@
 		"el": "Email",
 		"zu": "Imeyili",
 		"xh": "Iposi",
+		"st": "Poso",
 		"ca": "Adreça de correu electrònic"
 	},
 	"attribute_mobile": {
@@ -316,6 +323,7 @@
 		"el": "\u039a\u03b9\u03bd\u03b7\u03c4\u03cc \u03c4\u03b7\u03bb\u03ad\u03c6\u03c9\u03bd\u03bf",
 		"zu": "Imobhayili",
 		"xh": "Imobhayili",
+		"st": "E tsamayang",
 		"ca": "Telèfon mòbil"
 	},
 	"attribute_preferredlanguage": {
@@ -356,6 +364,7 @@
 		"el": "\u03a0\u03c1\u03bf\u03c4\u03b9\u03bc\u03ce\u03bc\u03b5\u03bd\u03b7 \u03b3\u03bb\u03ce\u03c3\u03c3\u03b1",
 		"xh": "Ulwimi olukhethayo",
 		"zu": "Ulimi oluncanyelwayo",
+		"st": "Puo e kgethwang",
 		"ca": "Idioma preferit"
 	},
 	"attribute_noredupersonnin": {
@@ -396,6 +405,7 @@
 		"el": "\u0391\u03c1\u03b9\u03b8\u03bc\u03cc\u03c2 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 \u03b1\u03c0\u03cc \u03b4\u03b7\u03bc\u03cc\u03c3\u03b9\u03b1 \u03b1\u03c1\u03c7\u03ae",
 		"xh": "Inombolo yesazisi eyabelwe ngamagunya oluntu",
 		"zu": "Inombolo kamazisi eyabelwe amagunya omphakathi",
+		"st": "Nomoro ya boitsebiso e abilwe ke bolaodi ba puso",
 		"ca": "Número de la Seguretat Social"
 	},
 	"attribute_schachomeorganization": {
@@ -435,6 +445,7 @@
 		"el": "\u038c\u03bd\u03bf\u03bc\u03b1 \u03c0\u03b5\u03c1\u03b9\u03bf\u03c7\u03ae\u03c2 (domain) \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd",
 		"zu": "Igama lesizinda senhlangano yasekhaya",
 		"xh": "Igama ledomeyini yombutho wekhaya",
+		"st": "Lebitso la domeine ya khampani",
 		"ca": "Identificador únic de l’organització principal"
 	},
 	"attribute_organisationname": {
@@ -475,6 +486,7 @@
 		"el": "\u038c\u03bd\u03bf\u03bc\u03b1 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd",
 		"xh": "Igama lombutho",
 		"zu": "Igama lenhlangano",
+		"st": "Lebitso la khampani",
 		"ca": "Nom de l'organització"
 	},
 	"attribute_edupersonentitlement": {
@@ -515,6 +527,7 @@
 		"el": "\u0394\u03b9\u03ba\u03b1\u03b9\u03ce\u03bc\u03b1\u03c4\u03b1 \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2 \u03c3\u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1",
 		"zu": "Ilungelo eliphathelene nesevisi",
 		"xh": "Ilungelo ngokuphathelele inkonzo",
+		"st": "Thuo bakeng sa tshebeletso",
 		"ca": "Drets relatiu al servei"
 	},
 	"attribute_edupersonscopedaffiliation": {
@@ -555,6 +568,7 @@
 		"el": "\u0399\u03b4\u03b9\u03cc\u03c4\u03b7\u03c4\u03b1 \u03b1\u03bd\u03ac \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03b9\u03ba\u03ae \u03c0\u03b5\u03c1\u03b9\u03bf\u03c7\u03ae (administrative domain)",
 		"zu": "Indima enhlanganweni yasekhaya",
 		"xh": "Indima kumbutho wasekhaya",
+		"st": "Kamano khampaning ya habo",
 		"ca": "Afiliació a l’organització principal"
 	},
 	"attribute_edupersontargetedid": {
@@ -594,6 +608,7 @@
 		"el": "\u0391\u03b4\u03b9\u03b1\u03c6\u03b1\u03bd\u03ad\u03c2 \u03b1\u03bd\u03b1\u03b3\u03bd\u03c9\u03c1\u03b9\u03c3\u03c4\u03b9\u03ba\u03cc \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03bc\u03b1\u03ba\u03c1\u03ac\u03c2 \u03b4\u03b9\u03ac\u03c1\u03ba\u03b5\u03b9\u03b1\u03c2",
 		"zu": "Isibizo esingashintshi esiqondene nesevisi",
 		"xh": "Igama elingelolakhe elingatshintshiyo elingqale kwinkonzo",
+		"st": "ID e phehellang ya lebitso la boiqapelo",
 		"ca": "Identificació anònima persistent"
 	},
 	"attribute_pairwise_id": {
@@ -638,13 +653,15 @@
 		"el": "\u0391\u03bd\u03b1\u03b3\u03bd\u03c9\u03c1\u03b9\u03c3\u03c4\u03b9\u03ba\u03cc \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03c3\u03c4\u03bf\u03bd \u03bf\u03b9\u03ba\u03b5\u03af\u03bf \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03cc",
 		"xh": "Igama elingundoqo lomntu kwinkampani yekhaya",
 		"zu": "Igama eliyinhloko lomuntu enhlanganweni yasekhaya",
- 		"ca": "Identificador \u00fanic de la persona a l'organitzaci\u00f3 principal"
+		"st": "Lebitso la sehlooho la motho khampaning ya habo",
+		"ca": "Identificador \u00fanic de la persona a l'organitzaci\u00f3 principal"
 	},
 	"attribute_edupersonuniqueid": {
 		"zh-tw": "\u500b\u4eba\u7121\u6cd5\u91cd\u65b0\u8a2d\u7f6e\uff0c\u65bc\u6240\u5c6c\u7d44\u7e54\u7684\u6c38\u4e45\u533f\u540d ID",
 		"el": "\u039c\u03cc\u03bd\u03b9\u03bc\u03bf, \u03b1\u03b4\u03b9\u03b1\u03c6\u03b1\u03bd\u03ad\u03c2 \u03b1\u03bd\u03b1\u03b3\u03bd\u03c9\u03c1\u03b9\u03c3\u03c4\u03b9\u03ba\u03cc \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03c3\u03c4\u03bf\u03bd \u03bf\u03b9\u03ba\u03b5\u03af\u03bf \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03cc",
 		"zu": "I-ID yesibizo ephikelelayo, engakwazi ukwabelwa kabusha yomuntu yenhlangano yasekhaya",
 		"xh": "I-ID yomntu enganakuphinda yabelwe, ebhalwe ngegama lobuxoki eqhubekayo kwinkampani yekhaya",
+		"st": "ID ya boiqapelo le phehellang, e sa ajweng botjha ya motho ya khampani ya lapeng",
 		"ca": "Identificació anònima persistent i no reasignable de la persona a l'organització principal"
 	},
 	"attribute_subject_id": {
@@ -657,6 +674,7 @@
 		"af": "ORCID identifiseerder",
 		"zu": "Isihlonzi se-ORCID",
 		"xh": "Isazisi se-ORCID",
+		"st": "Ditsebahatsi tsa mofuputsi tsa ORCID",
 		"ca": "Identificador d'investigador ORCID"
 	},
 	"attribute_o": {
@@ -696,6 +714,7 @@
 		"el": "\u038c\u03bd\u03bf\u03bc\u03b1 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd",
 		"zu": "Igama lenhlangano",
 		"xh": "Igama lombutho",
+		"st": "Lebitso la khampani",
 		"ca": "Nom de l'organització"
 	},
 	"attribute_dc": {
@@ -735,6 +754,7 @@
 		"el": "\u03a3\u03c5\u03c3\u03c4\u03b1\u03c4\u03b9\u03ba\u03cc \u03a4\u03bf\u03bc\u03ad\u03b1 (DC)",
 		"zu": "Ingxenye yesizinda (I-DC)",
 		"xh": "Ikhomponenti yedomeyin (DC)",
+		"st": "Karolwana ya domeine (DC)",
 		"ca": "Component de domini (DC)"
 	},
 	"attribute_displayname": {
@@ -774,6 +794,7 @@
 		"el": "\u0395\u03bc\u03c6\u03b1\u03bd\u03b9\u03b6\u03cc\u03bc\u03b5\u03bd\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1",
 		"zu": "Igama lesibonisi",
 		"xh": "Igama lomboniso",
+		"st": "Lebitso le bontshwang",
 		"ca": "Nom a mostrar"
 	},
 	"attribute_facsimiletelephonenumber": {
@@ -813,6 +834,7 @@
 		"el": "Fax",
 		"zu": "Inombolo yefeksi",
 		"xh": "Inombolo yefeksi",
+		"st": "Nomoro ya fekse",
 		"ca": "Número de fax"
 	},
 	"attribute_homephone": {
@@ -852,6 +874,7 @@
 		"el": "\u03a4\u03b7\u03bb\u03ad\u03c6\u03c9\u03bd\u03bf \u03bf\u03b9\u03ba\u03af\u03b1\u03c2",
 		"xh": "Umnxeba wasekhaya",
 		"zu": "Ucingo lwasekhaya",
+		"st": "Founu ya lapeng",
 		"ca": "Telèfon fix particular"
 	},
 	"attribute_homepostaladdress": {
@@ -891,6 +914,7 @@
 		"el": "\u03a4\u03b1\u03c7\u03c5\u03b4\u03c1\u03bf\u03bc\u03b9\u03ba\u03ae \u03b4\u03b9\u03b5\u03cd\u03b8\u03c5\u03bd\u03c3\u03b7 \u03bf\u03b9\u03ba\u03af\u03b1\u03c2",
 		"zu": "Ikheli leposi lasekhaya",
 		"xh": "Idilesi yeposi yasekhaya",
+		"st": "Aterese ya lapeng ya poso",
 		"ca": "Adreça particular"
 	},
 	"attribute_jpegphoto": {
@@ -930,6 +954,7 @@
 		"el": "\u03a6\u03c9\u03c4\u03bf\u03b3\u03c1\u03b1\u03c6\u03af\u03b1 \u03c3\u03b5 \u03bc\u03bf\u03c1\u03c6\u03ae JPEG",
 		"xh": "Ifoto ye-JPEG",
 		"zu": "Isithombe se-JPEG",
+		"st": "Foto ya JPEG",
 		"ca": "Fotografia en JPEG"
 	},
 	"attribute_l": {
@@ -969,6 +994,7 @@
 		"el": "\u03a4\u03bf\u03c0\u03bf\u03b8\u03b5\u03c3\u03af\u03b1",
 		"zu": "Indawo",
 		"xh": "Indawo",
+		"st": "Tulo",
 		"ca": "Localitat"
 	},
 	"attribute_labeleduri": {
@@ -1008,6 +1034,7 @@
 		"el": "\u0395\u03c0\u03b9\u03c3\u03b7\u03bc\u03b1\u03c3\u03bc\u03ad\u03bd\u03b1 URI",
 		"xh": "I-URI eneleyibheli",
 		"zu": "I-URI Enelebula",
+		"st": "Ya Leibole ya URI",
 		"ca": "URI etiquetat"
 	},
 	"attribute_ou": {
@@ -1047,6 +1074,7 @@
 		"el": "\u039f\u03c1\u03b3\u03b1\u03bd\u03c9\u03c4\u03b9\u03ba\u03ae \u03bc\u03bf\u03bd\u03ac\u03b4\u03b1",
 		"zu": "Iyunithi yenhlangano",
 		"xh": "Iyunithi yombutho",
+		"st": "Yuniti ya khampani",
 		"ca": "Unitat organitzativa"
 	},
 	"attribute_postaladdress": {
@@ -1086,6 +1114,7 @@
 		"el": "\u03a4\u03b1\u03c7\u03c5\u03b4\u03c1\u03bf\u03bc\u03b9\u03ba\u03ae \u03b4\u03b9\u03b5\u03cd\u03b8\u03c5\u03bd\u03c3\u03b7",
 		"xh": "Idilesi yeposi",
 		"zu": "Ikheli leposi",
+		"st": "Aterese ya poso",
 		"ca": "Adreça postal"
 	},
 	"attribute_postalcode": {
@@ -1125,6 +1154,7 @@
 		"el": "\u03a4\u03b1\u03c7\u03c5\u03b4\u03c1\u03bf\u03bc\u03b9\u03ba\u03cc\u03c2 \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2",
 		"zu": "Ikhodi yeposi",
 		"xh": "Ikhowudi yeposi",
+		"st": "Khoutu ya poso",
 		"ca": "Codi Postal"
 	},
 	"attribute_postofficebox": {
@@ -1164,6 +1194,7 @@
 		"el": "\u03a4\u03b1\u03c7\u03c5\u03b4\u03c1\u03bf\u03bc\u03b9\u03ba\u03ae \u03b8\u03c5\u03c1\u03af\u03b4\u03b1",
 		"zu": "Ibhokisi lehhovisi leposi",
 		"xh": "Ibhokisi yaseposini",
+		"st": "Lebokose la poso",
 		"ca": "Apartat de correus"
 	},
 	"attribute_street": {
@@ -1203,6 +1234,7 @@
 		"el": "\u039f\u03b4\u03cc\u03c2",
 		"xh": "Istrato",
 		"zu": "Umgwaqo",
+		"st": "Seterata",
 		"ca": "Carrer"
 	},
 	"attribute_telephonenumber": {
@@ -1242,6 +1274,7 @@
 		"el": "\u03a4\u03b7\u03bb\u03ad\u03c6\u03c9\u03bd\u03bf",
 		"zu": "Inombolo yocingo",
 		"xh": "Inombolo yomnxeba",
+		"st": "Nomoro ya founu",
 		"ca": "Número de telèfon"
 	},
 	"attribute_eduorghomepageuri": {
@@ -1281,6 +1314,7 @@
 		"el": "\u0394\u03b9\u03b5\u03cd\u03b8\u03c5\u03bd\u03c3\u03b7 \u03b1\u03c1\u03c7\u03b9\u03ba\u03ae\u03c2 \u03c3\u03b5\u03bb\u03af\u03b4\u03b1\u03c2 \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd",
 		"xh": "Ikhasi lekhaya Lenkampani",
 		"zu": "Ikhasi lasekhaya lenhlangano",
+		"st": "Leqephe la lapeng la khampani",
 		"ca": "Pàgina principal de l'organització"
 	},
 	"attribute_eduorglegalname": {
@@ -1320,6 +1354,7 @@
 		"el": "\u0395\u03c0\u03af\u03c3\u03b7\u03bc\u03b7 \u03b5\u03c0\u03c9\u03bd\u03c5\u03bc\u03af\u03b1 \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd",
 		"zu": "Igama elisemthethweni lenhlangano",
 		"xh": "Igama elisemthethweni lenkampani",
+		"st": "Lebitso la molao la khampani",
 		"ca": "Nom legal de l'organització"
 	},
 	"attribute_edupersonnickname": {
@@ -1359,6 +1394,7 @@
 		"el": "\u03a8\u03b5\u03c5\u03b4\u03ce\u03bd\u03c5\u03bc\u03bf \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7",
 		"xh": "Isiteketiso",
 		"zu": "Isidlaliso",
+		"st": "Lebitso la boswaswi",
 		"ca": "Sobrenom"
 	},
 	"attribute_edupersonorgdn": {
@@ -1398,6 +1434,7 @@
 		"el": "\u0394\u03b9\u03b1\u03ba\u03b5\u03ba\u03c1\u03b9\u03bc\u03ad\u03bd\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 (DN) \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd",
 		"xh": "Igama elahlukileyo (DN) lenkampani yekhaya yomntu",
 		"zu": "Igama elihloniphekile (I-DN) lenhlangano yasekhaya yomuntu",
+		"st": "Lebitso le kgethehileng (DN) la khampani ya habo motho",
 		"ca": "Nom distingit (DN) de l'organització principal de la persona"
 	},
 	"attribute_edupersonorgunitdn": {
@@ -1437,6 +1474,7 @@
 		"el": "\u0394\u03b9\u03b1\u03ba\u03b5\u03ba\u03c1\u03b9\u03bc\u03ad\u03bd\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 (DN) \u03bf\u03b9\u03ba\u03b5\u03af\u03b1\u03c2 \u03bf\u03c1\u03b3\u03b1\u03bd\u03c9\u03c4\u03b9\u03ba\u03ae\u03c2 \u03bc\u03bf\u03bd\u03ac\u03b4\u03b1\u03c2",
 		"xh": "Igama elahlukileyo (DN) leyunithi yenkampani yekhaya yomntu",
 		"zu": "Igama elihloniphekile (I-DN) leyunithi yenhlangano yasekhaya yomuntu",
+		"st": "Lebitso le kgethehileng (DN) la yuniti ya khampani ya habo motho",
 		"ca": "Nom distingit (DN) de la unitat organitzativa (OU) de l'organització principal de la persona"
 	},
 	"attribute_edupersonprimaryaffiliation": {
@@ -1476,6 +1514,7 @@
 		"el": "\u039a\u03cd\u03c1\u03b9\u03b1 \u03b9\u03b4\u03b9\u03cc\u03c4\u03b7\u03c4\u03b1",
 		"xh": "Indima eyintloko",
 		"zu": "Indima eyinhloko",
+		"st": "Kamano ya motheo",
 		"ca": "Afiliació primària"
 	},
 	"attribute_noreduorgnin": {
@@ -1515,6 +1554,7 @@
 		"el": "\u0391\u03c1\u03b9\u03b8\u03bc\u03cc\u03c2 \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd",
 		"zu": "Inombolo yenhlangano",
 		"xh": "Inombolo yenkampani",
+		"st": "Nomoro ya khampani",
 		"ca": "Número de l’organització"
 	},
 	"attribute_noredupersonbirthdate": {
@@ -1554,6 +1594,7 @@
 		"el": "\u0397\u03bc\u03b5\u03c1\u03bf\u03bc\u03b7\u03bd\u03af\u03b1 \u03b3\u03ad\u03bd\u03bd\u03b7\u03c3\u03b7\u03c2",
 		"zu": "Usuku lokuzalwa",
 		"xh": "Umhla wokuzalwa",
+		"st": "Letsatsi la tswalo",
 		"ca": "Data de naixement"
 	},
 	"attribute_noredupersonlin": {
@@ -1593,6 +1634,7 @@
 		"el": "\u0391\u03c1\u03b9\u03b8\u03bc\u03cc\u03c2 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2",
 		"zu": "Inombolo kamazisi yasendaweni",
 		"xh": "Inombolo yesazisi yasekuhlaleni",
+		"st": "Nomoro ya boitsebiso ya lehae",
 		"ca": "Número d'identitat local"
 	},
 	"attribute_manager": {
@@ -1632,6 +1674,7 @@
 		"el": "\u0394\u03b9\u03b1\u03ba\u03b5\u03ba\u03c1\u03b9\u03bc\u03ad\u03bd\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 (DN) \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ae",
 		"xh": "Umanejala",
 		"zu": "Umphathi",
+		"st": "Mookamedi",
 		"ca": "Gestor"
 	},
 	"attribute_userpassword": {
@@ -1670,6 +1713,7 @@
 		"el": "\u039a\u03c1\u03c5\u03c0\u03c4\u03bf\u03b3\u03c1\u03b1\u03c6\u03b7\u03bc\u03ad\u03bd\u03bf\u03c2 \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2",
 		"xh": "Iheshi yephaswedi yomsebenzisi",
 		"zu": "Uheshi wephasiwedi yomsebenzisi",
+		"st": "Hesh ya phasewete ya mosebedisi",
 		"ca": "Clau o contrasenya i mètode d'encriptació utilitzat"
 	},
 	"attribute_edupersonprimaryorgunitdn": {
@@ -1706,6 +1750,7 @@
 		"el": "\u0394\u03b9\u03b1\u03ba\u03b5\u03ba\u03c1\u03b9\u03bc\u03ad\u03bd\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 (DN) \u03ba\u03cd\u03c1\u03b9\u03b1\u03c2 \u03bf\u03c1\u03b3\u03b1\u03bd\u03c9\u03c4\u03b9\u03ba\u03ae\u03c2 \u03bc\u03bf\u03bd\u03ac\u03b4\u03b1\u03c2",
 		"xh": "Igama elahlukileyo (DN) leYunithi Yenkampani yokuqala yomntu",
 		"zu": "Igama elihloniphekile (I-DN) Leyunithi Yenhlangano eyinhloko yomuntu",
+		"st": "Lebitso le kgethehileng (DN) la Yuniti ya Khampani ya Motheo ya habo motho",
 		"ca": "Nom distingit (DN) de l'entrada del directori que representa l'identificador"
 	},
 	"attribute_schacuserprivateattribute": {
@@ -1743,6 +1788,7 @@
 		"el": "\u0391\u03c0\u03cc\u03c1\u03c1\u03b7\u03c4\u03b1 \u03c0\u03c1\u03bf\u03c3\u03c9\u03c0\u03b9\u03ba\u03ac \u03c3\u03c4\u03bf\u03b9\u03c7\u03b5\u03af\u03b1",
 		"zu": "Izingxenye zolwazi oluyimfihlo",
 		"xh": "Iimpawu zenkcazelo yangasese",
+		"st": "Dielemente tsa tlhahisoleseding ya poraefete",
 		"ca": "Elements d'informació privada"
 	},
 	"attribute_noredupersonlegalname": {
@@ -1778,6 +1824,7 @@
 		"el": "\u0395\u03c0\u03af\u03c3\u03b7\u03bc\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1",
 		"xh": "Igama elisemthethweni",
 		"zu": "Igama elisemthethweni",
+		"st": "Lebitso la molao",
 		"ca": "Nom legal"
 	},
 	"attribute_edupersonassurance": {
@@ -1810,6 +1857,7 @@
 		"el": "\u0395\u03c0\u03af\u03c0\u03b5\u03b4\u03bf \u03b1\u03be\u03b9\u03bf\u03c0\u03b9\u03c3\u03c4\u03af\u03b1\u03c2 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7\u03c2",
 		"zu": "Iphrofayela yokuqinisekisa umazisi",
 		"xh": "Iprofayile yokuqinisekisa isazisi",
+		"st": "Profaele ya tiisetso ya boitsebiso",
 		"ca": "Identificador del perfil de garantia"
 	},
 	"attribute_ismemberof": {
@@ -1823,6 +1871,7 @@
 		"el": "\u03a3\u03c5\u03bc\u03bc\u03b5\u03c4\u03bf\u03c7\u03ae \u03c3\u03b5 \u03bf\u03bc\u03ac\u03b4\u03b5\u03c2",
 		"xh": "Ubulungu beqela",
 		"zu": "Ubulungu beqembu",
+		"st": "Botho ba sehlopha",
 		"ca": "Pertinença al grup"
 	}
 }

--- a/dictionaries/disco.translation.json
+++ b/dictionaries/disco.translation.json
@@ -35,6 +35,7 @@
 		"el": "\u0395\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03c6\u03bf\u03c1\u03ad\u03b1",
 		"xh": "Khetha umboneleli wesazisi wakho",
 		"zu": "Khetha umhlinzeki wakho kamazisi",
+		"st": "Kgetha mofani wa boitsebiso wa hao",
 		"ca": "Seleccioneu el vostre proveïdor d'identitat"
 	},
 	"selectidp_full": {
@@ -73,6 +74,7 @@
 		"el": "\u0395\u03c0\u03b9\u03bb\u03ad\u03be\u03c4\u03b5 \u03bf\u03b9\u03ba\u03b5\u03af\u03bf \u03c6\u03bf\u03c1\u03ad\u03b1 \u03c0\u03bf\u03c5 \u03bc\u03c0\u03bf\u03c1\u03b5\u03af \u03bd\u03b1 \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03ae\u03c3\u03b5\u03b9 \u03c4\u03b7\u03bd \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03ac \u03c3\u03b1\u03c2",
 		"zu": "Sicela ukhethe umhlinzeki kamazisi lapho ofuna ukuqinisekisa khona:",
 		"xh": "Nceda ukhethe umboneleli wesazisi apho ufuna ukungqinisisa:",
+		"st": "Ka kopo kgetha mofani wa boitsebiso moo o batlang ho netefatsa:",
 		"ca": "Seleccioneu el proveïdor d’identitat on vulgueu autenticar:"
 	},
 	"select": {
@@ -111,6 +113,7 @@
 		"el": "\u0395\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae",
 		"zu": "Khetha",
 		"xh": "Khetha",
+		"st": "Kgetha",
 		"ca": "Seleccioneu"
 	},
 	"remember": {
@@ -149,6 +152,7 @@
 		"el": "\u039d\u03b1 \u03b8\u03c5\u03bc\u03ac\u03c3\u03b1\u03b9 \u03c4\u03b7\u03bd \u03b5\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae \u03bc\u03bf\u03cd",
 		"zu": "Khumbula ukukhetha kwami",
 		"xh": "Khumbula ukhetho lwam",
+		"st": "Hopola kgetho ya ka",
 		"ca": "Recorda la meva elecció"
 	},
 	"icon_prefered_idp": {
@@ -187,6 +191,7 @@
 		"el": "[\u0391\u03c0\u03bf\u03b8\u03b7\u03ba\u03b5\u03c5\u03bc\u03ad\u03bd\u03b7 \u03c0\u03c1\u03bf\u03b5\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae]",
 		"xh": "[Ukhetho olukhethwayo]",
 		"zu": "[Ukukhetha okuncanyelwayo]",
+		"st": "[Kgetho e kgethwang]",
 		"ca": "[Opció preferida]"
 	},
 	"previous_auth": {
@@ -224,6 +229,7 @@
 		"el": "\u0391\u03c0\u03bf\u03b8\u03b7\u03ba\u03b5\u03c5\u03bc\u03ad\u03bd\u03b7 \u03c0\u03c1\u03bf\u03b5\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03c6\u03bf\u03c1\u03ad\u03b1:",
 		"zu": "Ngaphambilini ukhethe ukuqinisekisa kokuthi",
 		"xh": "Kwixesha elidlulileyo ukhethe ukungqinisisa ngo-",
+		"st": "O qadile ka ho kgetha netefatso ho",
 		"ca": "Abans heu escollit autenticar-vos a"
 	},
 	"login_at": {
@@ -261,6 +267,7 @@
 		"el": "\u0395\u03af\u03c3\u03bf\u03b4\u03bf\u03c2 \u0040",
 		"zu": "Ngena kokuthi",
 		"xh": "Ungeno ngo-",
+		"st": "Kena ho",
 		"ca": "Inicieu sessió a"
 	}
 }

--- a/dictionaries/errors.translation.json
+++ b/dictionaries/errors.translation.json
@@ -36,6 +36,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03c4\u03bf\u03c5 SimpleSAMLphp",
 		"zu": "Iphutha le-SimpleSAMLphp",
 		"xh": "Impazamo ye-SimpleSAMLphp",
+		"st": "Phoso ya SimpleSAMLphp",
 		"ca": "Error de SimpleSAMLphp"
 	},
 	"report_trackid": {
@@ -75,6 +76,7 @@
 		"el": "\u0391\u03bd \u03b1\u03bd\u03b1\u03c6\u03ad\u03c1\u03b5\u03c4\u03b5 \u03b1\u03c5\u03c4\u03cc \u03c4\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1\u002c \u03c0\u03b1\u03c1\u03b1\u03ba\u03b1\u03bb\u03bf\u03cd\u03bc\u03b5 \u03bd\u03b1 \u03c3\u03c5\u03bc\u03c0\u03b5\u03c1\u03b9\u03bb\u03ac\u03b2\u03b5\u03c4\u03b5 \u03c3\u03c4\u03b7\u03bd \u03b1\u03bd\u03b1\u03c6\u03bf\u03c1\u03ac \u03c3\u03b1\u03c2 \u03b1\u03c5\u03c4\u03cc\u03bd \u03c4\u03bf\u03bd \u03b1\u03c1\u03b9\u03b8\u03bc\u03cc \u03c0\u03c1\u03bf\u03ba\u03b5\u03b9\u03bc\u03ad\u03bd\u03bf\u03c5 \u03bd\u03b1 \u03b4\u03b9\u03b5\u03c5\u03ba\u03bf\u03bb\u03cd\u03bd\u03b5\u03c4\u03b5 \u03c4\u03b7 \u03b4\u03b9\u03b1\u03b4\u03b9\u03ba\u03b1\u03c3\u03af\u03b1 \u03b5\u03bd\u03c4\u03bf\u03c0\u03b9\u03c3\u03bc\u03bf\u03cd \u03ba\u03b1\u03b9 \u03b5\u03c0\u03af\u03bb\u03c5\u03c3\u03b7\u03c2 \u03c4\u03bf\u03c5 \u03c0\u03c1\u03bf\u03b2\u03bb\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2:",
 		"zu": "Uma ubika leli phutha, sicela futhi ubike le nombolo yokulandelela eyenza kube nokwenzeka ukuthola iseshini yakho kumalogi atholakalayo kumlawuli wesistimu:",
 		"xh": "Ukuba ngaba uchaza le mpazamo, nceda kananjalo uchaze le nombolo yolandelelo eyenza kube lula ukufumana iseshoni yakho kwiincwadi ezifumaneka kumlawuli wesistim:",
+		"st": "Haeba o tlaleha phoso ena, ka kopo tlaleha hape nomoro ena ya ho sala morao e kgonahatsang hore o fumane seshene ya hao ho di-log ts efumanehang ho sistimi ya motsamaisi:",
 		"ca": "Si informeu d’aquest error, notifiqueu també aquest número de seguiment que permet localitzar la vostra sessió als registres disponibles per a l’administrador del sistema:"
 	},
 	"debuginfo_header": {
@@ -114,6 +116,7 @@
 		"el": "\u03a0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03b5\u03bd\u03c4\u03bf\u03c0\u03b9\u03c3\u03bc\u03bf\u03cd \u03c3\u03c6\u03b1\u03bb\u03bc\u03ac\u03c4\u03c9\u03bd",
 		"xh": "Inkcazelo yokulungisa",
 		"zu": "Ulwazi lokususwa kwephutha",
+		"st": "Tlhahisoleseding ya debug",
 		"ca": "Informació de depuració"
 	},
 	"debuginfo_text": {
@@ -153,6 +156,7 @@
 		"el": "\u039f\u03b9 \u03c0\u03b1\u03c1\u03b1\u03ba\u03ac\u03c4\u03c9 \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03bc\u03c0\u03bf\u03c1\u03b5\u03af \u03bd\u03b1 \u03b4\u03b9\u03b5\u03c5\u03ba\u03bf\u03bb\u03cd\u03bd\u03bf\u03c5\u03bd \u03c4\u03b7 \u03b4\u03b9\u03b1\u03b4\u03b9\u03ba\u03b1\u03c3\u03af\u03b1 \u03b5\u03bd\u03c4\u03bf\u03c0\u03b9\u03c3\u03bc\u03bf\u03cd \u03ba\u03b1\u03b9 \u03b5\u03c0\u03af\u03bb\u03c5\u03c3\u03b7\u03c2 \u03c3\u03c6\u03b1\u03bb\u03bc\u03ac\u03c4\u03c9\u03bd.",
 		"xh": "Inkcazelo yokulungisa engezantsi isenokuba ibangela umdla kumlawuli / idesika yoncedo:",
 		"zu": "Ulwazi lokususwa kwephutha olungezansi lungase lukhange kumlawuli / ideski losizo:",
+		"st": "Tlhahisoleseding ya debug e ka tlase mona e  ka nna ya kgahla motsamaisi / deske ya thuso:",
 		"ca": "La informació de depuració següent pot ser d’interès per l’administrador \/ centre d'atenció a l'usuari:"
 	},
 	"report_header": {
@@ -192,6 +196,7 @@
 		"el": "\u0391\u03bd\u03b1\u03c6\u03bf\u03c1\u03ac \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1\u03c4\u03bf\u03c2",
 		"zu": "Amaphutha ombiko",
 		"xh": "Chaza iimpazamo",
+		"st": "Tlaleha diphoso",
 		"ca": "Informeu de l’error"
 	},
 	"report_text": {
@@ -231,6 +236,7 @@
 		"el": "\u03a0\u03c1\u03bf\u03b1\u03b9\u03c1\u03b5\u03c4\u03b9\u03ba\u03ac\u002c \u03b5\u03b9\u03c3\u03ac\u03b3\u03b5\u03c4\u03b5 \u03c4\u03b7 \u03b4\u03b9\u03b5\u03cd\u03b8\u03c5\u03bd\u03c3\u03b7 \u03b7\u03bb\u03b5\u03ba\u03c4\u03c1\u03bf\u03bd\u03b9\u03ba\u03bf\u03cd \u03c4\u03b1\u03c7\u03c5\u03b4\u03c1\u03bf\u03bc\u03b5\u03af\u03bf\u03c5 \u03c3\u03b1\u03c2 \u03ce\u03c3\u03c4\u03b5 \u03bd\u03b1 \u03b5\u03af\u03bc\u03b1\u03c3\u03c4\u03b5 \u03c3\u03b5 \u03b8\u03ad\u03c3\u03b7 \u03bd\u03b1 \u03ad\u03c1\u03b8\u03bf\u03c5\u03bc\u03b5 \u03c3\u03b5 \u03b5\u03c0\u03b1\u03c6\u03ae \u03bc\u03b1\u03b6\u03af \u03c3\u03b1\u03c2 \u03b3\u03b9\u03b1 \u03c0\u03b5\u03c1\u03b1\u03b9\u03c4\u03ad\u03c1\u03c9 \u03b5\u03c1\u03c9\u03c4\u03ae\u03c3\u03b5\u03b9\u03c2 \u03c3\u03c7\u03b5\u03c4\u03b9\u03ba\u03ac \u03bc\u03b5 \u03c4\u03bf \u03b8\u03ad\u03bc\u03b1 \u03c3\u03b1\u03c2:",
 		"xh": "Unokhetho lokuthumela idilesi yeimeyile yakho, ukuze abalawuli bakwazi ukukuqhagamshela ukuba banemibuzo engakumbi malunga nomba wakho:",
 		"zu": "Faka ngokuzithandela ikheli lakho le-imeyili, ukuze abalawuli bakwazi ukukuthinta ngemibuzo eyengeziwe mayelana nenkinga yakho:",
+		"st": "Ka boikgethelo o ka kenya aterse ya imeile ya hao, bakeng sa batsamaisi hore ba kgone ho ikopanya le wena mabapi le dipotso tse ding ka ditaba tsa hao:",
 		"ca": "Opcionalment, introduïu la vostra adreça de correu electrònic, per a que els administradors puguin contactar amb vosaltres per obtenir més detalls del problema:"
 	},
 	"report_email": {
@@ -271,6 +277,7 @@
 		"el": "Email:",
 		"xh": "Idilesi ye-imeyile:",
 		"zu": "Ikheli le-imeyili:",
+		"st": "Aterese ya imeile:",
 		"ca": "Adreça de correu electrònic:"
 	},
 	"report_explain": {
@@ -310,6 +317,7 @@
 		"el": "\u03a0\u03b5\u03c1\u03b9\u03b3\u03c1\u03ac\u03c8\u03c4\u03b5 \u03c4\u03b9\u03c2 \u03b5\u03bd\u03ad\u03c1\u03b3\u03b5\u03b9\u03ad\u03c2 \u03c3\u03b1\u03c2 \u03cc\u03c4\u03b1\u03bd \u03c3\u03c5\u03bd\u03ad\u03b2\u03b7 \u03c4\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1...",
 		"xh": "Cacisa ukuba wenze ntoni xa bekusenzeka le mpazamo...",
 		"zu": "Chaza ukuthi yini oyenzile ngenkathi kuvela leli phutha...",
+		"st": "Hlalosa seo o se entseng ha phoso ena e ne e hlaha...",
 		"ca": "Expliqueu què heu fet quan es va produir aquest error..."
 	},
 	"report_submit": {
@@ -349,6 +357,7 @@
 		"el": "\u0391\u03c0\u03bf\u03c3\u03c4\u03bf\u03bb\u03ae \u03b1\u03bd\u03b1\u03c6\u03bf\u03c1\u03ac\u03c2",
 		"zu": "Thumela umbiko wephutha",
 		"xh": "Thumela ingxelo yempazamo",
+		"st": "Romela tlaleho ya phoso",
 		"ca": "Envia informe d'error"
 	},
 	"howto_header": {
@@ -388,6 +397,7 @@
 		"el": "\u03a0\u03ce\u03c2 \u03bd\u03b1 \u03bb\u03ac\u03b2\u03b5\u03c4\u03b5 \u03b2\u03bf\u03ae\u03b8\u03b5\u03b9\u03b1",
 		"zu": "Indlela yokuthola usizo",
 		"xh": "Indlela yokufumana uncedo",
+		"st": "Ka moo o ka fumanang thuso",
 		"ca": "Com obtenir ajuda"
 	},
 	"howto_text": {
@@ -427,6 +437,7 @@
 		"el": "\u0391\u03c5\u03c4\u03cc \u03c4\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03c0\u03b9\u03b8\u03b1\u03bd\u03cc\u03c4\u03b1\u03c4\u03b1 \u03bf\u03c6\u03b5\u03af\u03bb\u03b5\u03c4\u03b1\u03b9 \u03c3\u03b5 \u03ba\u03ac\u03c0\u03bf\u03b9\u03b1 \u03b1\u03c0\u03c1\u03bf\u03c3\u03b4\u03cc\u03ba\u03b7\u03c4\u03b7 \u03c3\u03c5\u03bc\u03c0\u03b5\u03c1\u03b9\u03c6\u03bf\u03c1\u03ac \u03ae \u03b5\u03c3\u03c6\u03b1\u03bb\u03bc\u03ad\u03bd\u03b7 \u03c1\u03cd\u03b8\u03bc\u03b9\u03c3\u03b7 \u03c4\u03bf\u03c5 SimpleSAMLphp. \u0395\u03c0\u03b9\u03ba\u03bf\u03b9\u03bd\u03c9\u03bd\u03ae\u03c3\u03c4\u03b5 \u03bc\u03b5 \u03c4\u03bf\u03bd \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ae \u03b1\u03c5\u03c4\u03ae\u03c2 \u03c4\u03b7\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1\u03c2 \u03c3\u03c5\u03bc\u03c0\u03b5\u03c1\u03b9\u03bb\u03b1\u03bc\u03b2\u03ac\u03bd\u03bf\u03bd\u03c4\u03b1\u03c2 \u03c4\u03bf \u03c0\u03b1\u03c1\u03b1\u03c0\u03ac\u03bd\u03c9 \u03bc\u03ae\u03bd\u03c5\u03bc\u03b1 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1\u03c4\u03bf\u03c2.",
 		"zu": "Leli phutha kungenzeka ukuthi libangelwa indlela yokuziphatha engalindelwe noma umiso olungafanele lwe-SimpleSAMLphp. Thinta umlawuli wale sevisi yokungena, bese umthumela umlayezo wephutha ongenhla.",
 		"xh": "Le mpazamo kusenokwenzeka ingenxa yendlela yokwenza engalindelekanga okanye ulungiselelo olungachanekanga lwe-SimpleSAMLphp. Qhagamshelana nomlawuli wale nkonzo yokungena, uze umthumele umyalezo wempazamo ongentla.",
+		"st": "Mohlomong phoso ena e ka lebaka la boitshwaro bo itseng bo sa lebellwang kapa tlhophiso e fosahetseng ya SimpleSAMLphp. Ikopanye le motsamaisi wa tshebeletso ena ya ho kena, ebe o romela molaetsa wa phoso ka hodimo mona.",
 		"ca": "Segurament aquest error es deu a un comportament inesperat o a una configuració incorrecta de SimpleSAMLphp. Poseu-vos en contacte amb l’administrador d’aquest servei i envieu-li el missatge d’error anterior."
 	},
 	"title_CREATEREQUEST": {
@@ -466,6 +477,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7 \u03b4\u03b7\u03bc\u03b9\u03bf\u03c5\u03c1\u03b3\u03af\u03b1 \u03b1\u03b9\u03c4\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2",
 		"xh": "Impazamo nokuyila isicelo",
 		"zu": "Iphutha lokwakha isicelo",
+		"st": "Phoso ho thehweng ha kopo",
 		"ca": "S'ha produït un error en crear la sol·licitud"
 	},
 	"descr_CREATEREQUEST": {
@@ -505,6 +517,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7 \u03b4\u03b7\u03bc\u03b9\u03bf\u03c5\u03c1\u03b3\u03af\u03b1 \u03c4\u03bf\u03c5 \u03b1\u03b9\u03c4\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2 SAML.",
 		"xh": "Kwenzeke impazamo xa kuzanywa ukuyilwa isicelo se-SAML.",
 		"zu": "Kuvele iphutha ngenkathi izama ukwakha isicelo se-SAML.",
+		"st": "Phoso e hlahile ha o leka ho theha kopo ya SAML.",
 		"ca": "S'ha produït un error en intentar crear la sol·licitud SAML."
 	},
 	"title_DISCOPARAMS": {
@@ -544,6 +557,7 @@
 		"el": "\u0395\u03c3\u03c6\u03b1\u03bb\u03bc\u03ad\u03bd\u03bf \u03b1\u03af\u03c4\u03b7\u03bc\u03b1 \u03c0\u03c1\u03bf\u03c2 \u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 \u03b1\u03bd\u03b5\u03cd\u03c1\u03b5\u03c3\u03b7\u03c2 \u03c0\u03b1\u03c1\u03cc\u03c7\u03bf\u03c5 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2",
 		"zu": "Isicelo esingalungile sesevisi yokuthola",
 		"xh": "Isicelo esibi kwinkonzo yofumaniso",
+		"st": "Kopo e mpe bakeng sa tshebeletso ya tshibollo",
 		"ca": "Sol·licitud incorrecta pel servei de descoberta"
 	},
 	"descr_DISCOPARAMS": {
@@ -583,6 +597,7 @@
 		"el": "\u039f\u03b9 \u03c0\u03b1\u03c1\u03ac\u03bc\u03b5\u03c4\u03c1\u03bf\u03b9 \u03c0\u03bf\u03c5 \u03c3\u03c4\u03ac\u03bb\u03b8\u03b7\u03ba\u03b1\u03bd \u03c3\u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 \u03b1\u03bd\u03b5\u03cd\u03c1\u03b5\u03c3\u03b7\u03c2 \u03c0\u03b1\u03c1\u03cc\u03c7\u03bf\u03c5 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 \u03ae\u03c4\u03b1\u03bd \u03b5\u03c3\u03c6\u03b1\u03bb\u03bc\u03ad\u03bd\u03b5\u03c2.",
 		"xh": "Iipharamitha ezithunyelwe kwinkonzo yofumaniso azihambelani neenkcukacha.",
 		"zu": "Amapharamitha athunyelwe kusevisi yokuthola abengavumelani nezici.",
+		"st": "Dipharamitha tse rometsweng tshebeltsong ya tshibollo di ne di se ho latela ditekanyetso.",
 		"ca": "Els paràmetres enviats al servei de descoberta no s'ajusten a les especificacions."
 	},
 	"title_GENERATEAUTHNRESPONSE": {
@@ -622,6 +637,7 @@
 		"el": "\u0394\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03ae \u03b7 \u03b4\u03b7\u03bc\u03b9\u03bf\u03c5\u03c1\u03b3\u03af\u03b1 \u03b1\u03c0\u03cc\u03ba\u03c1\u03b9\u03c3\u03b7\u03c2 \u03c3\u03c4\u03bf \u03b1\u03af\u03c4\u03b7\u03bc\u03b1 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7\u03c2",
 		"zu": "Ayikwazanga ukwakha impendulo yokuqinisekisa",
 		"xh": "Ayikwazanga ukuyila impendulo yongqinisiso",
+		"st": "Ha e a kgona ho theha karabelo ya ntefatso",
 		"ca": "No s’ha pogut crear la resposta d’autenticació"
 	},
 	"descr_GENERATEAUTHNRESPONSE": {
@@ -661,6 +677,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7 \u03b4\u03b7\u03bc\u03b9\u03bf\u03c5\u03c1\u03b3\u03af\u03b1 \u03b1\u03c0\u03cc\u03ba\u03c1\u03b9\u03c3\u03b7\u03c2 \u03b1\u03c0\u03cc \u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2.",
 		"zu": "Ngenkathi lo mhlinzeki kamazisi ezama ukwakha impendulo yokuqinisekisa, kuvele iphutha.",
 		"xh": "Xa lo mboneleli wesazisi ezama ukuyila impendulo yongqinisiso, kwenzeke impazamo.",
+		"st": "Ha mofani enwa wa boitsebiso a leka ho theha karabelo ya netefatso, phoso e bile teng.",
 		"ca": "Quan el proveïdor d’identitat ha intentat crear una resposta d’autenticació, s’ha produït un error."
 	},
 	"title_LDAPERROR": {
@@ -700,6 +717,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 LDAP",
 		"xh": "Impazamo ye-LDAP",
 		"zu": "Iphutha le-LDAP",
+		"st": "Phoso ya LDAP",
 		"ca": "Error LDAP"
 	},
 	"descr_LDAPERROR": {
@@ -739,6 +757,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03b5\u03c0\u03b9\u03ba\u03bf\u03b9\u03bd\u03c9\u03bd\u03af\u03b1 \u03bc\u03b5 \u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 \u03ba\u03b1\u03c4\u03b1\u03bb\u03cc\u03b3\u03bf\u03c5 \u03c7\u03c1\u03b7\u03c3\u03c4\u03ce\u03bd (LDAP).",
 		"xh": "I-LDAP ngumvimba wengcombolo yomsebenzisi, yaye xa uzame ukungena, kufuneka siqhagamshele uvimba wengcombolo we-LDAP. Kwenzeke impazamo xa besiyizama.",
 		"zu": "I-LDAP iyidathabheyisi yomsebenzisi, futhi lapho uzama ukungena, sidinga ukuthinta idathabheyisi ye-LDAP. Kuvele iphutha ngesikhathi siyizama ngalesi sikhathi.",
+		"st": "LDAP ke dathabeise ya mosebedisi, mme ha o leka ho kena, re hloka ho ikopanya le dathabeise ya LDAP. Phoso e hlahile ha re e leka lekgelong lena.",
 		"ca": "LDAP és la base de dades d'usuaris i, quan intenteu iniciar la sessió, necessitem connectar amb una base de dades LDAP. S'ha produït un error quan hem provat d'accedir-hi."
 	},
 	"title_LOGOUTREQUEST": {
@@ -778,6 +797,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7 \u03b4\u03b9\u03b1\u03b4\u03b9\u03ba\u03b1\u03c3\u03af\u03b1 \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7\u03c2",
 		"xh": "Impazamo iprosesa iSicelo Sokuphuma",
 		"zu": "Iphutha lokucubungula Isicelo Sokuphuma",
+		"st": "Phoso ho sebetseng Kopo ya Ho Tswa",
 		"ca": "S'ha produït un error en processar la sol·licitud de desconnexió"
 	},
 	"descr_LOGOUTREQUEST": {
@@ -817,6 +837,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03b1\u03c3\u03c4\u03ae\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03b5\u03c0\u03b5\u03be\u03b5\u03c1\u03b3\u03b1\u03c3\u03af\u03b1 \u03c4\u03bf\u03c5 \u03b1\u03b9\u03c4\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2 \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7\u03c2.",
 		"zu": "Kuvele iphutha ngenkathi izama ukucubungula Isicelo Sokuphuma.",
 		"xh": "Kwenzeke impazamo ngoxa kuproseswa isiCelo Sokuphuma.",
+		"st": "Phoso e hlahile ha e leka ho sebetsa Kopo ya Ho Tswa.",
 		"ca": "S'ha produït un error en intentar processar la sol·licitud de desconnexió."
 	},
 	"title_METADATA": {
@@ -856,6 +877,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7 \u03c6\u03cc\u03c1\u03c4\u03c9\u03c3\u03b7 \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03c9\u03bd",
 		"zu": "Iphutha lokulayisha imethadatha",
 		"xh": "Impazamo ilayisha imetadata",
+		"st": "Phoso ya ho louta metadata",
 		"ca": "S'ha produït un error en carregar les metadades"
 	},
 	"descr_METADATA": {
@@ -895,6 +917,7 @@
 		"el": "\u03a5\u03c0\u03ac\u03c1\u03c7\u03b5\u03b9 \u03ba\u03ac\u03c0\u03bf\u03b9\u03bf \u03c0\u03c1\u03cc\u03b2\u03bb\u03b7\u03bc\u03b1 \u03c3\u03c4\u03b9\u03c2 \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03b9\u03c2 \u03c4\u03bf\u03c5 SimpleSAMLphp. \u0395\u03ac\u03bd \u03b5\u03af\u03c3\u03c4\u03b5 \u03bf \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ae\u03c2 \u03c4\u03b7\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1\u03c2 \u03b1\u03c5\u03c4\u03ae\u03c2, \u03b2\u03b5\u03b2\u03b1\u03b9\u03c9\u03b8\u03b5\u03af\u03c4\u03b5 \u03cc\u03c4\u03b9 \u03c4\u03b1 \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03b1 \u03ad\u03c7\u03bf\u03c5\u03bd \u03c1\u03c5\u03b8\u03bc\u03b9\u03c3\u03c4\u03b5\u03af \u03c3\u03c9\u03c3\u03c4\u03ac.",
 		"xh": "Kukho ulungiselelo olungachanekanga oluthile lofakelo lwakho lwe-SimpleSAMLphp. Ukuba ngaba ungumlawuli wale nkonzo, ufanele uqinisekise ulungiselelo lwakho  lweempawu-ngcaciso zefayile lusetwe ngokuchanekileyo.",
 		"zu": "Kukhona umiso olungafanele kukufaka kwakho kwe-SimpleSAMLphp. Uma ungumlawuli wale sevisi, kufanele wenze isiqiniseko sokuthi umiso lwakho lwemethadatha lumiswe ngendlela efanele.",
+		"st": "Ho na le tlhophiso e fosahetseng ya kenyo ya ho instola SimpleSAMLphp ya hao. Haeba o motsamaisi wa tshebeletso ena, o tlameha ho etsa bonnete ba hore tlhophiso ya metadata ya hao e setilwe ka nepo.",
 		"ca": "Hi ha alguna configuració incorrecta a la vostra instal·lació de SimpleSAMLphp. Si sou l’administrador d’aquest servei, heu d’assegurar-vos que la configuració de les vostres metadades s’ha realitzat correctament."
 	},
 	"title_NOACCESS": {
@@ -934,6 +957,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7",
 		"zu": "Akukho ukufinyelela",
 		"xh": "Akukho fikelelo",
+		"st": "Ha ho phihlello",
 		"ca": "Sense accès"
 	},
 	"descr_NOACCESS": {
@@ -973,6 +997,7 @@
 		"el": "\u0391\u03c5\u03c4\u03cc \u03c4\u03bf \u03c4\u03b5\u03bb\u03b9\u03ba\u03cc \u03c3\u03b7\u03bc\u03b5\u03af\u03bf \u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7\u03c2 (endpoint) \u03b4\u03b5\u03bd \u03b5\u03af\u03bd\u03b1\u03b9 \u03b5\u03bd\u03b5\u03c1\u03b3\u03bf\u03c0\u03bf\u03b9\u03b7\u03bc\u03ad\u03bd\u03bf. \u0395\u03ac\u03bd \u03b5\u03af\u03c3\u03c4\u03b5 \u03bf \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ae\u03c2 \u03c4\u03b7\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1\u03c2, \u03b5\u03bb\u03ad\u03b3\u03be\u03c4\u03b5 \u03c4\u03b9\u03c2 \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03b9\u03c2 \u03c4\u03bf\u03c5 SimpleSAMLphp.",
 		"xh": "Le ndawo yokuphela ayenziwanga yasebenza. Jonga ukhetho lokwenza isebenze kulungiselelo lwakho lwe-SimpleSAMLphp.",
 		"zu": "Lesi siphetho asivunyelwe. Hlola izinketho zokuvumela kumiso lwakho lwe-SimpleSAMLphp.",
+		"st": "Ntlha ya bofelo ha e a bulelwa. Hlahloba dikgetho tse tlhophisong ya hao ya SimpleSAMLphp.",
 		"ca": "Aquest punt final no està habilitat. Comproveu les opcions d’habilitació en la configuració de SimpleSAMLphp."
 	},
 	"title_NORELAYSTATE": {
@@ -1012,6 +1037,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03c0\u03b1\u03c1\u03b1\u03bc\u03ad\u03c4\u03c1\u03bf\u03c5 'RelayState'",
 		"zu": "Ayikho I-RelayState",
 		"xh": "Akukho RelayState",
+		"st": "Ha ho RelayState",
 		"ca": "Sense RelayState"
 	},
 	"descr_NORELAYSTATE": {
@@ -1051,6 +1077,7 @@
 		"el": "\u0397 \u03c0\u03b1\u03c1\u03ac\u03bc\u03b5\u03c4\u03c1\u03bf\u03c2 'RelayState' \u03c4\u03bf\u03c5 \u03c0\u03c1\u03c9\u03c4\u03bf\u03ba\u03cc\u03bb\u03bb\u03bf\u03c5 SAML \u03b4\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b5 \u03ae \u03b4\u03b5\u03bd \u03b5\u03af\u03bd\u03b1\u03b9 \u03ad\u03b3\u03ba\u03c5\u03c1\u03b7 \u03bc\u03b5 \u03b1\u03c0\u03bf\u03c4\u03ad\u03bb\u03b5\u03c3\u03bc\u03b1 \u03bd\u03b1 \u03bc\u03b7\u03bd \u03b5\u03af\u03bd\u03b1\u03b9 \u03b4\u03c5\u03bd\u03b1\u03c4\u03ae \u03b7 \u03bc\u03b5\u03c4\u03ac\u03b2\u03b1\u03c3\u03b7 \u03c3\u03b5 \u03ba\u03ac\u03c0\u03bf\u03b9\u03bf\u03bd \u03c0\u03cc\u03c1\u03bf \u03c4\u03bf\u03c5 \u03c0\u03b1\u03c1\u03cc\u03c7\u03bf\u03c5 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd0.",
 		"xh": "Umqalisi wesi sicelo akanikelanga ngepharamitha ye-RelayState apho kufanele kuyiwe khona.",
 		"zu": "Umqalisi walesi sicelo akazange ahlinzeke ngepharamitha ye-RelayState ebonisa ukuthi kufanele uye kuphi ngokulandelayo.",
+		"st": "Moqadi wa kopo ena ha a fana pharamitha ya RelayState e bontshang hore ho uwe kae ho tloha mona.",
 		"ca": "L’iniciador d’aquesta sol·licitud no ha proporcionat un paràmetre de RelayState que indiqui on seguirà."
 	},
 	"title_PROCESSASSERTION": {
@@ -1090,6 +1117,7 @@
 		"el": "\u0395\u03c3\u03c6\u03b1\u03bb\u03bc\u03ad\u03bd\u03b7 \u03b1\u03c0\u03cc\u03ba\u03c1\u03b9\u03c3\u03b7 \u03b1\u03c0\u03cc \u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2",
 		"xh": "Impazamo iprosesa impendulo esuka kuMboneleli Wesazisi",
 		"zu": "Iphutha lokucubungula impendulo esuka Kumhlinzeki Kamazisi",
+		"st": "Phoso ho sebetseng karabelo ho tswa ho Mofani wa Boitsebiso",
 		"ca": "S'ha produït un error en processar la resposta del proveïdor d’identitat"
 	},
 	"descr_PROCESSASSERTION": {
@@ -1129,6 +1157,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03b5\u03c0\u03b5\u03be\u03b5\u03c1\u03b3\u03b1\u03c3\u03af\u03b1 \u03c4\u03b7\u03c2 \u03b1\u03c0\u03ac\u03bd\u03c4\u03b7\u03c3\u03b7\u03c2 \u03b1\u03c0\u03cc \u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2.",
 		"zu": "Asizange samukele impendulo ethunyelwe ukusuka Kumhlinzeki Kamazisi.",
 		"xh": "Asiyamkelanga impendulo ethunyelwe ukusuka kuMboneleli Wesazisi.",
+		"st": "Ha re a amohela karabelo ho tswa ho Mofani wa Boitsebiso.",
 		"ca": "La resposta enviada pel proveïdor d’identitat no ha estat acceptada."
 	},
 	"title_PROCESSAUTHNREQUEST": {
@@ -1168,6 +1197,7 @@
 		"el": "\u0395\u03c3\u03c6\u03b1\u03bb\u03bc\u03ad\u03bd\u03bf \u03b1\u03af\u03c4\u03b7\u03bc\u03b1 \u03b1\u03c0\u03cc \u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd",
 		"xh": "Impazamo iprosesa isicelo esisuka kuMboneleli Wenkonzo",
 		"zu": "Iphutha lokucubungula isicelo esisuka Kumhlinzeki Wesevisi",
+		"st": "Phoso ho sebetseng kopo ho tswa ho Mofani wa Tshebeletso",
 		"ca": "S'ha produït un error en processar la sol·licitud del proveïdor de serveis"
 	},
 	"descr_PROCESSAUTHNREQUEST": {
@@ -1207,6 +1237,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03b5\u03c0\u03b5\u03be\u03b5\u03c1\u03b3\u03b1\u03c3\u03af\u03b1 \u03c4\u03bf\u03c5 \u03b1\u03b9\u03c4\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7\u03c2 \u03c0\u03bf\u03c5 \u03ad\u03bb\u03b1\u03b2\u03b5 \u03bf \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf\u03c2 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 \u03b1\u03c0\u03cc \u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd.",
 		"zu": "Lo Mhlinzeki Kamazisi uthole Isicelo Sokuqinisekisa ukusuka Kumhlinzeki Wesevisi, kodw,a kuvele iphutha ngenkathi ezama ukucubungula isicelo.",
 		"xh": "Lo Mboneleli Wesazisi ufumene Isicelo Songqinisiso esisuka kuMboneleli Wenkonzo, kodwa kwenzeke impazamo xa kuzanywa ukuprosesa isicelo.",
+		"st": "Mofani enwa wa Boitsebiso o fumane Kopo ya Netefatso ho tswa ho Mofani wa Tshebeletso, empa ho bile le phoso ha ho leka ho fihlellwa kopo.",
 		"ca": "Aquest proveïdor d’identitat ha rebut una sol·licitud d’autenticació d’un proveïdor de serveis, però s’ha produït un error en intentar processar la sol·licitud."
 	},
 	"title_SLOSERVICEPARAMS": {
@@ -1246,6 +1277,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7 \u03c3\u03c4\u03b7 \u03b4\u03b9\u03b5\u03c0\u03b1\u03c6\u03ae SingleLogoutService",
 		"zu": "Awukho umlayezo we-SAML onikeziwe",
 		"xh": "Akukho myalezo we-SAML unikelweyo",
+		"st": "Ha ho molaetsa wa SAML o fanweng",
 		"ca": "No s’ha proporcionat cap missatge SAML"
 	},
 	"descr_SLOSERVICEPARAMS": {
@@ -1285,6 +1317,7 @@
 		"el": "\u039a\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03ae \u03c3\u03b1\u03c2 \u03c3\u03c4\u03b7 \u03b4\u03b9\u03b5\u03c0\u03b1\u03c6\u03ae SingleLogoutService \u03c0\u03b1\u03c1\u03b1\u03bb\u03b5\u03af\u03c8\u03b1\u03c4\u03b5 \u03bd\u03b1 \u03c3\u03c5\u03bc\u03c0\u03b5\u03c1\u03b9\u03bb\u03ac\u03b2\u03b5\u03c4\u03b5 \u03bc\u03ae\u03bd\u03c5\u03bc\u03b1 LogoutRequest \u03ae LogoutResponse \u03c4\u03bf\u03c5 \u03c0\u03c1\u03c9\u03c4\u03bf\u03ba\u03cc\u03bb\u03bb\u03bf\u03c5 SAML. \u03a3\u03b7\u03bc\u03b5\u03b9\u03ce\u03c3\u03c4\u03b5 \u03cc\u03c4\u03b9 \u03b1\u03c5\u03c4\u03cc \u03c4\u03bf \u03c4\u03b5\u03bb\u03b9\u03ba\u03cc \u03c3\u03b7\u03bc\u03b5\u03af\u03bf (endpoint) \u03b4\u03b5\u03bd \u03c0\u03c1\u03bf\u03bf\u03c1\u03af\u03b6\u03b5\u03c4\u03b1\u03b9 \u03bd\u03b1 \u03b5\u03af\u03bd\u03b1\u03b9 \u03ac\u03bc\u03b5\u03c3\u03b1 \u03c0\u03c1\u03bf\u03c3\u03b2\u03ac\u03c3\u03b9\u03bc\u03bf.",
 		"zu": "Ufinyelele ukusebenzisana kwe-SingleLogoutService, kodwa awuzange uhlinzeke nge-SAML LogoutRequest noma i-LogoutResponse. Sicela uphawule ukuthi isiphetho asihloselwe ukufinyelelwa ngokuqondile.",
 		"xh": "Ufikelele i-intafeyisi ye-SingleLogoutService, kodwa awukhange unikele i-SAML LogoutRequest okanye i-LogoutResponse. Nceda uqaphele ukuba le ndawo yokuphela ayilungiselelwanga ukuba ifikelelwe ngokuthe ngqo.",
+		"st": "O fihletse tshebeletsano ya SingleLogoutService, empa ha o a fana ka SAML LogoutRequest kapa LogoutResponse. Ka kopo lemoha hore ntlha ena ya bofelo ha e a rerelwa ho fihlellwa ka kotloloho.",
 		"ca": "Heu accedit a la interfície de SingleLogoutService, però no heu proporcionat un missatge SAML de LogoutRequest ni LogoutResponse. Tingueu en compte que en aquest punt no s'hi pot accedir directament."
 	},
 	"title_ACSPARAMS": {
@@ -1324,6 +1357,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7 \u03c3\u03c4\u03b7 \u03b4\u03b9\u03b5\u03c0\u03b1\u03c6\u03ae AssertionConsumerService",
 		"zu": "Ayikho impendulo ye-SAML enikeziwe",
 		"xh": "Akukho mpendulo ye-SAML inikelweyo",
+		"st": "Ha ho karabelo ya SAML e fanweng",
 		"ca": "No s’ha proporcionat cap resposta de SAML"
 	},
 	"descr_ACSPARAMS": {
@@ -1363,30 +1397,35 @@
 		"el": "\u039a\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03ae \u03c3\u03b1\u03c2 \u03c3\u03c4\u03b7 \u03b4\u03b9\u03b5\u03c0\u03b1\u03c6\u03ae AssertionConsumerService  \u03c0\u03b1\u03c1\u03b1\u03bb\u03b5\u03af\u03c8\u03b1\u03c4\u03b5 \u03bd\u03b1 \u03c3\u03c5\u03bc\u03c0\u03b5\u03c1\u03b9\u03bb\u03ac\u03b2\u03b5\u03c4\u03b5 \u03b1\u03c0\u03ac\u03bd\u03c4\u03b7\u03c3\u03b7 \u03c3\u03b5 \u03b1\u03af\u03c4\u03b7\u03bc\u03b1 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7\u03c2 \u03c4\u03bf\u03c5 \u03c0\u03c1\u03c9\u03c4\u03bf\u03ba\u03cc\u03bb\u03bb\u03bf\u03c5 SAML. \u03a3\u03b7\u03bc\u03b5\u03b9\u03ce\u03c3\u03c4\u03b5 \u03cc\u03c4\u03b9 \u03b1\u03c5\u03c4\u03cc \u03c4\u03bf \u03c4\u03b5\u03bb\u03b9\u03ba\u03cc \u03c3\u03b7\u03bc\u03b5\u03af\u03bf (endpoint) \u03b4\u03b5\u03bd \u03c0\u03c1\u03bf\u03bf\u03c1\u03af\u03b6\u03b5\u03c4\u03b1\u03b9 \u03bd\u03b1 \u03b5\u03af\u03bd\u03b1\u03b9 \u03ac\u03bc\u03b5\u03c3\u03b1 \u03c0\u03c1\u03bf\u03c3\u03b2\u03ac\u03c3\u03b9\u03bc\u03bf.",
 		"zu": "Ufinyelele ukusebenzisana Kwesevisi Yomthengi Yesimemezelo, kodwa awuzange uhlinzeke Ngempendulo Yokuqinisekisa ye-SAML. Sicela uphawule ukuthi isiphetho asihloselwe ukufinyelelwa ngokuqondile.",
 		"xh": "Ufikelele i-intafeyisi ye-Assertion Consumer Service, kodwa awukhange unikele iMpendulo Yongqinisiso ye-SAML. Nceda uqaphele ukuba le ndawo yokuphela ayilungiselelwanga ukuba ifikelelwe ngokuthe ngqo.",
+		"st": "O fihletse kopano ya Tiiso ya Tshebeletso ya Bareki, empa ha o a fana ka Karabelo ya Netefatso ya SAML. Ka kopo lemoha hore ntlha ena ya bofelo ha e a rerelwa ho fihlellwa ka kotloloho.",
 		"ca": "Heu accedit a la interfície Assertion Consumer Service però no heu proporcionat una resposta d’autenticació SAML. Tingueu en compte que en aquest punt no s'hi pot accedir directament."
 	},
 	"title_SSOPARAMS": {
 		"zh-tw": "\u672a\u63d0\u4f9b SAML \u8acb\u6c42",
 		"zu": "Asikho isicelo se-SAML esinikeziwe",
 		"xh": "Akukho sicelo se-SAML sinikelweyo",
+		"st": "Ha ho kopo ya SAML e fanweng",
 		"ca": "No s’ha proporcionat cap sol·licitud SAML"
 	},
 	"descr_SSOPARAMS": {
 		"zh-tw": "\u60a8\u9023\u7d50\u55ae\u4e00\u7c3d\u5165\u670d\u52d9\u4ecb\u9762\uff0c\u4f46\u672a\u63d0\u4f9b\u4e00\u500b SAML \u9a57\u8b49\u8acb\u6c42\u3002\u8acb\u6ce8\u610f\uff0c\u8a72\u7aef\u9ede\u4e26\u975e\u76f4\u63a5\u9023\u7dda\u3002",
 		"xh": "Ufikelele i-intafeyisi ye-Single Sign On Service, kodwa awukhange unikele iMpendulo Yongqinisiso ye-SAML. Nceda uqaphele ukuba le ndawo yokuphela ayilungiselelwanga ukuba ifikelelwe ngokuthe ngqo.",
 		"zu": "Ufinyelele ukusebenzisana Kwesevisi Yokubhalisa Okukodwa, kodwa awuzange uhlinzeke Ngempendulo Yokuqinisekisa ye-SAML. Sicela uphawule ukuthi isiphetho asihloselwe ukufinyelelwa ngokuqondile.",
+		"st": "O fihletse tshebeletsano ya Tshaeno ya Hang, empa ha o a fan aka Kopo ya Netefatso ya SAML. Ka kopo lemoha hore ntlha ena ya bofelo ha e a rerelwa ho fihlellwa ka kotloloho.",
 		"ca": "Heu accedit a la interfície del servei d’inici de sessió únic, però no heu proporcionat una sol·licitud d’autenticació SAML. Tingueu en compte que en aquest punt no s'hi pot accedir directament."
 	},
 	"title_ARSPARAMS": {
 		"zh-tw": "\u672a\u63d0\u4f9b SAML \u8a0a\u606f",
 		"zu": "Awukho umlayezo we-SAML onikeziwe",
 		"xh": "Akukho myalezo we-SAML unikelweyo",
+		"st": "Ha ho molaetsa wa SAML o fanweng",
 		"ca": "No s’ha proporcionat cap missatge SAML"
 	},
 	"descr_ARSPARAMS": {
 		"zh-tw": "\u60a8\u9023\u7d50\u4eba\u5de5\u8655\u7406\u670d\u52d9\u4ecb\u9762\uff0c\u4f46\u672a\u63d0\u4f9b SAML \u4eba\u5de5\u8655\u7406\u670d\u52d9\u8a0a\u606f\u3002\u8acb\u6ce8\u610f\uff0c\u8a72\u7aef\u9ede\u4e26\u975e\u76f4\u63a5\u9023\u7dda\u3002",
 		"xh": "Ufikelele i-intafeyisi ye-Artifact Resolution Service, kodwa awukhange unikrele umyalezo we-SAML ArtifactResolve. Nceda uqaphele ukuba le ndawo yokuphela ayilungiselelwanga ukuba ifikelelwe ngokuthe ngqo.",
 		"zu": "Ufinyelele ukusebenzisana Kwesevisi Yokucaciswa Kobuciko, kodwa awuzange uhlinzeke umlayezo we-SAML ArtifactResolve. Sicela uphawule ukuthi isiphetho asihloselwe ukufinyelelwa ngokuqondile.",
+		"st": "O fihletse kopano ya Tshebeletso ya Tlhakiso ya Athifekte, empa ha o a fana ka molaetsa wa SAML ArtifactResolve. Ka kopo lemoha hore ntlha ena ya bofelo ha e a rerelwa ho fihlellwa ka kotloloho.",
 		"ca": "Heu accedit a la interfície del servei de resolució Artifact, però no heu proporcionat un missatge d’ArtifactResolve de SAML. Tingueu en compte que en aquest punt no s'hi pot accedir directament."
 
 	},
@@ -1427,6 +1466,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 CAS",
 		"xh": "Impazamo ye-CAS",
 		"zu": "Iphutha Le-CAS",
+		"st": "Phoso ya CAS",
 		"ca": "Error CAS"
 	},
 	"descr_CASERROR": {
@@ -1466,6 +1506,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03b5\u03c0\u03b9\u03ba\u03bf\u03b9\u03bd\u03c9\u03bd\u03af\u03b1 \u03bc\u03b5 \u03c4\u03bf\u03bd \u03b5\u03be\u03c5\u03c0\u03b7\u03c1\u03b5\u03c4\u03b7\u03c4\u03ae CAS.",
 		"zu": "Iphutha ngenkathi kuxhunyanwa neseva ye-CAS.",
 		"xh": "Impazamo xa kunxibelelwana neseva ye-CAS.",
+		"st": "Phoso e bile teng ka seva ya CAS.",
 		"ca": "S'ha produït un error al intentar connectar amb el servidor CAS."
 	},
 	"title_CONFIG": {
@@ -1505,6 +1546,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03c9\u03bd",
 		"zu": "Iphutha lomiso",
 		"xh": "Impazamo yolungiselelo",
+		"st": "Phoso ya Netefatso",
 		"ca": "Error de configuració"
 	},
 	"descr_CONFIG": {
@@ -1544,6 +1586,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03c9\u03bd \u03c4\u03bf\u03c5 SimpleSAMLphp. \u0395\u03c0\u03b9\u03ba\u03bf\u03b9\u03bd\u03c9\u03bd\u03ae\u03c3\u03c4\u03b5 \u03bc\u03b5 \u03c4\u03bf\u03bd \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ae \u03c4\u03b7\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1\u03c2.",
 		"xh": "I-SimpleSAMLphp ibonakala ingalungiselelwanga kakuhle.",
 		"zu": "I-SimpleSAMLphp ibonakala ingamisiwe ngendlela efanele.",
+		"st": "SimpleSAMLphp e bonahala e hlophisitswe hampe.",
 		"ca": "SimpleSAMLphp sembla estar mal configurat."
 	},
 	"title_NOTSET": {
@@ -1583,6 +1626,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03c9\u03b4\u03b9\u03ba\u03bf\u03cd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2",
 		"xh": "Iphaswedi ayisetwanga",
 		"zu": "Iphasiwedi ayisethiwe",
+		"st": "Phasewete ha e a setwa",
 		"ca": "No s'ha definit la contrasenya"
 	},
 	"descr_NOTSET": {
@@ -1622,6 +1666,7 @@
 		"el": "\u03a7\u03c1\u03b7\u03c3\u03b9\u03bc\u03bf\u03c0\u03bf\u03b9\u03b5\u03af\u03c4\u03b1\u03b9 \u03b7 \u03c0\u03c1\u03bf\u03ba\u03b1\u03b8\u03bf\u03c1\u03b9\u03c3\u03bc\u03ad\u03bd\u03b7 \u03c4\u03b9\u03bc\u03ae \u03c4\u03bf\u03c5 \u03ba\u03c9\u03b4\u03b9\u03ba\u03bf\u03cd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2. \u03a0\u03b1\u03c1\u03b1\u03ba\u03b1\u03bb\u03bf\u03cd\u03bc\u03b5 \u03b5\u03c0\u03b5\u03be\u03b5\u03c1\u03b3\u03b1\u03c3\u03c4\u03b5\u03af\u03c4\u03b5 \u03c4\u03bf \u03b1\u03c1\u03c7\u03b5\u03af\u03bf \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03c9\u03bd.",
 		"xh": "Iphaswedi ekulungiselelo (auth.adminpassword) ayitshintshwanga ukusuka kwixabiso lesiseko. Nceda uhlele ifayile yolungiselelo.",
 		"zu": "Iphasiwedi kumiso (auth.adminpassword) ayishintshiwe kunani elizenzakalelayo. Sicela uhlele ifayela lomiso.",
+		"st": "Phasewete ya tlhophiso (auth.adminpassword) ha e a fetolwa ho tswa palong ya tlwaelo. Ka kopo edita faele ya tlhophiso.",
 		"ca": "La contrasenya de la configuració (auth.adminpassword) no s'ha canviat del valor predeterminat. Editeu el fitxer de configuració."
 	},
 	"title_NOTVALIDCERT": {
@@ -1661,6 +1706,7 @@
 		"el": "\u039c\u03b7 \u03ad\u03b3\u03ba\u03c5\u03c1\u03bf \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03cc",
 		"xh": "Isatifikethi esingasebenziyo",
 		"zu": "Isitifiketi esingalungile",
+		"st": "Setifikeiti se sa tshwaneleheng",
 		"ca": "Certificat no vàlid"
 	},
 	"descr_NOTVALIDCERT": {
@@ -1700,6 +1746,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03bb\u03cc\u03b3\u03c9 \u03bc\u03b7 \u03ad\u03b3\u03ba\u03c5\u03c1\u03bf\u03c5 \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03bf\u03cd.",
 		"zu": "Awuzange wethule isitifiketi esilungile.",
 		"xh": "Awukhange uzise isatifikethi esisebenzayo.",
+		"st": "Ha o a fana ka setifikeiti se nepahetseng.",
 		"ca": "No heu presentat un certificat vàlid."
 	},
 	"errorreport_header": {
@@ -1738,6 +1785,7 @@
 		"el": "\u0397 \u03b1\u03bd\u03b1\u03c6\u03bf\u03c1\u03ac \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1\u03c4\u03bf\u03c2 \u03c3\u03c4\u03ac\u03bb\u03b8\u03b7\u03ba\u03b5",
 		"zu": "Umbiko wephutha uthunyelwe",
 		"xh": "Ingxelo yempazamo ithunyelwe",
+		"st": "Tlaleho ya phoso e rometswe",
 		"ca": "S'ha enviat un informe d'error"
 	},
 	"errorreport_text": {
@@ -1776,6 +1824,7 @@
 		"el": "\u0397 \u03b1\u03c0\u03bf\u03c3\u03c4\u03bf\u03bb\u03ae \u03c4\u03b7\u03c2 \u03b1\u03bd\u03b1\u03c6\u03bf\u03c1\u03ac\u03c2 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1\u03c4\u03bf\u03c2 \u03c3\u03c4\u03bf\u03c5\u03c2 \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ad\u03c2 \u03bf\u03bb\u03bf\u03ba\u03bb\u03b7\u03c1\u03ce\u03b8\u03b7\u03ba\u03b5.",
 		"xh": "Ingxelo yempazamo ithunyelwe kubalawuli.",
 		"zu": "Umbiko wephutha uthunyelwe kubalawuli.",
+		"st": "Tlaleho ya phoso e rometswe ho batsamaisi.",
 		"ca": "L’informe d’errors s’ha enviat als administradors."
 	},
 	"title_LOGOUTINFOLOST": {
@@ -1814,6 +1863,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7\u03c2",
 		"zu": "Ulwazi lokuphuma lulahlekile",
 		"xh": "Inkcazelo yokuphuma ilahlekile",
+		"st": "Tlhahisoleseding ya ho tswa e lahlehile",
 		"ca": "S'ha perdut la informació del tancament de sessió"
 	},
 	"descr_LOGOUTINFOLOST": {
@@ -1852,6 +1902,7 @@
 		"el": "\u039f\u03b9 \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03c3\u03c7\u03b5\u03c4\u03b9\u03ba\u03ac \u03bc\u03b5 \u03c4\u03b7\u03bd \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7 \u03ad\u03c7\u03bf\u03c5\u03bd \u03c7\u03b1\u03b8\u03b5\u03af. \u0398\u03b1 \u03c0\u03c1\u03ad\u03c0\u03b5\u03b9 \u03bd\u03b1 \u03b5\u03c0\u03b9\u03c3\u03c4\u03c1\u03ad\u03c8\u03b5\u03c4\u03b5 \u03c3\u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 \u03b1\u03c0\u03cc \u03c4\u03b7\u03bd \u03bf\u03c0\u03bf\u03af\u03b1 \u03c0\u03c1\u03bf\u03c3\u03c0\u03b1\u03b8\u03b5\u03af\u03c4\u03b5 \u03bd\u03b1 \u03b1\u03c0\u03bf\u03c3\u03c5\u03bd\u03b4\u03b5\u03b8\u03b5\u03af\u03c4\u03b5 \u03ba\u03b1\u03b9 \u03bd\u03b1 \u03c0\u03c1\u03bf\u03c3\u03c0\u03b1\u03b8\u03ae\u03c3\u03b5\u03c4\u03b5 \u03b5\u03ba \u03bd\u03ad\u03bf\u03c5. \u0391\u03c5\u03c4\u03cc \u03c4\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03bc\u03c0\u03bf\u03c1\u03b5\u03af \u03bd\u03b1 \u03c0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03b1\u03c3\u03c4\u03b5\u03af \u03b1\u03bd \u03b7 \u03b9\u03c3\u03c7\u03cd\u03c2 \u03c4\u03c9\u03bd \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03b9\u03ce\u03bd \u03c3\u03c7\u03b5\u03c4\u03b9\u03ba\u03ac \u03bc\u03b5 \u03c4\u03b7\u03bd \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7 \u03ad\u03c7\u03b5\u03b9 \u03bb\u03ae\u03be\u03b5\u03b9. \u039f\u03b9 \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03b1\u03c5\u03c4\u03ad\u03c2 \u03b1\u03c0\u03bf\u03b8\u03b7\u03ba\u03b5\u03cd\u03b5\u03c4\u03b1\u03b9 \u03b3\u03b9\u03b1 \u03c0\u03b5\u03c1\u03b9\u03bf\u03c1\u03b9\u03c3\u03bc\u03ad\u03bd\u03bf \u03c7\u03c1\u03bf\u03bd\u03b9\u03ba\u03cc \u03b4\u03b9\u03ac\u03c3\u03c4\u03b7\u03bc\u03b1 - \u03c3\u03c5\u03bd\u03ae\u03b8\u03c9\u03c2 \u03bc\u03b5\u03c1\u03b9\u03ba\u03ce\u03bd \u03c9\u03c1\u03ce\u03bd. \u0391\u03c5\u03c4\u03cc \u03c3\u03c5\u03bd\u03ae\u03b8\u03c9\u03c2 \u03b5\u03c0\u03b1\u03c1\u03ba\u03b5\u03af \u03b3\u03b9\u03b1 \u03bc\u03b9\u03b1 \u03ba\u03b1\u03bd\u03bf\u03bd\u03b9\u03ba\u03ae \u03bb\u03b5\u03b9\u03c4\u03bf\u03c5\u03c1\u03b3\u03af\u03b1 \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7\u03c2, \u03c3\u03c5\u03bd\u03b5\u03c0\u03ce\u03c2 \u03c3\u03c4\u03b7\u03bd \u03c0\u03c1\u03bf\u03ba\u03b5\u03b9\u03bc\u03ad\u03bd\u03b7 \u03c0\u03b5\u03c1\u03af\u03c0\u03c4\u03c9\u03c3\u03b7 \u03c4\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03bc\u03c0\u03bf\u03c1\u03b5\u03af \u03bd\u03b1 \u03c5\u03c0\u03bf\u03b4\u03b5\u03b9\u03ba\u03bd\u03cd\u03b5\u03b9 \u03ba\u03ac\u03c0\u03bf\u03b9\u03bf \u03ac\u03bb\u03bb\u03bf \u03b8\u03ad\u03bc\u03b1 \u03bc\u03b5 \u03c4\u03b9\u03c2 \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03b9\u03c2. \u0395\u03ac\u03bd \u03c4\u03bf \u03c0\u03c1\u03cc\u03b2\u03bb\u03b7\u03bc\u03b1 \u03c0\u03b1\u03c1\u03b1\u03bc\u03ad\u03bd\u03b5\u03b9, \u03b5\u03c0\u03b9\u03ba\u03bf\u03b9\u03bd\u03c9\u03bd\u03ae\u03c3\u03c4\u03b5 \u03bc\u03b5 \u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd.",
 		"zu": "Ulwazi olumayelana nomsebenzi wokuphuma wamanje lulahlekile. Kufanele ubuyele kusevisi obuzama ukuphuma kuyo futhi uzame ukuphuma futhi. Leli phutha lingabangelwa ukuphelelwa isikhathi kolwazi lokuphuma. Ulwazi lokuphuma lugcinwa isikhathi esilinganiselwe - ngokuvamile amahora ambalwa. Lokhu kude kunanoma yimuphi umsebenzi wokuphuma ovamile, ngakho leli phutha lingase libonise elinye iphutha ngomiso. Uma inkinga iphikelela, thinta umhlinzeki wakho wesevisi.",
 		"xh": "Inkcazelo malunga nomsebenzi wokuphuma wangoku ilahlekile. Ufanele ubuyele kwinkonzo ubuzama ukuphuma kuyo uzame ukuphuma kwakhona. Le mpazamo inokubangelwa kukuphelelwa kwenkcazelo yokuphuma. Inkcazelo yokuphuma igcinwa ixesha elithile - ngokuqhelekileyo iiyure eziliqela. Oku kuthatha ixesha elide kunawo nawuphi na umsebenzi wokuphuma ofanele ulithathe, ngoko le mpazamo isenokubonisa enye impazamo ngolungiselelo. Ukuba ingxaki iyaqhubeka, qhagamshela umboneleli wenkonzo wakho.",
+		"st": "Tlhahisoleseding e mabapi le tshebetos ya ho tswa ya hajwale e lahlehile. O tlameha ho kgutlela tshebeletsong eo o neng o leka ho tswa ho yona le ho leka ho tswa hape. Phoso ena e ka bakwa ke phelo nako ya tlhahisoleseding ya ho tswa. Tlhahisoleseding ya ho tswa e bolokwa nako e lekantsweng - ka tlwaelo ke palo ya dihora. Sena se setelele ho feta nako eo tshebetso efe kapa efe ya tlwaelo ya ho tswa e tlamehang ho e nka, ka hona phoso ena e ka nna ya bontsha phoso e nngwe ka tlhophiso esele. Haeba bothata bo phehella, ikopanye le mofani wa tshebeletso wa hao.",
 		"ca": "S'ha perdut la informació sobre el tancament de sessió actual. Heu de tornar al servei del qual esteu intentant desconnectar i provar de sortir de nou. Aquest error pot ser causat per l’expiració de la informació del tancament de sessió. La informació de tancament de sessió s’emmagatzema per un període limitat de temps, normalment un nombre d'hores. Això és més llarg del que hauria de tenir qualsevol operació de tancament de sessió normal, de manera que aquest error pot indicar algun altre error amb la configuració. Si el problema continua, poseu-vos en contacte amb el vostre proveïdor de serveis."
 	},
 	"title_UNHANDLEDEXCEPTION": {
@@ -1890,6 +1941,7 @@
 		"el": "\u0391\u03bd\u03b5\u03c0\u03af\u03bb\u03c5\u03c4\u03b7 \u03b5\u03be\u03b1\u03af\u03c1\u03b5\u03c3\u03b7",
 		"xh": "Isinxaxhi esingasingathwanga",
 		"zu": "Okuhlukile okungasingathiwe",
+		"st": "Mokgelo o sa rarollwang",
 		"ca": "Excepció no controlada"
 	},
 	"descr_UNHANDLEDEXCEPTION": {
@@ -1928,6 +1980,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03b1\u03bd\u03b5\u03c0\u03af\u03bb\u03c5\u03c4\u03b7 \u03b5\u03be\u03b1\u03af\u03c1\u03b5\u03c3\u03b7",
 		"xh": "Isinxaxhi esingasingathwanga silahliwe.",
 		"zu": "Okuhlukile okungasingathiwe kulahliwe.",
+		"st": "Kgeloho e sa rarollwang e lahlilwe.",
 		"ca": "S'ha enviat una excepció no controlada."
 	},
 	"title_NOTFOUND": {
@@ -1966,6 +2019,7 @@
 		"el": "\u0397 \u03c3\u03b5\u03bb\u03af\u03b4\u03b1 \u03b4\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b5",
 		"xh": "Ikhasi alifunyenwanga",
 		"zu": "Ikhasi alitholakali",
+		"st": "Leqephe ha le a fumanwa",
 		"ca": "Pàgina no trobada"
 	},
 	"descr_NOTFOUND": {
@@ -2004,6 +2058,7 @@
 		"el": "\u0397 \u03c3\u03b5\u03bb\u03af\u03b4\u03b1 \u03c0\u03bf\u03c5 \u03b6\u03b7\u03c4\u03ae\u03c3\u03b1\u03c4\u03b5 \u03c3\u03c4\u03b7 \u03b4\u03b9\u03b5\u03cd\u03b8\u03c5\u03bd\u03c3\u03b7 %URL% \u03b4\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b5.",
 		"zu": "Ikhasi elinikeziwe alitholakalanga. I-URL ibithi: %URL%",
 		"xh": "Ikhasi elinikelweyo alifunyenwanga. I-URL ngu: %URL%",
+		"st": "Leqephe le fanweng ha le a fumanwa. URL e bile: %URL%",
 		"ca": "No s’ha trobat la pàgina indicada. L’URL és: %URL%"
 	},
 	"title_NOTFOUNDREASON": {
@@ -2042,6 +2097,7 @@
 		"el": "\u0397 \u03c3\u03b5\u03bb\u03af\u03b4\u03b1 \u03b4\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b5",
 		"xh": "Ikhasi alifunyenwanga",
 		"zu": "Ikhasi alitholakali",
+		"st": "Leqephe ha le a fumanwa",
 		"ca": "Pàgina no trobada"
 	},
 	"descr_NOTFOUNDREASON": {
@@ -2080,6 +2136,7 @@
 		"el": "\u0397 \u03c3\u03b5\u03bb\u03af\u03b4\u03b1 \u03c0\u03bf\u03c5 \u03b6\u03b7\u03c4\u03ae\u03c3\u03b1\u03c4\u03b5 \u03c3\u03c4\u03b7 \u03b4\u03b9\u03b5\u03cd\u03b8\u03c5\u03bd\u03c3\u03b7 %URL% \u03b4\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b5: %REASON%",
 		"zu": "Ikhasi elinikeziwe alitholakalanga. Isizathu besithi: %REASON%  I-URL ibithi: %URL%",
 		"xh": "Ikhasi elinikelweyo alifunyenwanga. Isizathu sesi: %REASON%  I-URL ngu: %URL%",
+		"st": "Leqephe le fanweng ha le a fumanwa. Lebaka e bile: %LEBAKA%  URL e bile: %URL%",
 		"ca": "No s’ha trobat la pàgina indicada. El motiu és: %REASON%. L’URL és: %URL%"
 	},
 	"title_BADREQUEST": {
@@ -2118,6 +2175,7 @@
 		"el": "\u0395\u03c3\u03c6\u03b1\u03bb\u03bc\u03ad\u03bd\u03bf \u03b1\u03af\u03c4\u03b7\u03bc\u03b1",
 		"zu": "Kutholwe umlayezo ongalungile",
 		"xh": "Kufunyenwe isicelo esibi",
+		"st": "Kopo e mpe e amohetswe",
 		"ca": "S'ha rebut una petició incorrecta"
 	},
 	"descr_BADREQUEST": {
@@ -2155,6 +2213,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03b5\u03c0\u03b5\u03be\u03b5\u03c1\u03b3\u03b1\u03c3\u03af\u03b1 \u03c4\u03bf\u03c5 \u03b1\u03b9\u03c4\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2: %REASON%",
 		"zu": "Kukhona iphutha kusicelo saleli khasi. Isizathu besithi: %REASON%",
 		"xh": "Kukho impazamo kwisicelo kweli khasi. Isizathu sesi: %REASON%",
+		"st": "Ho na le phoso kopong e leqepheng lena. Lebaka e bile: %REASON%",
 		"ca": "Hi ha un error en la sol·licitud d’aquesta pàgina. El motiu és: %REASON%"
 	},
 	"title_WRONGUSERPASS": {
@@ -2193,6 +2252,7 @@
 		"el": "\u03a4\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03ae \u03bf \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2 \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2 \u03b5\u03af\u03bd\u03b1\u03b9 \u03bb\u03ac\u03b8\u03bf\u03c2",
 		"zu": "Igama lomsebenzisi elingalungile noma iphasiwedi",
 		"xh": "Igama lomsebenzisi okanye iphaswedi engachanekanga",
+		"st": "Lebitso la mosebedisi kapa phasewete e fosahetseng",
 		"ca": "Nom d'usuari o contrasenya incorrecta"
 	},
 	"descr_WRONGUSERPASS": {
@@ -2230,6 +2290,7 @@
 		"el": "\u039f \u03c3\u03c5\u03bd\u03b4\u03c5\u03b1\u03c3\u03bc\u03cc\u03c2 \u03bf\u03bd\u03cc\u03bc\u03b1\u03c4\u03bf\u03c2 \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03ba\u03b1\u03b9 \u03ba\u03c9\u03b4\u03b9\u03ba\u03bf\u03cd \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2 \u03b4\u03b5\u03bd \u03b5\u03af\u03bd\u03b1\u03b9 \u03c3\u03c9\u03c3\u03c4\u03cc\u03c2. \u03a0\u03b1\u03c1\u03b1\u03ba\u03b1\u03bb\u03ce \u03b5\u03bb\u03ad\u03b3\u03be\u03c4\u03b5 \u03c4\u03b7\u03bd \u03bf\u03c1\u03b8\u03cc\u03c4\u03b7\u03c4\u03b1 \u03c4\u03c9\u03bd \u03c3\u03c4\u03bf\u03b9\u03c7\u03b5\u03af\u03c9\u03bd \u03c3\u03b1\u03c2 \u03ba\u03b1\u03b9 \u03c0\u03c1\u03bf\u03c3\u03c0\u03b1\u03b8\u03ae\u03c3\u03c4\u03b5 \u03be\u03b1\u03bd\u03ac.",
 		"zu": "Kungenzeka ukuthi akekho umsebenzisi onegama lomsebenzisi otholiwe, noma iphasiwedi oyinikezile ayilungile. Sicela uhlole igama lomsebenzisi bese uzame futhi.",
 		"xh": "Kusenokwenzeka akukho msebenzisi unegama lomsebenzisi elinikelweyo ofunyenweyo, okanye iphaswedi oyinikeleyo ayichanekanga. Nceda ujonge igama lomsebenzisi uzame kwakhona.",
+		"st": "Ekaba mosebedisi wa lebitso la mosebedisi le fanweng ha a fumanwe, kapa phasewete eo o e fananeng e fosahetse. Ka kopo hlahloba lebitso la mosebedisi la hao, ebe o leka hape.",
 		"ca": "No s’ha pogut trobar cap usuari amb el nom d’usuari donat, o la contrasenya no és correcta. Comproveu el nom d’usuari i torneu-ho a provar."
 	},
 	"title_RESPONSESTATUSNOSUCCESS": {
@@ -2268,6 +2329,7 @@
 		"el": "\u039b\u03ae\u03c8\u03b7 \u03ba\u03c9\u03b4\u03b9\u03ba\u03bf\u03cd \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1\u03c4\u03bf\u03c2 \u03b1\u03c0\u03cc \u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2",
 		"zu": "Iphutha litholwe ukusuka Kumhlinzeki Kamazisi",
 		"xh": "Impazamo efunyenwe kuMboneleli Wesazisi",
+		"st": "Phoso e amohetswe ho tswa ho Mofani wa Boitsebiso",
 		"ca": "S'ha rebut un error del proveïdor d’identitats"
 	},
 	"descr_RESPONSESTATUSNOSUCCESS": {
@@ -2306,6 +2368,7 @@
 		"el": "\u039f \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2 \u03ba\u03b1\u03c4\u03ac\u03c3\u03c4\u03b1\u03c3\u03b7\u03c2 \u03c0\u03bf\u03c5 \u03c0\u03b5\u03c1\u03b9\u03ad\u03c7\u03b5\u03b9 \u03b7 \u03b1\u03c0\u03ac\u03bd\u03c4\u03b7\u03c3\u03b7 \u03c4\u03bf\u03c5 \u03c0\u03b1\u03c1\u03cc\u03c7\u03bf\u03c5 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 \u03c5\u03c0\u03bf\u03b4\u03b5\u03b9\u03ba\u03bd\u03cd\u03b5\u03b9 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1.",
 		"xh": "Umboneleli Wesazisi uphendule ngempazamo. (Ikhowudi yobume kwiMpendulo ye-SAML ayiphumelelanga)",
 		"zu": "Umhlinzeki Womazisi uphendule ngephutha. (Ikhodi yesimo Sempendulo ye-SAML ayizange iphumelele)",
+		"st": "Mofani wa Boitsebiso o arabetse ka phoso. (Khoutu ya boemo Karabelong ya SAML ha e a atleha)",
 		"ca": "El proveïdor d’identitat ha respost amb un error (el codi d'estat de la resposta SAML no ha estat exitós)."
 	},
 	"title_NOCERT": {
@@ -2342,6 +2405,7 @@
 		"el": "\u0394\u03b5\u03bd \u03c5\u03c0\u03ac\u03c1\u03c7\u03b5\u03b9 \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03cc",
 		"xh": "Akukho satifikethi",
 		"zu": "Asikho isitifiketi",
+		"st": "Ha ho setifikeiti",
 		"ca": "Sense certificat"
 	},
 	"descr_NOCERT": {
@@ -2377,6 +2441,7 @@
 		"el": "\u0397 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7 \u03b1\u03c0\u03ad\u03c4\u03c5\u03c7\u03b5: \u03a4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 \u03b9\u03c3\u03c4\u03bf\u03cd \u03c0\u03bf\u03c5 \u03c7\u03c1\u03b7\u03c3\u03b9\u03bc\u03bf\u03c0\u03bf\u03b9\u03b5\u03af\u03c4\u03b5 \u03b4\u03b5\u03bd \u03ad\u03c3\u03c4\u03b5\u03b9\u03bb\u03b5 \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03cc.",
 		"zu": "Ukuqinisekisa kuhlulekile: isiphequluli sakho asizange sithumele noma yisiphi isitifiketi",
 		"xh": "Ungqinisiso lusilele: ibhrawuza yakho ayithumelanga nasiphi na isatifikethi",
+		"st": "Netefatso e hlolehile: sebadi sa hao ha se a romela setifikeiti sa letho",
 		"ca": "Ha fallat l’autenticació: el navegador no ha enviat cap certificat"
 	},
 	"title_INVALIDCERT": {
@@ -2413,6 +2478,7 @@
 		"el": "\u039c\u03b7 \u03ad\u03b3\u03ba\u03c5\u03c1\u03bf \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03cc",
 		"xh": "Isatifikethi esingasebenziyo",
 		"zu": "Isifiketi esingalungile",
+		"st": "Setifikeiti se sa nepahalang",
 		"ca": "Certificat no vàlid"
 	},
 	"descr_INVALIDCERT": {
@@ -2448,6 +2514,7 @@
 		"el": "\u0397 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7 \u03b1\u03c0\u03ad\u03c4\u03c5\u03c7\u03b5: \u03a4\u03bf \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03cc \u03c0\u03bf\u03c5 \u03ad\u03c3\u03c4\u03b5\u03b9\u03bb\u03b5 \u03c4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 \u03b9\u03c3\u03c4\u03bf\u03cd \u03c0\u03bf\u03c5 \u03c7\u03c1\u03b7\u03c3\u03b9\u03bc\u03bf\u03c0\u03bf\u03b9\u03b5\u03af\u03c4\u03b5 \u03b4\u03b5\u03bd \u03b5\u03af\u03bd\u03b1\u03b9 \u03ad\u03b3\u03ba\u03c5\u03c1\u03bf \u03ae \u03b4\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03ae \u03b7 \u03b1\u03bd\u03ac\u03b3\u03bd\u03c9\u03c3\u03ae \u03c4\u03bf\u03c5.",
 		"xh": "Ungqinisiso lusilele: isatifikethi esithunyelwe yibhrawuza yakho asisebenzi okanye asikwazi ukufundwa",
 		"zu": "Ukuqinisekisa kuhlulekile: isitifiketi esithunyelwe isiphequluli sakho asivumelekile noma asikwazi ukufundwa",
+		"st": "Netefatso e hlolehile: setifikeiti seo sebadi sa hao se se rometseng ha se a nepahala kapa ha se balehe",
 		"ca": "Ha fallat l’autenticació: el certificat que el navegador ha enviat no és vàlid o no es pot llegir"
 	},
 	"title_UNKNOWNCERT": {
@@ -2484,6 +2551,7 @@
 		"el": "\u0386\u03b3\u03bd\u03c9\u03c3\u03c4\u03bf \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03cc",
 		"zu": "Isitifiketi esingaziwa",
 		"xh": "Isatifikethi esingaziwayo",
+		"st": "Setifikeiti se sa tsejweng",
 		"ca": "Certificat desconegut"
 	},
 	"descr_UNKNOWNCERT": {
@@ -2519,6 +2587,7 @@
 		"el": "\u0397 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7 \u03b1\u03c0\u03ad\u03c4\u03c5\u03c7\u03b5: \u03a4\u03bf \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03c4\u03b9\u03ba\u03cc \u03c0\u03bf\u03c5 \u03ad\u03c3\u03c4\u03b5\u03b9\u03bb\u03b5 \u03c4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 \u03b9\u03c3\u03c4\u03bf\u03cd \u03c0\u03bf\u03c5 \u03c7\u03c1\u03b7\u03c3\u03b9\u03bc\u03bf\u03c0\u03bf\u03b9\u03b5\u03af\u03c4\u03b5 \u03b4\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03cc \u03bd\u03b1 \u03b1\u03bd\u03b1\u03b3\u03bd\u03c9\u03c1\u03b9\u03c3\u03c4\u03b5\u03af.",
 		"zu": "Ukuqinisekisa kuhlulekile: isitifiketi esithunyelwe isiphequluli sakho asaziwa",
 		"xh": "Ungqinisiso lusilele: isatifikerthi esithunyelwe yibhrawuza yakho asaziwa",
+		"st": "Netefatso e hlolehile: setifikeiti se rometsweng ke sebadi sa hao ha se tsejwe",
 		"ca": "Ha fallat l’autenticació: el certificat que el navegador ha enviat és desconegut"
 	},
 	"title_USERABORTED": {
@@ -2554,6 +2623,7 @@
 		"el": "\u0397 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7 \u03bc\u03b1\u03c4\u03b1\u03b9\u03ce\u03b8\u03b7\u03ba\u03b5",
 		"zu": "Ukuqinisekisa kuyekisiwe",
 		"xh": "Ungqinisiso luyekiwe",
+		"st": "Netefatso e kgaoditswe",
 		"ca": "S'ha avortat l’autenticació"
 	},
 	"descr_USERABORTED": {
@@ -2589,6 +2659,7 @@
 		"el": "\u0397 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7 \u03bc\u03b1\u03c4\u03b1\u03b9\u03ce\u03b8\u03b7\u03ba\u03b5 \u03b1\u03c0\u03cc \u03c4\u03bf\u03bd \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7.",
 		"zu": "Ukuqinisekisa kuyekiswe umsebenzisi",
 		"xh": "Ungqinisiso luyekiswe ngumsebenzisi",
+		"st": "Netefatso e kgaoditswe ke mosebedisi",
 		"ca": "L’usuari ha cancel·lat l’autenticació"
 	},
 	"title_NOSTATE": {
@@ -2624,6 +2695,7 @@
 		"el": "\u0394\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b1\u03bd \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03c3\u03c7\u03b5\u03c4\u03b9\u03ba\u03ac \u03bc\u03b5 \u03c4\u03b7\u03bd \u03ba\u03b1\u03c4\u03ac\u03c3\u03c4\u03b1\u03c3\u03b7 \u03c4\u03bf\u03c5 \u03b1\u03b9\u03c4\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2",
 		"xh": "Inkcazelo yobume ilahlekile",
 		"zu": "Ulwazi lwesifunda lulahlekile",
+		"st": "Tlhahisoleseding ya provense e lahlehile",
 		"ca": "Informació d'estat perduda"
 	},
 	"descr_NOSTATE": {
@@ -2659,6 +2731,7 @@
 		"el": "\u0394\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03cc \u03bd\u03b1 \u03b5\u03be\u03c5\u03c0\u03b7\u03c1\u03b5\u03c4\u03b7\u03b8\u03b5\u03af \u03c4\u03bf \u03b1\u03af\u03c4\u03b7\u03bc\u03ac \u03c3\u03b1\u03c2 \u03ba\u03b1\u03b8\u03ce\u03c2 \u03b4\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b1\u03bd \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03c3\u03c7\u03b5\u03c4\u03b9\u03ba\u03ac \u03bc\u03b5 \u03c4\u03b7\u03bd \u03ba\u03b1\u03c4\u03ac\u03c3\u03c4\u03b1\u03c3\u03ae \u03c4\u03bf\u03c5",
 		"xh": "Inkcazelo yobume ilahlekile, yaye akukho ndlela yokuqalisa isicelo",
 		"zu": "Ulwazi lwesifunda lulahlekile, futhi ayikho indlela yokuqala kabusha isicelo",
+		"st": "Tlhahisoleeding ya porofensi e lahlehile, mmeha ho tsela ya ho qala kopo botjha",
 		"ca": "Infomració d'estat perduda, i no hi ha cap manera de reiniciar la sol·licitud"
 	},
 	"title_METADATANOTFOUND": {
@@ -2694,6 +2767,7 @@
 		"el": "\u0394\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b1\u03bd \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03b1",
 		"zu": "Imethadatha ayitholakalanga",
 		"xh": "Imetadata ayifunyenwanga",
+		"st": "Metadata ha e a fumanwa",
 		"ca": "Metadades no trobades"
 	},
 	"descr_METADATANOTFOUND": {
@@ -2729,6 +2803,7 @@
 		"el": "\u0394\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03cc \u03bd\u03b1 \u03b2\u03c1\u03b5\u03b8\u03bf\u03cd\u03bd \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03b1 \u03b3\u03b9\u03b1 \u03c4\u03b7\u03bd \u03bf\u03bd\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1 %ENTITYID%",
 		"xh": "Ayikwazi ukufumana iimpawu-ngcaciso zefayile ze-%ENTITYID%",
 		"zu": "Ayikwazi ukuthola imethadatha yokuthi %ENTITYID%",
+		"st": "Ha e kgone ho fumana metadata bakeng sa %ID YA SETHEO%",
 		"ca": "No es poden localitzar les metadades per a %ENTITYID%"
 	},
 	"title_AUTHSOURCEERROR": {
@@ -2764,6 +2839,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03bc\u03b5 \u03c4\u03b7\u03bd \u03c0\u03b7\u03b3\u03ae \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7\u03c2",
 		"zu": "Iphutha lomthombo wokuqinisekisa",
 		"xh": "Impazamo yomthombo wongqinisiso",
+		"st": "Phoso ya netefatso ya mohlodi",
 		"ca": "Error en l’autenticació d'origen"
 	},
 	"descr_AUTHSOURCEERROR": {
@@ -2799,6 +2875,7 @@
 		"el": "\u03a0\u03b1\u03c1\u03bf\u03c5\u03c3\u03b9\u03ac\u03c3\u03c4\u03b7\u03ba\u03b5 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03ba\u03b1\u03c4\u03ac \u03c4\u03b7\u03bd \u03b5\u03c0\u03b9\u03ba\u03bf\u03b9\u03bd\u03c9\u03bd\u03af\u03b1 \u03bc\u03b5 \u03c4\u03b7\u03bd \u03c0\u03b7\u03b3\u03ae \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7\u03c2 %AUTHSOURCE%: %REASON%",
 		"zu": "Iphutha lokuqinisekisa kumthombo othi %AUTHSOURCE%. Isizathu besithi: %REASON%",
 		"xh": "Impazamo yongqinisiso kumthombo %AUTHSOURCE%. Isizathu sesi: %REASON%",
+		"st": "Phoso ya tiiso mohloding %AUTHSOURCE%. Lebaka e bile: %REASON%",
 		"ca": "Error en l’autenticació d'origen %AUTHSOURCE%. El motiu és: %REASON%"
 	},
 	"title_MEMCACHEDOWN": {
@@ -2806,6 +2883,7 @@
 		"el": "\u0394\u03b5\u03bd \u03b5\u03af\u03bd\u03b1\u03b9 \u03b4\u03c5\u03bd\u03b1\u03c4\u03ae \u03b7 \u03b1\u03bd\u03ac\u03ba\u03c4\u03b7\u03c3\u03b7 \u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03c9\u03bd \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1\u03c2",
 		"xh": "Ayikwazi ukubuyisela ingcombolo yeseshoni",
 		"zu": "Ayikwazi ukubuyisela idatha yeseshini",
+		"st": "Ha e a kgona ho fumana datha ya seshene",
 		"ca": "No es poden recuperar les dades de la sessió"
 	},
 	"descr_MEMCACHEDOWN": {
@@ -2813,6 +2891,7 @@
 		"el": "\u0394\u03b5\u03bd \u03b5\u03af\u03bd\u03b1\u03b9 \u03b4\u03c5\u03bd\u03b1\u03c4\u03ae \u03b7 \u03b1\u03bd\u03ac\u03ba\u03c4\u03b7\u03c3\u03b7 \u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03c9\u03bd \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1\u03c2 \u03bb\u03cc\u03b3\u03c9 \u03c4\u03b5\u03c7\u03bd\u03b9\u03ba\u03ce\u03bd \u03b4\u03c5\u03c3\u03ba\u03bf\u03bb\u03b9\u03ce\u03bd. \u03a0\u03b1\u03c1\u03b1\u03ba\u03b1\u03bb\u03bf\u03cd\u03bc\u03b5 \u03b4\u03bf\u03ba\u03b9\u03bc\u03ac\u03c3\u03c4\u03b5 \u03be\u03b1\u03bd\u03ac \u03b1\u03c1\u03b3\u03cc\u03c4\u03b5\u03c1\u03b1",
 		"zu": "Idatha yeseshini yakho ayikwazi ukubuyiswa njengamanje ngenxa yezinkinga zobuchwepheshe. Sicela uzame futhi emizuzwini embalwa.",
 		"xh": "Ingcombolo yeseshoni yakho ayikwazi ukubuyiselwa okwangoku ngenxa yeengxaki zobugcisa. Nceda uzame kwakhona kwimizuzu embalwa.",
+		"st": "Datha ya seshene ya hao ha e kgone ho fumanwa hona jwale ka lebaka la mathata a sethekeniki. Ka kopo leka hape kamora metsotso e mmalwa.",
 		"ca": "Les vostres dades de sessió no es poden recuperar ara mateix a causa de dificultats tècniques. Torneu-ho a provar d'aquí a uns minuts."
 	}
 }

--- a/dictionaries/general.translation.json
+++ b/dictionaries/general.translation.json
@@ -36,6 +36,7 @@
     "el": "\u039d\u03b1\u03af",
     "zu": "Yebo",
     "xh": "Ewe",
+    "st": "E",
     "ca": "Sí"
   },
   "no": {
@@ -75,6 +76,7 @@
     "el": "\u038c\u03c7\u03b9",
     "xh": "Hayi",
     "zu": "Cha",
+    "st": "Tjhe",
     "ca": "No"
   },
   "remember": {
@@ -114,6 +116,7 @@
     "el": "\u039d\u03b1 \u03b8\u03c5\u03bc\u03ac\u03c3\u03b1\u03b9 \u03c4\u03b7\u03bd \u03b5\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae \u03bc\u03bf\u03c5",
     "zu": "Khumbula",
     "xh": "Khumbula",
+    "st": "Hopola",
     "ca": "Recorda"
   },
   "yes_continue": {
@@ -153,6 +156,7 @@
     "el": "\u0391\u03c0\u03bf\u03b4\u03bf\u03c7\u03ae",
     "xh": "Ewe, qhubeka",
     "zu": "Yebo, qhubeka",
+    "st": "E, tswela pele",
     "ca": "Sí, continua"
   },
   "no_cancel": {
@@ -192,6 +196,7 @@
     "el": "\u0391\u03c0\u03cc\u03c1\u03c1\u03b9\u03c8\u03b7",
     "xh": "Hayi, rhoxisa",
     "zu": "Cha, khansela",
+    "st": "Tjhe, hlakola",
     "ca": "No, cancel·la"
   },
   "service_provider": {
@@ -231,6 +236,7 @@
     "el": "\u03a0\u03ac\u03c1\u03bf\u03c7\u03bf\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1\u03c2",
     "xh": "Umboneleli Wenkonzo",
     "zu": "Umhlinzeki Wesevisi",
+    "st": "Mofani wa Tshebeletso",
     "ca": "Proveïdor de servei"
   }
 }

--- a/dictionaries/login.translation.json
+++ b/dictionaries/login.translation.json
@@ -36,6 +36,7 @@
 		"el": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1",
 		"zu": "Iphutha",
 		"xh": "Impazamo",
+		"st": "Phoso",
 		"ca": "Error"
 	},
 	"user_pass_header": {
@@ -75,6 +76,7 @@
 		"af": "Voer jou gebruikersnaam en wagwoord in",
 		"el": "\u0395\u03b9\u03c3\u03ac\u03b3\u03b5\u03c4\u03b5 \u03cc\u03bd\u03bf\u03bc\u03b1 \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03ba\u03b1\u03b9 \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2",
 		"zu": "Faka igama lakho lomsebenzisi nephasiwedi",
+		"st": "Kenya lebitso la mosebedisi le phasewete",
 		"ca": "Introduïu el vostre nom d’usuari i contrasenya"
 	},
 	"user_pass_text": {
@@ -114,6 +116,7 @@
 		"el": "\u039c\u03b9\u03b1 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 \u03ad\u03c7\u03b5\u03b9 \u03b6\u03b7\u03c4\u03ae\u03c3\u03b5\u03b9 \u03c4\u03b7\u03bd \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03ae \u03c3\u03b1\u03c2. \u03a0\u03b1\u03c1\u03b1\u03ba\u03b1\u03bb\u03ce \u03b5\u03b9\u03c3\u03ac\u03b3\u03b5\u03c4\u03b5 \u03c4\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03ba\u03b1\u03b9 \u03c4\u03bf\u03bd \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03ae\u03c2 \u03c3\u03b1\u03c2 \u03c3\u03c4\u03b7\u03bd \u03c0\u03b1\u03c1\u03b1\u03ba\u03ac\u03c4\u03c9 \u03c6\u03cc\u03c1\u03bc\u03b1.",
 		"zu": "Isevisi icele ukuthi uziqinisekise. Sicela ufake igama lakho lomsebenzisi nephasiwedi ngohlobo olungezansi.",
 		"xh": "Inkonzo icele ukuba uzingqinisise. Nceda ungenise igama lomsebenzisi nephaswedi yakho kwifomu ngezantsi.",
+		"st": "Tshebeletso  e kopile hore o inetefatse. Ka kopo kenya lebitso la mosebedisi le phasewete ya hao foromong e ka tlase mona.",
 		"ca": "Un servei us ha demanat autenticar-vos. Introduïu el vostre nom d’usuari i contrasenya en el formulari següent."
 	},
 	"login_button": {
@@ -154,6 +157,7 @@
 		"af": "Meld aan",
 		"el": "\u0395\u03af\u03c3\u03bf\u03b4\u03bf\u03c2",
 		"zu": "Ngena",
+		"st": "Ho kena",
 		"ca": "Inicia la sessió"
 	},
 	"processing": {
@@ -162,6 +166,7 @@
 		"zh-tw": "\u8655\u7406\u4e2d...",
 		"zu": "Iyacubungula...",
 		"xh": "Iyaprosesa...",
+		"st": "E a sebetsa...",
 		"ca": "Processant.."
 	},
 	"username": {
@@ -202,6 +207,7 @@
 		"af": "Gebruikersnaam",
 		"el": "\u038c\u03bd\u03bf\u03bc\u03b1 \u03a7\u03c1\u03ae\u03c3\u03c4\u03b7",
 		"zu": "Igama lomsebenzisi",
+		"st": "Lebitso la mosebedisi",
 		"ca": "Nom d'usuari"
 	},
 	"organization": {
@@ -242,6 +248,7 @@
 		"af": "Organisasie",
 		"el": "\u039f\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03cc\u03c2",
 		"zu": "Inhlangano",
+		"st": "Khampani",
 		"ca": "Organització"
 	},
 	"password": {
@@ -282,6 +289,7 @@
 		"af": "Wagwoord",
 		"el": "\u039a\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2",
 		"zu": "Iphasiwedi",
+		"st": "Phasewete",
 		"ca": "Contrasenya"
 	},
 	"help_header": {
@@ -321,6 +329,7 @@
 		"el": "\u0392\u03bf\u03ae\u03b8\u03b5\u03b9\u03b1! \u0394\u03b5 \u03b8\u03c5\u03bc\u03ac\u03bc\u03b1\u03b9 \u03c4\u03bf\u03bd \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc \u03bc\u03bf\u03c5.",
 		"zu": "Siza! Angiyikhumbuli iphasiwedi yami.",
 		"xh": "Ncedani! Andiyikhumbuli iphaswedi yam.",
+		"st": "Thuso! Ha ke hopole phasewete ya ka.",
 		"ca": "Ajuda! No recordo la meva contrasenya."
 	},
 	"help_text": {
@@ -360,6 +369,7 @@
 		"el": "\u039b\u03c5\u03c0\u03bf\u03cd\u03bc\u03b1\u03c3\u03c4\u03b5. \u03a7\u03c9\u03c1\u03af\u03c2 \u03c4\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03ba\u03b1\u03b9 \u03c4\u03bf\u03bd \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc \u03c3\u03b1\u03c2, \u03b4\u03b5\u03bd \u03bc\u03c0\u03bf\u03c1\u03b5\u03af\u03c4\u03b5 \u03bd\u03b1 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03b9\u03b7\u03b8\u03b5\u03af\u03c4\u03b5 \u03ce\u03c3\u03c4\u03b5 \u03bd\u03b1 \u03b1\u03c0\u03bf\u03ba\u03c4\u03ae\u03c3\u03b5\u03c4\u03b5 \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7 \u03c3\u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1. \u03a3\u03c5\u03bc\u03b2\u03bf\u03c5\u03bb\u03b5\u03c5\u03c4\u03b5\u03af\u03c4\u03b5 \u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 \u03b1\u03c1\u03c9\u03b3\u03ae\u03c2 \u03c7\u03c1\u03b7\u03c3\u03c4\u03ce\u03bd \u0028\u0068\u0065\u006c\u0070 \u0064\u0065\u0073\u006b\u0029 \u03c4\u03bf\u03c5 \u03bf\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03bf\u03cd \u03c3\u03b1\u03c2.",
 		"xh": "Ngaphandle kwegama lomsebenzisi nephaswedi yakho awukwazi ukuzingqinisisa ukuze ufumane ufikelelo kwinkonzo. Kusenokuba ukho umntu onokukunceda. Qhagamshelana nedesika yoncedo kumbutho wakho!",
 		"zu": "Ngaphandle kwegama lakho lomsebenzisi nephasiwedi awukwazi ukuziqinisekisa ukuze ufinyelele isevisi. Kungase kube khona ozokusiza. Thinta ideski losizo enhlanganweni yakho!",
+		"st": "Ntle le lebitso l ahao la mosebedisi le phasewete o ke ke wa inetefatsa bakeng sa phihlello ho tshebeletso. Ho ka nna ha ba le motho ya ka o thusang. Ikopanye le ba deske ya thuso khampaning ya heno!",
 		"ca": "Sense el vostre nom d'usuari i contrasenya, no podeu autenticar-vos per accedir al servei. Pot ser que algú us pugui ajudar. Poseu-vos en contacte amb el centre d'atenció a l'usuari"
 	},
 	"error_nopassword": {
@@ -399,6 +409,7 @@
 		"el": "\u039f \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2 \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2 \u03b4\u03b5\u03bd \u03b5\u03c3\u03c4\u03ac\u03bb\u03b7. \u03a0\u03b1\u03c1\u03b1\u03ba\u03b1\u03bb\u03ce, \u03c0\u03c1\u03bf\u03c3\u03c0\u03b1\u03b8\u03ae\u03c3\u03c4\u03b5 \u03be\u03b1\u03bd\u03ac.",
 		"zu": "Uthumele okuthile ekhasini lokungena, kodwa ngasizathu simbe iphasiwedi ayizange ithunyelwe. Sicela uzame futhi.",
 		"xh": "Uthumele into kwikhasi lokungena, kodwa ngesizathu esithile iphaswedi ayithunyelwanga. Nceda uzame kwakhona.",
+		"st": "o Rometse se seng leqepheng la ho kena, empa ka lebaka le sa tsejweng phaewete ha e a romelwa. Ka kopo leka hape.",
 		"ca": "Heu enviat alguna cosa a la pàgina d’inici de sessió, però per alguna raó la contrasenya no s’ha enviat. Torneu-ho a provar."
 	},
 	"error_wrongpassword": {
@@ -439,6 +450,7 @@
 		"af": "Verkeerde gebruikersnaam of wagwoord.",
 		"el": "\u03a4\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7 \u03ae \u03bf \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2 \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2 \u03b5\u03af\u03bd\u03b1\u03b9 \u03bb\u03ac\u03b8\u03bf\u03c2.",
 		"zu": "Igama lomsebenzisi noma iphasiwedi engalungile.",
+		"st": "Lebitso la mosebedisi kapa phasewete e fosahetse.",
 		"ca": "Nom d'usuari o contrasenya incorrecta."
 	},
 	"contact_info": {
@@ -477,6 +489,7 @@
 		"el": "\u03a3\u03c4\u03bf\u03b9\u03c7\u03b5\u03af\u03b1 \u03b5\u03c0\u03b9\u03ba\u03bf\u03b9\u03bd\u03c9\u03bd\u03af\u03b1\u03c2:",
 		"zu": "Ulwazi lokuxhumana:",
 		"xh": "Inkcazelo yoqhagamshelwano:",
+		"st": "Tlhahisoleseding ya boikopanyo:",
 		"ca": "Informació de contacte:"
 	},
 	"select_home_org": {
@@ -515,6 +528,7 @@
 		"el": "\u0395\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03c6\u03bf\u03c1\u03ad\u03b1",
 		"xh": "Khetha umbutho wakho wekhaya",
 		"zu": "Khetha inhlangano yakho yasekhaya",
+		"st": "Kgetha khampani ya lehae ya hao",
 		"ca": "Trieu la vostra organització principal"
 	},
 	"change_home_org_title": {
@@ -553,6 +567,7 @@
 		"el": "\u0391\u03bb\u03bb\u03b1\u03b3\u03ae \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03c6\u03bf\u03c1\u03ad\u03b1",
 		"xh": "Tshintsha umbutho wakho wekhaya",
 		"zu": "Shintsha inhlangano yakho yasekhaya",
+		"st": "Fetola khampani ya lehae ya heno",
 		"ca": "Canvieu la vostra organització principal"
 	},
 	"change_home_org_text": {
@@ -591,6 +606,7 @@
 		"el": "\u0395\u03c0\u03b9\u03bb\u03b5\u03b3\u03bc\u03ad\u03bd\u03bf\u03c2 \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c2 \u03c6\u03bf\u03c1\u03ad\u03b1\u03c2: <b>%HOMEORG%<\/b>.",
 		"zu": "Ukhethe okuthi <b>%HOMEORG%</b> njengenhlangano yakho yasekhaya. Uma lokhu kungalungile ungase ukhethe enye.",
 		"xh": "Uye wakhetha u-<b>%HOMEORG%</b> njengombutho wakho wekhaya. Ukuba oku akuchanekanga usenokukhetha omnye.",
+		"st": "O kgethile <b>%HOMEORG%</b> jwalo ka khampani ya lehae ya heno. Haeba sena se fosahetse o ka kgetha e nngwe hape.",
 		"ca": "Heu triat <b>%HOMEORG%<\/b> com la vostra organització principal. Si això no és correcte, podeu triar-ne una altra."
 	},
 	"change_home_org_button": {
@@ -629,6 +645,7 @@
 		"el": "\u0395\u03c0\u03b9\u03bb\u03bf\u03b3\u03ae \u03bf\u03b9\u03ba\u03b5\u03af\u03bf\u03c5 \u03c6\u03bf\u03c1\u03ad\u03b1",
 		"xh": "Khetha umbutho wekhaya",
 		"zu": "Khetha inhlangano yasekhaya",
+		"st": "Kgetha khampani ya lehae",
 		"ca": "Escull la teva organització principal"
 	},
 	"help_desk_link": {
@@ -667,6 +684,7 @@
 		"el": "\u03a3\u03b5\u03bb\u03af\u03b4\u03b1 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1\u03c2 \u03b1\u03c1\u03c9\u03b3\u03ae\u03c2 \u03c7\u03c1\u03b7\u03c3\u03c4\u03ce\u03bd",
 		"zu": "Ikhasi lasekhaya ledeski losizo",
 		"xh": "Ikhasi lekhaya ledesika yoncedo",
+		"st": "Leqephe la lapeng la ba deske ya thuso",
 		"ca": "Pàgina d'inici del centre d'atenció a l'usuari"
 	},
 	"help_desk_email": {
@@ -705,6 +723,7 @@
 		"el": "\u0391\u03c0\u03bf\u03c3\u03c4\u03bf\u03bb\u03ae \u0065\u006d\u0061\u0069\u006c \u03c3\u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 \u03b1\u03c1\u03c9\u03b3\u03ae\u03c2 \u03c7\u03c1\u03b7\u03c3\u03c4\u03ce\u03bd",
 		"xh": "Thumela i-imeyile kwidesika yoncedo",
 		"zu": "Thumela i-imeyili edeskini losizo",
+		"st": "Romela imeile ho ba deske ya thuso",
 		"ca": "Envia un correu electrònic el centre d'atenció a l'usuari"
 	},
 	"next": {
@@ -743,11 +762,12 @@
 		"af": "Volgende",
 		"el": "\u0395\u03c0\u03cc\u03bc\u03b5\u03bd\u03bf",
 		"zu": "Okulandelayo",
+		"st": "E latelang",
 		"ca": "Següent"
 	},
 	"remember_username": {
 		"es": "Recordar mi nombre de usuario",
-        "de": "Nutzername merken",
+		"de": "Nutzername merken",
 		"hu": "Eml\u00e9kezzen a felhaszn\u00e1l\u00f3nevemre",
 		"ru": "\u0417\u0430\u043f\u043e\u043c\u043d\u0438\u0442\u044c \u043c\u043e\u0451 \u0438\u043c\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f",
 		"zh-tw": "\u8a18\u4f4f\u6211\u7684\u4f7f\u7528\u8005\u540d\u7a31",
@@ -758,12 +778,13 @@
 		"el": "\u039d\u03b1 \u03b8\u03c5\u03bc\u03ac\u03c3\u03b1\u03b9 \u03c4\u03bf \u03cc\u03bd\u03bf\u03bc\u03b1 \u03c7\u03c1\u03ae\u03c3\u03c4\u03b7",
 		"zu": "Khumbula igama lami lomsebenzisi",
 		"xh": "Khumbula igama lomsebenzisi lam",
+		"st": "Hopola lebitso la ka la mosebedisi",
 		"sl": "Zapomni si moje uporabniško ime",
 		"ca": "Recorda el meu nom d’usuari"
 	},
 	"remember_me": {
 		"es": "Recordarme",
-        "de": "Angemeldet bleiben",
+		"de": "Angemeldet bleiben",
 		"hu": "Eml\u00e9kezzen r\u00e1m",
 		"ru": "\u0417\u0430\u043f\u043e\u043c\u043d\u0438\u0442\u044c \u043c\u0435\u043d\u044f",
 		"zh-tw": "\u8a18\u4f4f\u6211",
@@ -775,9 +796,10 @@
 		"xh": "Ndikhumbule",
 		"zu": "Ngikhumbule",
 		"sl": "Zapomni si me",
+		"st": "Nkgopole",
 		"ca": "Recorda'm"
 	},
 	"remember_organization": {
 		"ca": "Recorda la meva organització principal"
-    }
+	}
 }

--- a/dictionaries/logout.translation.json
+++ b/dictionaries/logout.translation.json
@@ -35,6 +35,7 @@
 		"el": "\u0391\u03c0\u03bf\u03c3\u03c5\u03bd\u03b4\u03b5\u03b4\u03b5\u03bc\u03ad\u03bd\u03bf\u03c2/\u03b7",
 		"xh": "Uphumile",
 		"zu": "Uphume ngemvume",
+		"st": "O ntshitswe",
 		"ca": "Desconnectat"
 	},
 	"logged_out_text": {
@@ -73,6 +74,7 @@
 		"el": "\u0388\u03c7\u03b5\u03c4\u03b5 \u03b1\u03c0\u03bf\u03c3\u03c5\u03bd\u03b4\u03b5\u03b8\u03b5\u03af.",
 		"zu": "Usuphumile.",
 		"xh": "Uphumile.",
+		"st": "O ntshitswe.",
 		"ca": "Us heu desconnectat."
 	},
 	"default_link_text": {
@@ -111,6 +113,7 @@
 		"el": "\u0395\u03c0\u03b9\u03c3\u03c4\u03c1\u03bf\u03c6\u03ae \u03c3\u03c4\u03b7\u03bd \u03b1\u03c1\u03c7\u03b9\u03ba\u03ae \u03c3\u03b5\u03bb\u03af\u03b4\u03b1",
 		"xh": "Buyela emva kwikhasi lofakelo le-SimpleSAMLphp",
 		"zu": "Buyela emuva ekhasini lokufaka le-SimpleSAMLphp",
+		"st": "Kgutlela leqepheng la ho instola la SimpleSAMLphp",
 		"ca": "Torneu a la pàgina d’instal·lació de SimpleSAMLphp"
 	},
 	"hold": {
@@ -149,6 +152,7 @@
 		"el": "\u03a3\u03b5 \u03b1\u03bd\u03b1\u03bc\u03bf\u03bd\u03ae",
 		"xh": "Ibanjiwe",
 		"zu": "Imisiwe",
+		"st": "Tshwarisitswe",
 		"ca": "En espera"
 	},
 	"completed": {
@@ -187,6 +191,7 @@
 		"el": "\u039f\u03bb\u03bf\u03ba\u03bb\u03b7\u03c1\u03ce\u03b8\u03b7\u03ba\u03b5",
 		"xh": "Igqityiwe",
 		"zu": "Kuqedile",
+		"st": "E phethilwe",
 		"ca": "Completat"
 	},
 	"progress": {
@@ -225,6 +230,7 @@
 		"el": "\u0393\u03af\u03bd\u03b5\u03c4\u03b1\u03b9 \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7...",
 		"zu": "Iyaphuma...",
 		"xh": "Iyaphuma...",
+		"st": "E a tswa...",
 		"ca": "Tancant la sessió..."
 	},
 	"failed": {
@@ -263,6 +269,7 @@
 		"el": "\u0397 \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7 \u03b1\u03c0\u03ad\u03c4\u03c5\u03c7\u03b5",
 		"xh": "Ukuphuma kusilele",
 		"zu": "Ukuphuma kuhlulekile",
+		"st": "Ho tswa ho hlolehile",
 		"ca": "Ha fallat el tancament de sessió"
 	},
 	"return": {
@@ -301,6 +308,7 @@
 		"el": "\u0395\u03c0\u03b9\u03c3\u03c4\u03c1\u03bf\u03c6\u03ae \u03c3\u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1",
 		"xh": "Buyela kwinkonzo",
 		"zu": "Buyela kusevisi",
+		"st": "E kgutlela tshebeletsong",
 		"ca": "Tornar al servei"
 	},
 	"success": {
@@ -339,6 +347,7 @@
 		"el": "\u0388\u03c7\u03b5\u03c4\u03b5 \u03b1\u03c0\u03bf\u03c3\u03c5\u03bd\u03b4\u03b5\u03b8\u03b5\u03af \u03bc\u03b5 \u03b5\u03c0\u03b9\u03c4\u03c5\u03c7\u03af\u03b1 \u03b1\u03c0\u03cc \u03cc\u03bb\u03b5\u03c2 \u03c4\u03b9\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b5\u03c2 \u03c0\u03bf\u03c5 \u03b1\u03bd\u03b1\u03c6\u03ad\u03c1\u03bf\u03bd\u03c4\u03b1\u03b9 \u03c0\u03b1\u03c1\u03b1\u03c0\u03ac\u03bd\u03c9.",
 		"xh": "Uphume ngokuyimpumelelo kuzo zonke iinkonzo ezidweliswe ngasentla.",
 		"zu": "Uphume ngempumelelo kuwo wonke amasevisi abhalwe ngenhla.",
+		"st": "O tswile ka katleho ditshebeletsong tsohle tse thathamisitsweng ka hodimo mona.",
 		"ca": "Heu sortit correctament de tots els serveis esmentats anteriorment."
 	},
 	"loggedoutfrom": {
@@ -377,6 +386,7 @@
 		"el": "\u0388\u03c7\u03b5\u03c4\u03b5 \u03b1\u03c0\u03bf\u03c3\u03c5\u03bd\u03b4\u03b5\u03b8\u03b5\u03af \u03bc\u03b5 \u03b5\u03c0\u03b9\u03c4\u03c5\u03c7\u03af\u03b1 \u03b1\u03c0\u03cc \u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 %SP%.",
 		"xh": "Ngoku uphume ngokuyimpumelelo kwi-%SP%.",
 		"zu": "Usuphume ngempumelelo kokuthi %SP%.",
+		"st": "Jwale o ntshitswe ka katleho ho %SP%.",
 		"ca": "S’ha tancat la sessió amb èxit de %SP%."
 	},
 	"also_from": {
@@ -415,6 +425,7 @@
 		"el": "\u0395\u03af\u03c3\u03c4\u03b5 \u03b5\u03c0\u03af\u03c3\u03b7\u03c2 \u03c3\u03c5\u03bd\u03b4\u03b5\u03b4\u03b5\u03bc\u03ad\u03bd\u03bf\u03c2 \u03c3\u03b5 \u03b1\u03c5\u03c4\u03ad\u03c2 \u03c4\u03b9\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b5\u03c2:",
 		"zu": "Ungenile futhi kulawa masevisi:",
 		"xh": "Kananjalo ungene kwezi nkonzo:",
+		"st": "Hape o kene ditshebeletsong tsena:",
 		"ca": "També heu iniciat la sessió en aquests serveis:"
 	},
 	"logout_all_question": {
@@ -453,6 +464,7 @@
 		"el": "\u0395\u03c0\u03b9\u03b8\u03c5\u03bc\u03b5\u03af\u03c4\u03b5 \u03bd\u03b1 \u03b1\u03c0\u03bf\u03c3\u03c5\u03bd\u03b4\u03b5\u03b8\u03b5\u03af\u03c4\u03b5 \u03b1\u03c0\u03cc \u03cc\u03bb\u03b5\u03c2 \u03c4\u03b9\u03c2 \u03c0\u03b1\u03c1\u03b1\u03c0\u03ac\u03bd\u03c9 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b5\u03c2\u003b",
 		"xh": "Ngaba ufuna ukuphuma kuzo zonke iinkonzo ezingasentla?",
 		"zu": "Ingabe ufuna ukuphuma kuwo wonke amasevisi angenhla?",
+		"st": "Na o batla ho tswa ditshebeletsong tsohle tse ka hodimo moo?",
 		"ca": "Voleu sortir de tots els serveis següents?"
 	},
 	"logout_all": {
@@ -491,6 +503,7 @@
 		"el": "\u039d\u03b1\u03b9, \u03cc\u03bb\u03b5\u03c2 \u03c4\u03b9\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b5\u03c2",
 		"zu": "Yebo, wonke amasevisi",
 		"xh": "Ewe, zonke iinkonzo",
+		"st": "E, ditshebeletso tsohle",
 		"ca": "Sí, tots els serveis"
 	},
 	"logout_only": {
@@ -529,6 +542,7 @@
 		"el": "\u038c\u03c7\u03b9, \u03bc\u03cc\u03bd\u03bf \u03b1\u03c0\u03cc \u03c4\u03b7\u03bd \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1 %SP%",
 		"zu": "Cha, ku-%SP% kuphela",
 		"xh": "Hayi, kuphela %SP%",
+		"st": "Tjhe, %SP% feela",
 		"ca": "No, només %SP%"
 	},
 	"incapablesps": {
@@ -567,6 +581,7 @@
 		"el": "\u039c\u03af\u03b1 \u03ae \u03c0\u03b5\u03c1\u03b9\u03c3\u03c3\u03cc\u03c4\u03b5\u03c1\u03b5\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b5\u03c2 \u03bc\u03b5 \u03c4\u03b9\u03c2 \u03bf\u03c0\u03bf\u03af\u03b5\u03c2 \u03b5\u03af\u03c3\u03c4\u03b5 \u03c3\u03c5\u03bd\u03b4\u03b5\u03b4\u03b5\u03bc\u03ad\u03bd\u03bf\u03c2\u002f\u03b7 \u03b4\u03b5\u03bd \u03c5\u03c0\u03bf\u03c3\u03c4\u03b7\u03c1\u03af\u03b6\u03bf\u03c5\u03bd \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7\u002e \u0393\u03b9\u03b1 \u03c4\u03bf \u03ba\u03bb\u03b5\u03af\u03c3\u03b9\u03bc\u03bf \u03cc\u03bb\u03c9\u03bd \u03c4\u03c9\u03bd \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03b9\u03ce\u03bd \u03c3\u03b1\u03c2 (sessions), \u03c3\u03b1\u03c2 \u03c3\u03c5\u03bd\u03b9\u03c3\u03c4\u03bf\u03cd\u03bc\u03b5 \u03bd\u03b1 <i>\u03ba\u03bb\u03b5\u03af\u03c3\u03b5\u03c4\u03b5<\/i> \u03c4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03bb\u03bf\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 (web browser).",
 		"zu": "Isevisi eyodwa noma ngaphezulu ongene kuyo <i>ayikusekeli ukuphuma</i>. Ukuze wenze isiqiniseko sokuthi wonke amaseshini akho avaliwe, ukhuthazwa ukuthi <i>uvale isiphequluli sakho sewebhu</i>.",
 		"xh": "Inkonzo enye okanye ezingakumbi ongeneyo kuzo <i>azikuxhasi ukuphuma</i>. Ukuqinisekisa zonke iiseshoni zakho zivaliwe, ukhuthazwa <i>uvale ibhrawuza yewebhu</i>.",
+		"st": "E le nngwe kapa ho feta ya ditshebeletso tseo o keneng ho tsona <i>ha e tshehetse ho tswa</i>. Ho netefatsa hore diseshene tsohle tsa hao di kwetswe, o kgothaletswa ho <i>kwala sebadi sa webo sa hao</i>.",
 		"ca": "Un o més dels serveis que heu accedit a <i>no admeten tancar la sessió<\/i>. Per assegurar-vos que totes les vostres sessions estan tancades, us animem a <i>tancar el vostre navegador web<\/i>."
 	},
 	"no": {
@@ -605,6 +620,7 @@
 		"el": "\u038c\u03c7\u03b9",
 		"xh": "Hayi",
 		"zu": "Cha",
+		"st": "Tjhe",
 		"ca": "No"
 	},
 	"logging_out_from": {
@@ -642,6 +658,7 @@
 		"el": "Γίνεται αποσύνδεση από τις ακόλουθες υπηρεσίες:",
 		"zu": "Iyaphuma kumasevisi alandelayo:",
 		"xh": "Iphuma kwezi nkonzo zilandelayo:",
+		"st": "E tswa ditshebeletsong tse latelang:",
 		"ca": "Sortida dels serveis següents:"
 	},
 	"failedsps": {
@@ -678,6 +695,7 @@
 		"el": "\u0394\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03ae \u03b7 \u03b1\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7 \u03b1\u03c0\u03cc \u03bc\u03af\u03b1 \u03ae \u03c0\u03b5\u03c1\u03b9\u03c3\u03c3\u03cc\u03c4\u03b5\u03c1\u03b5\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b5\u03c2\u002e \u0393\u03b9\u03b1 \u03c4\u03bf \u03ba\u03bb\u03b5\u03af\u03c3\u03b9\u03bc\u03bf \u03cc\u03bb\u03c9\u03bd \u03c4\u03c9\u03bd \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03b9\u03ce\u03bd \u03c3\u03b1\u03c2 (sessions), \u03c3\u03b1\u03c2 \u03c3\u03c5\u03bd\u03b9\u03c3\u03c4\u03bf\u03cd\u03bc\u03b5 \u03bd\u03b1 <i>\u03ba\u03bb\u03b5\u03af\u03c3\u03b5\u03c4\u03b5<\/i> \u03c4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03bb\u03bf\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 (web browser).",
 		"xh": "Awukwazi ukuphuma kwinkonzo enye okanye ezingakumbi. Ukuqinisekisa zonke iiseshoni zakho zivaliwe, ukhuthazwa <i>uvale ibhrawuza yewebhu</i>.",
 		"zu": "Ayikwazi ukuphuma kusevisi eyodwa noma ngaphezulu. Ukuze wenze isiqiniseko sokuthi wonke amaseshini akho avaliwe, ukhuthazwa ukuthi <i>uvale isiphequluli sakho sewebhu</i>.",
+		"st": "Ha e kgone ho tswa tshebeletsong e le nngwe kapa ho feta. Ho netefatsa hore diseshene tsohle tsa hao di kwetswe, o kgothaletswa ho <i>kwala sebadi sa webo sa hao</i>.",
 		"ca": "No es pot tancar la sessió d'un o més serveis. Per assegurar-vos que totes les vostres sessions estan tancades, us animem a <i>tancar el vostre navegador web<\/i>."
 	}
 }

--- a/dictionaries/status.translation.json
+++ b/dictionaries/status.translation.json
@@ -34,6 +34,7 @@
 		"el": "\u0394\u03bf\u03ba\u03b9\u03bc\u03b1\u03c3\u03c4\u03b9\u03ba\u03cc\u03c2 \u03a0\u03b1\u03c1\u03bf\u03c7\u03ad\u03b1\u03c2 \u03a5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd SAML 2.0",
 		"zu": "Isampula Ledemo Ye-SAML 2.0 SP",
 		"xh": "Umzekelo weDemo we-SAML 2.0 SP",
+		"st": "Mohlala wa Pontsho wa SAML 2.0 SP",
 		"ca": "Exemple de demostració SAML 2.0 SP"
 	},
 	"header_shib": {
@@ -71,6 +72,7 @@
 		"el": "\u0394\u03bf\u03ba\u03b9\u03bc\u03b1\u03c3\u03c4\u03b9\u03ba\u03cc\u03c2 \u03a0\u03b1\u03c1\u03bf\u03c7\u03ad\u03b1\u03c2 \u03a5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd Shibboleth",
 		"xh": "Idemo ye-Shibboleth",
 		"zu": "Idemo ye-Shibboleth",
+		"st": "Pontsho ya Shibboleth",
 		"ca": "Exemple de demostració Shibboleth"
 	},
 	"header_diagnostics": {
@@ -108,6 +110,7 @@
 		"el": "\u0394\u03b9\u03b1\u03b3\u03bd\u03c9\u03c3\u03c4\u03b9\u03ba\u03ac SimpleSAMLphp",
 		"zu": "Ukuhlonzwa Kwe-SimpleSAMLphp",
 		"xh": "Uhlalutyo lwe-SimpleSAMLphp",
+		"st": "Dimanollo tsa SimpleSAMLphp",
 		"ca": "Diagnòstic SimpleSAMLphp"
 	},
 	"some_error_occurred": {
@@ -145,6 +148,7 @@
 		"el": "\u03a3\u03c5\u03bd\u03ad\u03b2\u03b7 \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1",
 		"zu": "Kuvele iphutha elithile",
 		"xh": "Kwenzeke impazamo ethile",
+		"st": "Ho na le phoso e etsahetseng",
 		"ca": "S'ha produït un error"
 	},
 	"intro": {
@@ -182,6 +186,7 @@
 		"el": "\u03a7\u03b1\u03af\u03c1\u03b5\u03c4\u03b5, \u03b1\u03c5\u03c4\u03ae \u03b5\u03af\u03bd\u03b1\u03b9 \u03b7 \u03c3\u03b5\u03bb\u03af\u03b4\u03b1 \u03ba\u03b1\u03c4\u03ac\u03c3\u03c4\u03b1\u03c3\u03b7\u03c2 \u03c4\u03bf\u03c5 SimpleSAMLphp. \u0395\u03b4\u03ce \u03bc\u03c0\u03bf\u03c1\u03b5\u03af\u03c4\u03b5 \u03bd\u03b1 \u03b4\u03b5\u03af\u03c4\u03b5 \u03b1\u03bd \u03b7 \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1 \u03c3\u03b1\u03c2 \u0028\u0073\u0065\u0073\u0073\u0069\u006f\u006e\u0029 \u03ad\u03c7\u03b5\u03b9 \u03bb\u03ae\u03be\u03b5\u03b9\u002c \u03c4\u03bf \u03c7\u03c1\u03bf\u03bd\u03b9\u03ba\u03cc \u03b4\u03b9\u03ac\u03c3\u03c4\u03b7\u03bc\u03b1 \u03c0\u03bf\u03c5 \u03b4\u03b9\u03b1\u03c1\u03ba\u03b5\u03af \u03ad\u03c9\u03c2 \u03cc\u03c4\u03bf\u03c5 \u03bb\u03ae\u03be\u03b5\u03b9\u002c \u03ba\u03b1\u03b8\u03ce\u03c2 \u03ba\u03b1\u03b9 \u03cc\u03bb\u03b5\u03c2 \u03c4\u03b9\u03c2 \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03c0\u03bf\u03c5 \u03c3\u03c5\u03bd\u03b4\u03ad\u03bf\u03bd\u03c4\u03b1\u03b9 \u03bc\u03b5 \u03c4\u03b7 \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1 \u03c3\u03b1\u03c2.",
 		"zu": "Sawubona, leli ikhasi lesimo se-SimpleSAMLphp. Lapha ungakwazi ukubona ukuthi iseshini yakho iphelelwe isikhathi yini, ukuthi ihlala isikhathi eside kangakanani ngaphambi kokuthi iphelelwe isikhathi kanye nazo zonke izici ezihambisana neseshini yakho.",
 		"xh": "Molo, eli likhasi lobume be-SimpleSAMLphp. Apha ungabona ukuba ngaba iseshoni yakho iphelelwe lixesha, iza kuhlala ixesha elide kangakanani ngaphambi kokuba iphelelwe nazo zonke iimpawu ezincanyathiselweyo kwiseshoni yakho.",
+		"st": "Dumela, lena ke leqephe la boemo la SimpleSAMLphp. Mona o ka bona hore na seshene ya hao e feletswe ke nako na, hore e nka nako e kae hore e fellwe ke nako le makgabane ohle a hoketsweng sesheneng ya hao.",
 		"ca": "Hola, aquesta és la pàgina d'estat de SimpleSAMLphp. Aquí podeu veure si la vostra sessió ha caducat, quant de temps dura fins que finalitza el temps i tots els atributs que s'adjunten a la vostra sessió."
 	},
 	"validfor": {
@@ -219,6 +224,7 @@
 		"el": "\u0391\u03c0\u03bf\u03bc\u03ad\u03bd\u03bf\u03c5\u03bd %SECONDS% \u03b4\u03b5\u03c5\u03c4\u03b5\u03c1\u03cc\u03bb\u03b5\u03c0\u03c4\u03b1 \u03bc\u03ad\u03c7\u03c1\u03b9 \u03c4\u03b7 \u03bb\u03ae\u03be\u03b7 \u03c4\u03b7\u03c2 \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1\u03c2 \u03c3\u03b1\u03c2.",
 		"xh": "Iseshoni yakho iza kusebenza kangangemizuzu e-%SECONDS% ukususela ngoku.",
 		"zu": "Iseshini yakho isebenza imizuzwana engu-%SECONDS% ukusuka manje.",
+		"st": "Seshene ya hao e na le matla feela bakeng sa metsotswana e %SECONDS% ho tloha hona jwale.",
 		"ca": "La vostra sessió és vàlida durant %SECONDS% segons des d’ara."
 	},
 	"sessionsize": {
@@ -256,6 +262,7 @@
 		"el": "\u039c\u03ad\u03b3\u03b5\u03b8\u03bf\u03c2 \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1\u03c2: %SIZE%",
 		"xh": "Ubukhulu beseshoni: %SIZE%",
 		"zu": "Usayizi weseshini: %SIZE%",
+		"st": "Saese ya seshene: %SIZE%",
 		"ca": "Mida de la sessió: %SIZE%"
 	},
 	"attributes_header": {
@@ -293,6 +300,7 @@
 		"el": "\u03a0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2",
 		"zu": "Izici zakho",
 		"xh": "Iimpawu zakho",
+		"st": "Makgabane a hao",
 		"ca": "Els teus atributs"
 	},
 	"logout": {
@@ -330,6 +338,7 @@
 		"el": "\u0391\u03c0\u03bf\u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7",
 		"xh": "Phuma",
 		"zu": "Phuma",
+		"st": "Ho tswa",
 		"ca": "Tancar sessió"
 	},
 	"subject_header": {
@@ -341,6 +350,7 @@
 		"el": "\u03a5\u03c0\u03bf\u03ba\u03b5\u03af\u03bc\u03b5\u03bd\u03bf (subject) SAML",
 		"zu": "Isihloko Se-SAML",
 		"xh": "Umbandela we-SAML",
+		"st": "Taba ya SAML",
 		"ca": "Assumpte SAML"
 	},
 	"subject_notset": {
@@ -352,6 +362,7 @@
 		"el": "\u03b4\u03b5\u03bd \u03ad\u03c7\u03b5\u03b9 \u03bf\u03c1\u03b9\u03c3\u03c4\u03b5\u03af",
 		"xh": "ayikasetwa",
 		"zu": "akusethiwe",
+		"st": "ha e a setwa",
 		"ca": "no establert"
 	},
 	"subject_format": {
@@ -363,16 +374,19 @@
 		"el": "\u039c\u03bf\u03c1\u03c6\u03ae (format)",
 		"zu": "Ifomethi",
 		"xh": "Ufomatho",
+		"st": "Fomata",
 		"ca": "Format"
 	},
 	"authData_header": {
 		"xh": "Ungqinisiso lweNgcombolo",
 		"zu": "I-AuthData",
+		"st": "AuthData",
 		"ca": "AuthData"
 	},
 	"authData_summary": {
 		"xh": "Cofa ukuze ubone uNgqinisiso lweNgcombolo",
 		"zu": "Qhafaza ukuze ubuke i-AuthData",
+		"st": "Tlelika ho sheba AuthData",
 		"ca": "Feu clic per veure AuthData"
 	}
 }

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -122,6 +122,7 @@ class Language
         'af'    => 'Afrikaans', // Afrikaans
         'zu'    => 'IsiZulu', // Zulu
         'xh'    => 'isiXhosa', // Xhosa
+        'st'    => 'Sesotho', // Sesotho
     ];
 
     /**

--- a/locales/st/LC_MESSAGES/attributes.po
+++ b/locales/st/LC_MESSAGES/attributes.po
@@ -1,0 +1,1863 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"PO-Revision-Date: 2019-12-12 15:50+0200\n
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "aRecord"
+msgstr "aRecord"
+
+msgid "urn:mace:dir:attribute-def:aRecord"
+msgstr "urn:mace:dir:attribute-def:aRecord"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.26"
+msgstr "urn:oid:0.9.2342.19200300.100.1.26"
+
+msgid "aliasedEntryName"
+msgstr "aliasedEntryName"
+
+msgid "urn:mace:dir:attribute-def:aliasedEntryName"
+msgstr "urn:mace:dir:attribute-def:aliasedEntryName"
+
+msgid "urn:oid:2.5.4.1"
+msgstr "urn:oid:2.5.4.1"
+
+msgid "aliasedObjectName"
+msgstr "aliasedObjectName"
+
+msgid "urn:mace:dir:attribute-def:aliasedObjectName"
+msgstr "urn:mace:dir:attribute-def:aliasedObjectName"
+
+msgid "associatedDomain"
+msgstr "associatedDomain"
+
+msgid "urn:mace:dir:attribute-def:associatedDomain"
+msgstr "urn:mace:dir:attribute-def:associatedDomain"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.37"
+msgstr "urn:oid:0.9.2342.19200300.100.1.37"
+
+msgid "associatedName"
+msgstr "associatedName"
+
+msgid "urn:mace:dir:attribute-def:associatedName"
+msgstr "urn:mace:dir:attribute-def:associatedName"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.38"
+msgstr "urn:oid:0.9.2342.19200300.100.1.38"
+
+msgid "audio"
+msgstr "audio"
+
+msgid "urn:mace:dir:attribute-def:audio"
+msgstr "urn:mace:dir:attribute-def:audio"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.55"
+msgstr "urn:oid:0.9.2342.19200300.100.1.55"
+
+msgid "authorityRevocationList"
+msgstr "authorityRevocationList"
+
+msgid "urn:mace:dir:attribute-def:authorityRevocationList"
+msgstr "urn:mace:dir:attribute-def:authorityRevocationList"
+
+msgid "urn:oid:2.5.4.38"
+msgstr "urn:oid:2.5.4.38"
+
+msgid "buildingName"
+msgstr "buildingName"
+
+msgid "urn:mace:dir:attribute-def:buildingName"
+msgstr "urn:mace:dir:attribute-def:buildingName"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.48"
+msgstr "urn:oid:0.9.2342.19200300.100.1.48"
+
+msgid "businessCategory"
+msgstr "businessCategory"
+
+msgid "urn:mace:dir:attribute-def:businessCategory"
+msgstr "urn:mace:dir:attribute-def:businessCategory"
+
+msgid "urn:oid:2.5.4.15"
+msgstr "urn:oid:2.5.4.15"
+
+msgid "c"
+msgstr "c"
+
+msgid "urn:mace:dir:attribute-def:c"
+msgstr "urn:mace:dir:attribute-def:c"
+
+msgid "urn:oid:2.5.4.6"
+msgstr "urn:oid:2.5.4.6"
+
+msgid "cACertificate"
+msgstr "cACertificate"
+
+msgid "urn:mace:dir:attribute-def:cACertificate"
+msgstr "urn:mace:dir:attribute-def:cACertificate"
+
+msgid "urn:oid:2.5.4.37"
+msgstr "urn:oid:2.5.4.37"
+
+msgid "cNAMERecord"
+msgstr "cNAMERecord"
+
+msgid "urn:mace:dir:attribute-def:cNAMERecord"
+msgstr "urn:mace:dir:attribute-def:cNAMERecord"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.31"
+msgstr "urn:oid:0.9.2342.19200300.100.1.31"
+
+msgid "carLicense"
+msgstr "carLicense"
+
+msgid "urn:mace:dir:attribute-def:carLicense"
+msgstr "urn:mace:dir:attribute-def:carLicense"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.1"
+msgstr "urn:oid:2.16.840.1.113730.3.1.1"
+
+msgid "certificateRevocationList"
+msgstr "certificateRevocationList"
+
+msgid "urn:mace:dir:attribute-def:certificateRevocationList"
+msgstr "urn:mace:dir:attribute-def:certificateRevocationList"
+
+msgid "urn:oid:2.5.4.39"
+msgstr "urn:oid:2.5.4.39"
+
+msgid "cn"
+msgstr "Lebitso le tlwaelehileng"
+
+msgid "urn:mace:dir:attribute-def:cn"
+msgstr "Lebitso le tlwaelehileng"
+
+msgid "urn:oid:2.5.4.3"
+msgstr "Lebitso le tlwaelehileng"
+
+msgid "co"
+msgstr "co"
+
+msgid "urn:mace:dir:attribute-def:co"
+msgstr "urn:mace:dir:attribute-def:co"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.43"
+msgstr "urn:oid:0.9.2342.19200300.100.1.43"
+
+msgid "commonName"
+msgstr "commonName"
+
+msgid "urn:mace:dir:attribute-def:commonName"
+msgstr "urn:mace:dir:attribute-def:commonName"
+
+msgid "countryName"
+msgstr "countryName"
+
+msgid "urn:mace:dir:attribute-def:countryName"
+msgstr "urn:mace:dir:attribute-def:countryName"
+
+msgid "crossCertificatePair"
+msgstr "crossCertificatePair"
+
+msgid "urn:mace:dir:attribute-def:crossCertificatePair"
+msgstr "urn:mace:dir:attribute-def:crossCertificatePair"
+
+msgid "urn:oid:2.5.4.40"
+msgstr "urn:oid:2.5.4.40"
+
+msgid "dITRedirect"
+msgstr "dITRedirect"
+
+msgid "urn:mace:dir:attribute-def:dITRedirect"
+msgstr "urn:mace:dir:attribute-def:dITRedirect"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.54"
+msgstr "urn:oid:0.9.2342.19200300.100.1.54"
+
+msgid "dSAQuality"
+msgstr "dSAQuality"
+
+msgid "urn:mace:dir:attribute-def:dSAQuality"
+msgstr "urn:mace:dir:attribute-def:dSAQuality"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.49"
+msgstr "urn:oid:0.9.2342.19200300.100.1.49"
+
+msgid "dc"
+msgstr "Karolwana ya domeine (DC)"
+
+msgid "urn:mace:dir:attribute-def:dc"
+msgstr "Karolwana ya domeine (DC)"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.25"
+msgstr "Karolwana ya domeine (DC)"
+
+msgid "deltaRevocationList"
+msgstr "deltaRevocationList"
+
+msgid "urn:mace:dir:attribute-def:deltaRevocationList"
+msgstr "urn:mace:dir:attribute-def:deltaRevocationList"
+
+msgid "urn:oid:2.5.4.53"
+msgstr "urn:oid:2.5.4.53"
+
+msgid "departmentNumber"
+msgstr "departmentNumber"
+
+msgid "urn:mace:dir:attribute-def:departmentNumber"
+msgstr "urn:mace:dir:attribute-def:departmentNumber"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.2"
+msgstr "urn:oid:2.16.840.1.113730.3.1.2"
+
+msgid "description"
+msgstr "description"
+
+msgid "urn:mace:dir:attribute-def:description"
+msgstr "urn:mace:dir:attribute-def:description"
+
+msgid "urn:oid:2.5.4.13"
+msgstr "urn:oid:2.5.4.13"
+
+msgid "destinationIndicator"
+msgstr "destinationIndicator"
+
+msgid "urn:mace:dir:attribute-def:destinationIndicator"
+msgstr "urn:mace:dir:attribute-def:destinationIndicator"
+
+msgid "urn:oid:2.5.4.27"
+msgstr "urn:oid:2.5.4.27"
+
+msgid "displayName"
+msgstr "Lebitso le bontshwang"
+
+msgid "urn:mace:dir:attribute-def:displayName"
+msgstr "Lebitso le bontshwang"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.241"
+msgstr "Lebitso le bontshwang"
+
+msgid "distinguishedName"
+msgstr "distinguishedName"
+
+msgid "urn:mace:dir:attribute-def:distinguishedName"
+msgstr "urn:mace:dir:attribute-def:distinguishedName"
+
+msgid "urn:oid:2.5.4.49"
+msgstr "urn:oid:2.5.4.49"
+
+msgid "dmdName"
+msgstr "dmdName"
+
+msgid "urn:mace:dir:attribute-def:dmdName"
+msgstr "urn:mace:dir:attribute-def:dmdName"
+
+msgid "urn:oid:2.5.4.54"
+msgstr "urn:oid:2.5.4.54"
+
+msgid "dnQualifier"
+msgstr "dnQualifier"
+
+msgid "urn:mace:dir:attribute-def:dnQualifier"
+msgstr "urn:mace:dir:attribute-def:dnQualifier"
+
+msgid "urn:oid:2.5.4.46"
+msgstr "urn:oid:2.5.4.46"
+
+msgid "documentAuthor"
+msgstr "documentAuthor"
+
+msgid "urn:mace:dir:attribute-def:documentAuthor"
+msgstr "urn:mace:dir:attribute-def:documentAuthor"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.14"
+msgstr "urn:oid:0.9.2342.19200300.100.1.14"
+
+msgid "documentIdentifier"
+msgstr "documentIdentifier"
+
+msgid "urn:mace:dir:attribute-def:documentIdentifier"
+msgstr "urn:mace:dir:attribute-def:documentIdentifier"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.11"
+msgstr "urn:oid:0.9.2342.19200300.100.1.11"
+
+msgid "documentLocation"
+msgstr "documentLocation"
+
+msgid "urn:mace:dir:attribute-def:documentLocation"
+msgstr "urn:mace:dir:attribute-def:documentLocation"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.15"
+msgstr "urn:oid:0.9.2342.19200300.100.1.15"
+
+msgid "documentPublisher"
+msgstr "documentPublisher"
+
+msgid "urn:mace:dir:attribute-def:documentPublisher"
+msgstr "urn:mace:dir:attribute-def:documentPublisher"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.56"
+msgstr "urn:oid:0.9.2342.19200300.100.1.56"
+
+msgid "documentTitle"
+msgstr "documentTitle"
+
+msgid "urn:mace:dir:attribute-def:documentTitle"
+msgstr "urn:mace:dir:attribute-def:documentTitle"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.12"
+msgstr "urn:oid:0.9.2342.19200300.100.1.12"
+
+msgid "documentVersion"
+msgstr "documentVersion"
+
+msgid "urn:mace:dir:attribute-def:documentVersion"
+msgstr "urn:mace:dir:attribute-def:documentVersion"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.13"
+msgstr "urn:oid:0.9.2342.19200300.100.1.13"
+
+msgid "domainComponent"
+msgstr "domainComponent"
+
+msgid "urn:mace:dir:attribute-def:domainComponent"
+msgstr "urn:mace:dir:attribute-def:domainComponent"
+
+msgid "drink"
+msgstr "drink"
+
+msgid "urn:mace:dir:attribute-def:drink"
+msgstr "urn:mace:dir:attribute-def:drink"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.5"
+msgstr "urn:oid:0.9.2342.19200300.100.1.5"
+
+msgid "eduOrgHomePageURI"
+msgstr "Leqephe la lapeng la khampani"
+
+msgid "urn:mace:dir:attribute-def:eduOrgHomePageURI"
+msgstr "Leqephe la lapeng la khampani"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.2.1.2"
+msgstr "Leqephe la lapeng la khampani"
+
+msgid "eduOrgIdentityAuthNPolicyURI"
+msgstr "eduOrgIdentityAuthNPolicyURI"
+
+msgid "urn:mace:dir:attribute-def:eduOrgIdentityAuthNPolicyURI"
+msgstr "urn:mace:dir:attribute-def:eduOrgIdentityAuthNPolicyURI"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.2.1.3"
+msgstr "urn:oid:1.3.6.1.4.1.5923.1.2.1.3"
+
+msgid "eduOrgLegalName"
+msgstr "Lebitso la molao la khampani"
+
+msgid "urn:mace:dir:attribute-def:eduOrgLegalName"
+msgstr "Lebitso la molao la khampani"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.2.1.4"
+msgstr "Lebitso la molao la khampani"
+
+msgid "eduOrgSuperiorURI"
+msgstr "eduOrgSuperiorURI"
+
+msgid "urn:mace:dir:attribute-def:eduOrgSuperiorURI"
+msgstr "urn:mace:dir:attribute-def:eduOrgSuperiorURI"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.2.1.5"
+msgstr "urn:oid:1.3.6.1.4.1.5923.1.2.1.5"
+
+msgid "eduOrgWhitePagesURI"
+msgstr "eduOrgWhitePagesURI"
+
+msgid "urn:mace:dir:attribute-def:eduOrgWhitePagesURI"
+msgstr "urn:mace:dir:attribute-def:eduOrgWhitePagesURI"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.2.1.6"
+msgstr "urn:oid:1.3.6.1.4.1.5923.1.2.1.6"
+
+msgid "eduPersonAffiliation"
+msgstr "Kamano"
+
+msgid "urn:mace:dir:attribute-def:eduPersonAffiliation"
+msgstr "Kamano"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
+msgstr "Kamano"
+
+msgid "eduPersonAssurance"
+msgstr "Profaele ya tiisetso ya boitsebiso"
+
+msgid "urn:mace:dir:attribute-def:eduPersonAssurance"
+msgstr "Profaele ya tiisetso ya boitsebiso"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.11"
+msgstr "Profaele ya tiisetso ya boitsebiso"
+
+msgid "eduPersonEntitlement"
+msgstr "Thuo bakeng sa tshebeletso"
+
+msgid "urn:mace:dir:attribute-def:eduPersonEntitlement"
+msgstr "Thuo bakeng sa tshebeletso"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.7"
+msgstr "Thuo bakeng sa tshebeletso"
+
+msgid "eduPersonNickname"
+msgstr "Lebitso la boswaswi"
+
+msgid "urn:mace:dir:attribute-def:eduPersonNickname"
+msgstr "Lebitso la boswaswi"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.2"
+msgstr "Lebitso la boswaswi"
+
+msgid "eduPersonOrgDN"
+msgstr "Lebitso le kgethehileng (DN) la khampani ya habo motho"
+
+msgid "urn:mace:dir:attribute-def:eduPersonOrgDN"
+msgstr "Lebitso le kgethehileng (DN) la khampani ya habo motho"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.3"
+msgstr "Lebitso le kgethehileng (DN) la khampani ya habo motho"
+
+msgid "eduPersonOrgUnitDN"
+msgstr ""Lebitso le kgethehileng (DN) la yuniti ya khampani ya habo motho"
+
+msgid "urn:mace:dir:attribute-def:eduPersonOrgUnitDN"
+msgstr ""Lebitso le kgethehileng (DN) la yuniti ya khampani ya habo motho"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.4"
+msgstr ""Lebitso le kgethehileng (DN) la yuniti ya khampani ya habo motho"
+
+msgid "eduPersonPrimaryAffiliation"
+msgstr "Kamano ya motheo"
+
+msgid "urn:mace:dir:attribute-def:eduPersonPrimaryAffiliation"
+msgstr "Kamano ya motheo"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.5"
+msgstr "Kamano ya motheo"
+
+msgid "eduPersonPrimaryOrgUnitDN"
+msgstr "Lebitso le kgethehileng (DN) la Yuniti ya Khampani ya Motheo ya habo motho"
+
+msgid "urn:mace:dir:attribute-def:eduPersonPrimaryOrgUnitDN"
+msgstr "Lebitso le kgethehileng (DN) la Yuniti ya Khampani ya Motheo ya habo motho"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.8"
+msgstr "Lebitso le kgethehileng (DN) la Yuniti ya Khampani ya Motheo ya habo motho"
+
+msgid "eduPersonPrincipalName"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "urn:mace:dir:attribute-def:eduPersonPrincipalName"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "eduPersonScopedAffiliation"
+msgstr "Kamano khampaning ya habo"
+
+msgid "urn:mace:dir:attribute-def:eduPersonScopedAffiliation"
+msgstr "Kamano khampaning ya habo"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.9"
+msgstr "Kamano khampaning ya habo"
+
+msgid "eduPersonTargetedID"
+msgstr "ID e phehellang ya lebitso la boiqapelo"
+
+msgid "urn:mace:dir:attribute-def:eduPersonTargetedID"
+msgstr "ID e phehellang ya lebitso la boiqapelo"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.10"
+msgstr "ID e phehellang ya lebitso la boiqapelo"
+
+msgid "eduPersonUniqueId"
+msgstr "ID ya boiqapelo le phehellang, e sa ajweng botjha ya motho ya khampani ya lapeng"
+
+msgid "urn:mace:dir:attribute-def:eduPersonUniqueId"
+msgstr "ID ya boiqapelo le phehellang, e sa ajweng botjha ya motho ya khampani ya lapeng"
+
+msgid "urn:oid:1.3.6.1.4.1.5923.1.1.1.13"
+msgstr "ID ya boiqapelo le phehellang, e sa ajweng botjha ya motho ya khampani ya lapeng"
+
+msgid "email"
+msgstr "Poso"
+
+msgid "urn:mace:dir:attribute-def:email"
+msgstr "Poso"
+
+msgid "urn:oid:1.2.840.113549.1.9.1"
+msgstr "Poso"
+
+msgid "emailAddress"
+msgstr "Poso"
+
+msgid "urn:mace:dir:attribute-def:emailAddress"
+msgstr "Poso"
+
+msgid "employeeNumber"
+msgstr "employeeNumber"
+
+msgid "urn:mace:dir:attribute-def:employeeNumber"
+msgstr "urn:mace:dir:attribute-def:employeeNumber"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.3"
+msgstr "urn:oid:2.16.840.1.113730.3.1.3"
+
+msgid "employeeType"
+msgstr "employeeType"
+
+msgid "urn:mace:dir:attribute-def:employeeType"
+msgstr "urn:mace:dir:attribute-def:employeeType"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.4"
+msgstr "urn:oid:2.16.840.1.113730.3.1.4"
+
+msgid "enhancedSearchGuide"
+msgstr "enhancedSearchGuide"
+
+msgid "urn:mace:dir:attribute-def:enhancedSearchGuide"
+msgstr "urn:mace:dir:attribute-def:enhancedSearchGuide"
+
+msgid "urn:oid:2.5.4.47"
+msgstr "urn:oid:2.5.4.47"
+
+msgid "facsimileTelephoneNumber"
+msgstr "Nomoro ya fekse"
+
+msgid "urn:mace:dir:attribute-def:facsimileTelephoneNumber"
+msgstr "Nomoro ya fekse"
+
+msgid "urn:oid:2.5.4.23"
+msgstr "Nomoro ya fekse"
+
+msgid "favouriteDrink"
+msgstr "favouriteDrink"
+
+msgid "urn:mace:dir:attribute-def:favouriteDrink"
+msgstr "urn:mace:dir:attribute-def:favouriteDrink"
+
+msgid "fax"
+msgstr "fax"
+
+msgid "urn:mace:dir:attribute-def:fax"
+msgstr "urn:mace:dir:attribute-def:fax"
+
+msgid "federationFeideSchemaVersion"
+msgstr "federationFeideSchemaVersion"
+
+msgid "urn:mace:dir:attribute-def:federationFeideSchemaVersion"
+msgstr "urn:mace:dir:attribute-def:federationFeideSchemaVersion"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.9"
+msgstr "urn:oid:1.3.6.1.4.1.2428.90.1.9"
+
+msgid "friendlyCountryName"
+msgstr "friendlyCountryName"
+
+msgid "urn:mace:dir:attribute-def:friendlyCountryName"
+msgstr "urn:mace:dir:attribute-def:friendlyCountryName"
+
+msgid "generationQualifier"
+msgstr "generationQualifier"
+
+msgid "urn:mace:dir:attribute-def:generationQualifier"
+msgstr "urn:mace:dir:attribute-def:generationQualifier"
+
+msgid "urn:oid:2.5.4.44"
+msgstr "urn:oid:2.5.4.44"
+
+msgid "givenName"
+msgstr "Lebitso le fanweng"
+
+msgid "urn:mace:dir:attribute-def:givenName"
+msgstr "Lebitso le fanweng"
+
+msgid "urn:oid:2.5.4.42"
+msgstr "Lebitso le fanweng"
+
+msgid "gn"
+msgstr "gn"
+
+msgid "urn:mace:dir:attribute-def:gn"
+msgstr "urn:mace:dir:attribute-def:gn"
+
+msgid "homePhone"
+msgstr "Founu ya lapeng"
+
+msgid "urn:mace:dir:attribute-def:homePhone"
+msgstr "Founu ya lapeng"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.20"
+msgstr "Founu ya lapeng"
+
+msgid "homePostalAddress"
+msgstr "Aterese ya lapeng ya poso"
+
+msgid "urn:mace:dir:attribute-def:homePostalAddress"
+msgstr "Aterese ya lapeng ya poso"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.39"
+msgstr "Aterese ya lapeng ya poso"
+
+msgid "homeTelephoneNumber"
+msgstr "homeTelephoneNumber"
+
+msgid "urn:mace:dir:attribute-def:homeTelephoneNumber"
+msgstr "urn:mace:dir:attribute-def:homeTelephoneNumber"
+
+msgid "host"
+msgstr "host"
+
+msgid "urn:mace:dir:attribute-def:host"
+msgstr "urn:mace:dir:attribute-def:host"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.9"
+msgstr "urn:oid:0.9.2342.19200300.100.1.9"
+
+msgid "houseIdentifier"
+msgstr "houseIdentifier"
+
+msgid "urn:mace:dir:attribute-def:houseIdentifier"
+msgstr "urn:mace:dir:attribute-def:houseIdentifier"
+
+msgid "urn:oid:2.5.4.51"
+msgstr "urn:oid:2.5.4.51"
+
+msgid "info"
+msgstr "info"
+
+msgid "urn:mace:dir:attribute-def:info"
+msgstr "urn:mace:dir:attribute-def:info"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.4"
+msgstr "urn:oid:0.9.2342.19200300.100.1.4"
+
+msgid "initials"
+msgstr "initials"
+
+msgid "urn:mace:dir:attribute-def:initials"
+msgstr "urn:mace:dir:attribute-def:initials"
+
+msgid "urn:oid:2.5.4.43"
+msgstr "urn:oid:2.5.4.43"
+
+msgid "internationaliSDNNumber"
+msgstr "internationaliSDNNumber"
+
+msgid "urn:mace:dir:attribute-def:internationaliSDNNumber"
+msgstr "urn:mace:dir:attribute-def:internationaliSDNNumber"
+
+msgid "urn:oid:2.5.4.25"
+msgstr "urn:oid:2.5.4.25"
+
+msgid "janetMailbox"
+msgstr "janetMailbox"
+
+msgid "urn:mace:dir:attribute-def:janetMailbox"
+msgstr "urn:mace:dir:attribute-def:janetMailbox"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.46"
+msgstr "urn:oid:0.9.2342.19200300.100.1.46"
+
+msgid "jpegPhoto"
+msgstr "Foto ya JPEG"
+
+msgid "urn:mace:dir:attribute-def:jpegPhoto"
+msgstr "Foto ya JPEG"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.60"
+msgstr "Foto ya JPEG"
+
+msgid "knowledgeInformation"
+msgstr "knowledgeInformation"
+
+msgid "urn:mace:dir:attribute-def:knowledgeInformation"
+msgstr "urn:mace:dir:attribute-def:knowledgeInformation"
+
+msgid "urn:oid:2.5.4.2"
+msgstr "urn:oid:2.5.4.2"
+
+msgid "l"
+msgstr "Tulo"
+
+msgid "urn:mace:dir:attribute-def:l"
+msgstr "Tulo"
+
+msgid "urn:oid:2.5.4.7"
+msgstr "Tulo"
+
+msgid "labeledURI"
+msgstr "Ya Leibole ya URI"
+
+msgid "urn:mace:dir:attribute-def:labeledURI"
+msgstr "Ya Leibole ya URI"
+
+msgid "urn:oid:1.3.6.1.4.1.250.1.57"
+msgstr "Ya Leibole ya URI"
+
+msgid "localityName"
+msgstr "localityName"
+
+msgid "urn:mace:dir:attribute-def:localityName"
+msgstr "urn:mace:dir:attribute-def:localityName"
+
+msgid "mDRecord"
+msgstr "mDRecord"
+
+msgid "urn:mace:dir:attribute-def:mDRecord"
+msgstr "urn:mace:dir:attribute-def:mDRecord"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.27"
+msgstr "urn:oid:0.9.2342.19200300.100.1.27"
+
+msgid "mXRecord"
+msgstr "mXRecord"
+
+msgid "urn:mace:dir:attribute-def:mXRecord"
+msgstr "urn:mace:dir:attribute-def:mXRecord"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.28"
+msgstr "urn:oid:0.9.2342.19200300.100.1.28"
+
+msgid "Poso"
+msgstr "Poso"
+
+msgid "urn:mace:dir:attribute-def:mail"
+msgstr "Poso"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.3"
+msgstr "Poso"
+
+msgid "mailPreferenceOption"
+msgstr "mailPreferenceOption"
+
+msgid "urn:mace:dir:attribute-def:mailPreferenceOption"
+msgstr "urn:mace:dir:attribute-def:mailPreferenceOption"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.47"
+msgstr "urn:oid:0.9.2342.19200300.100.1.47"
+
+msgid "Mookamedi"
+msgstr "Mookamedi"
+
+msgid "urn:mace:dir:attribute-def:manager"
+msgstr "Mookamedi"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.10"
+msgstr "Mookamedi"
+
+msgid "member"
+msgstr "member"
+
+msgid "urn:mace:dir:attribute-def:member"
+msgstr "urn:mace:dir:attribute-def:member"
+
+msgid "urn:oid:2.5.4.31"
+msgstr "urn:oid:2.5.4.31"
+
+msgid "E tsamayang"
+msgstr "E tsamayang"
+
+msgid "urn:mace:dir:attribute-def:mobile"
+msgstr "E tsamayang"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.41"
+msgstr "E tsamayang"
+
+msgid "mobileTelephoneNumber"
+msgstr "E tsamayang"
+
+msgid "urn:mace:dir:attribute-def:mobileTelephoneNumber"
+msgstr "E tsamayang"
+
+msgid "nSRecord"
+msgstr "nSRecord"
+
+msgid "urn:mace:dir:attribute-def:nSRecord"
+msgstr "urn:mace:dir:attribute-def:nSRecord"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.29"
+msgstr "urn:oid:0.9.2342.19200300.100.1.29"
+
+msgid "name"
+msgstr "name"
+
+msgid "urn:mace:dir:attribute-def:name"
+msgstr "urn:mace:dir:attribute-def:name"
+
+msgid "urn:oid:2.5.4.41"
+msgstr "urn:oid:2.5.4.41"
+
+msgid "norEduOrgAcronym"
+msgstr "norEduOrgAcronym"
+
+msgid "urn:mace:dir:attribute-def:norEduOrgAcronym"
+msgstr "urn:mace:dir:attribute-def:norEduOrgAcronym"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.6"
+msgstr "urn:oid:1.3.6.1.4.1.2428.90.1.6"
+
+msgid "norEduOrgNIN"
+msgstr "Nomoro ya khampani"
+
+msgid "urn:mace:dir:attribute-def:norEduOrgNIN"
+msgstr "Nomoro ya khampani"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.12"
+msgstr "Nomoro ya khampani"
+
+msgid "norEduOrgSchemaVersion"
+msgstr "norEduOrgSchemaVersion"
+
+msgid "urn:mace:dir:attribute-def:norEduOrgSchemaVersion"
+msgstr "urn:mace:dir:attribute-def:norEduOrgSchemaVersion"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.11"
+msgstr "urn:oid:1.3.6.1.4.1.2428.90.1.11"
+
+msgid "norEduOrgUniqueIdentifier"
+msgstr "norEduOrgUniqueIdentifier"
+
+msgid "urn:mace:dir:attribute-def:norEduOrgUniqueIdentifier"
+msgstr "urn:mace:dir:attribute-def:norEduOrgUniqueIdentifier"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.7"
+msgstr "urn:oid:1.3.6.1.4.1.2428.90.1.7"
+
+msgid "norEduOrgUniqueNumber"
+msgstr "norEduOrgUniqueNumber"
+
+msgid "urn:mace:dir:attribute-def:norEduOrgUniqueNumber"
+msgstr "urn:mace:dir:attribute-def:norEduOrgUniqueNumber"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.1"
+msgstr "urn:oid:1.3.6.1.4.1.2428.90.1.1"
+
+msgid "norEduOrgUnitUniqueIdentifier"
+msgstr "norEduOrgUnitUniqueIdentifier"
+
+msgid "urn:mace:dir:attribute-def:norEduOrgUnitUniqueIdentifier"
+msgstr "urn:mace:dir:attribute-def:norEduOrgUnitUniqueIdentifier"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.8"
+msgstr "urn:oid:1.3.6.1.4.1.2428.90.1.8"
+
+msgid "norEduOrgUnitUniqueNumber"
+msgstr "norEduOrgUnitUniqueNumber"
+
+msgid "urn:mace:dir:attribute-def:norEduOrgUnitUniqueNumber"
+msgstr "urn:mace:dir:attribute-def:norEduOrgUnitUniqueNumber"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.2"
+msgstr "urn:oid:1.3.6.1.4.1.2428.90.1.2"
+
+msgid "norEduPersonBirthDate"
+msgstr "Letsatsi la tswalo"
+
+msgid "urn:mace:dir:attribute-def:norEduPersonBirthDate"
+msgstr "Letsatsi la tswalo"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.3"
+msgstr "Letsatsi la tswalo"
+
+msgid "norEduPersonLIN"
+msgstr "Nomoro ya boitsebiso ya lehae"
+
+msgid "urn:mace:dir:attribute-def:norEduPersonLIN"
+msgstr "Nomoro ya boitsebiso ya lehae"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.4"
+msgstr "Nomoro ya boitsebiso ya lehae"
+
+msgid "norEduPersonNIN"
+msgstr "Nomoro ya boitsebiso e abilwe ke bolaodi ba puso"
+
+msgid "urn:mace:dir:attribute-def:norEduPersonNIN"
+msgstr "Nomoro ya boitsebiso e abilwe ke bolaodi ba puso"
+
+msgid "urn:oid:1.3.6.1.4.1.2428.90.1.5"
+msgstr "Nomoro ya boitsebiso e abilwe ke bolaodi ba puso"
+
+msgid "o"
+msgstr "Lebitso la khampani"
+
+msgid "urn:mace:dir:attribute-def:o"
+msgstr "Lebitso la khampani"
+
+msgid "urn:oid:2.5.4.10"
+msgstr "Lebitso la khampani"
+
+msgid "objectClass"
+msgstr "objectClass"
+
+msgid "urn:mace:dir:attribute-def:objectClass"
+msgstr "urn:mace:dir:attribute-def:objectClass"
+
+msgid "urn:oid:2.5.4.0"
+msgstr "urn:oid:2.5.4.0"
+
+msgid "organizationName"
+msgstr "organizationName"
+
+msgid "urn:mace:dir:attribute-def:organizationName"
+msgstr "urn:mace:dir:attribute-def:organizationName"
+
+msgid "organizationalStatus"
+msgstr "organizationalStatus"
+
+msgid "urn:mace:dir:attribute-def:organizationalStatus"
+msgstr "urn:mace:dir:attribute-def:organizationalStatus"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.45"
+msgstr "urn:oid:0.9.2342.19200300.100.1.45"
+
+msgid "organizationalUnitName"
+msgstr "organizationalUnitName"
+
+msgid "urn:mace:dir:attribute-def:organizationalUnitName"
+msgstr "urn:mace:dir:attribute-def:organizationalUnitName"
+
+msgid "urn:oid:2.5.4.11"
+msgstr "Yuniti ya khampani"
+
+msgid "otherMailbox"
+msgstr "otherMailbox"
+
+msgid "urn:mace:dir:attribute-def:otherMailbox"
+msgstr "urn:mace:dir:attribute-def:otherMailbox"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.22"
+msgstr "urn:oid:0.9.2342.19200300.100.1.22"
+
+msgid "ou"
+msgstr "Yuniti ya khampani"
+
+msgid "urn:mace:dir:attribute-def:ou"
+msgstr "Yuniti ya khampani"
+
+msgid "owner"
+msgstr "owner"
+
+msgid "urn:mace:dir:attribute-def:owner"
+msgstr "urn:mace:dir:attribute-def:owner"
+
+msgid "urn:oid:2.5.4.32"
+msgstr "urn:oid:2.5.4.32"
+
+msgid "pager"
+msgstr "pager"
+
+msgid "urn:mace:dir:attribute-def:pager"
+msgstr "urn:mace:dir:attribute-def:pager"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.42"
+msgstr "urn:oid:0.9.2342.19200300.100.1.42"
+
+msgid "pagerTelephoneNumber"
+msgstr "pagerTelephoneNumber"
+
+msgid "urn:mace:dir:attribute-def:pagerTelephoneNumber"
+msgstr "urn:mace:dir:attribute-def:pagerTelephoneNumber"
+
+msgid "pairwise-id"
+msgstr "Service-specific pseudonymous ID at home organization"
+
+msgid "urn:oasis:names:tc:SAML:attribute:pairwise-id"
+msgstr "Service-specific pseudonymous ID at home organization"
+
+msgid "personalSignature"
+msgstr "personalSignature"
+
+msgid "urn:mace:dir:attribute-def:personalSignature"
+msgstr "urn:mace:dir:attribute-def:personalSignature"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.53"
+msgstr "urn:oid:0.9.2342.19200300.100.1.53"
+
+msgid "personalTitle"
+msgstr "personalTitle"
+
+msgid "urn:mace:dir:attribute-def:personalTitle"
+msgstr "urn:mace:dir:attribute-def:personalTitle"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.40"
+msgstr "urn:oid:0.9.2342.19200300.100.1.40"
+
+msgid "photo"
+msgstr "photo"
+
+msgid "urn:mace:dir:attribute-def:photo"
+msgstr "urn:mace:dir:attribute-def:photo"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.7"
+msgstr "urn:oid:0.9.2342.19200300.100.1.7"
+
+msgid "physicalDeliveryOfficeName"
+msgstr "physicalDeliveryOfficeName"
+
+msgid "urn:mace:dir:attribute-def:physicalDeliveryOfficeName"
+msgstr "urn:mace:dir:attribute-def:physicalDeliveryOfficeName"
+
+msgid "urn:oid:2.5.4.19"
+msgstr "urn:oid:2.5.4.19"
+
+msgid "pkcs9email"
+msgstr "pkcs9email"
+
+msgid "urn:mace:dir:attribute-def:pkcs9email"
+msgstr "urn:mace:dir:attribute-def:pkcs9email"
+
+msgid "postOfficeBox"
+msgstr "Lebokose la poso"
+
+msgid "urn:mace:dir:attribute-def:postOfficeBox"
+msgstr "Lebokose la poso"
+
+msgid "urn:oid:2.5.4.18"
+msgstr "Lebokose la poso"
+
+msgid "postalAddress"
+msgstr "Aterese ya poso"
+
+msgid "urn:mace:dir:attribute-def:postalAddress"
+msgstr "Aterese ya poso"
+
+msgid "urn:oid:2.5.4.16"
+msgstr "Aterese ya poso"
+
+msgid "postalCode"
+msgstr "Khoutu ya poso"
+
+msgid "urn:mace:dir:attribute-def:postalCode"
+msgstr "Khoutu ya poso"
+
+msgid "urn:oid:2.5.4.17"
+msgstr "Khoutu ya poso"
+
+msgid "preferredDeliveryMethod"
+msgstr "preferredDeliveryMethod"
+
+msgid "urn:mace:dir:attribute-def:preferredDeliveryMethod"
+msgstr "urn:mace:dir:attribute-def:preferredDeliveryMethod"
+
+msgid "urn:oid:2.5.4.28"
+msgstr "urn:oid:2.5.4.28"
+
+msgid "preferredLanguage"
+msgstr "Puo e kgethwang"
+
+msgid "urn:mace:dir:attribute-def:preferredLanguage"
+msgstr "Puo e kgethwang"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.39"
+msgstr "Puo e kgethwang"
+
+msgid "presentationAddress"
+msgstr "presentationAddress"
+
+msgid "urn:mace:dir:attribute-def:presentationAddress"
+msgstr "urn:mace:dir:attribute-def:presentationAddress"
+
+msgid "urn:oid:2.5.4.29"
+msgstr "urn:oid:2.5.4.29"
+
+msgid "protocolInformation"
+msgstr "protocolInformation"
+
+msgid "urn:mace:dir:attribute-def:protocolInformation"
+msgstr "urn:mace:dir:attribute-def:protocolInformation"
+
+msgid "urn:oid:2.5.4.48"
+msgstr "urn:oid:2.5.4.48"
+
+msgid "pseudonym"
+msgstr "pseudonym"
+
+msgid "urn:mace:dir:attribute-def:pseudonym"
+msgstr "urn:mace:dir:attribute-def:pseudonym"
+
+msgid "urn:oid:2.5.4.65"
+msgstr "urn:oid:2.5.4.65"
+
+msgid "registeredAddress"
+msgstr "registeredAddress"
+
+msgid "urn:mace:dir:attribute-def:registeredAddress"
+msgstr "urn:mace:dir:attribute-def:registeredAddress"
+
+msgid "urn:oid:2.5.4.26"
+msgstr "urn:oid:2.5.4.26"
+
+msgid "rfc822Mailbox"
+msgstr "rfc822Mailbox"
+
+msgid "urn:mace:dir:attribute-def:rfc822Mailbox"
+msgstr "urn:mace:dir:attribute-def:rfc822Mailbox"
+
+msgid "roleOccupant"
+msgstr "roleOccupant"
+
+msgid "urn:mace:dir:attribute-def:roleOccupant"
+msgstr "urn:mace:dir:attribute-def:roleOccupant"
+
+msgid "urn:oid:2.5.4.33"
+msgstr "urn:oid:2.5.4.33"
+
+msgid "roomNumber"
+msgstr "roomNumber"
+
+msgid "urn:mace:dir:attribute-def:roomNumber"
+msgstr "urn:mace:dir:attribute-def:roomNumber"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.6"
+msgstr "urn:oid:0.9.2342.19200300.100.1.6"
+
+msgid "sOARecord"
+msgstr "sOARecord"
+
+msgid "urn:mace:dir:attribute-def:sOARecord"
+msgstr "urn:mace:dir:attribute-def:sOARecord"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.30"
+msgstr "urn:oid:0.9.2342.19200300.100.1.30"
+
+msgid "schacCountryOfCitizenship"
+msgstr "schacCountryOfCitizenship"
+
+msgid "urn:mace:terena.org:attribute-def:schacCountryOfCitizenship"
+msgstr "urn:mace:terena.org:attribute-def:schacCountryOfCitizenship"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.5"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.5"
+
+msgid "urn:schac:attribute-def:schacCountryOfCitizenship"
+msgstr "urn:schac:attribute-def:schacCountryOfCitizenship"
+
+msgid "schacCountryOfResidence"
+msgstr "schacCountryOfResidence"
+
+msgid "urn:mace:terena.org:attribute-def:schacCountryOfResidence"
+msgstr "urn:mace:terena.org:attribute-def:schacCountryOfResidence"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.11"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.11"
+
+msgid "urn:schac:attribute-def:schacCountryOfResidence"
+msgstr "urn:schac:attribute-def:schacCountryOfResidence"
+
+msgid "schacDateOfBirth"
+msgstr "schacDateOfBirth"
+
+msgid "urn:mace:terena.org:attribute-def:schacDateOfBirth"
+msgstr "urn:mace:terena.org:attribute-def:schacDateOfBirth"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.3"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.3"
+
+msgid "urn:schac:attribute-def:schacDateOfBirth"
+msgstr "urn:schac:attribute-def:schacDateOfBirth"
+
+msgid "schacExpiryDate"
+msgstr "schacExpiryDate"
+
+msgid "urn:mace:terena.org:attribute-def:schacExpiryDate"
+msgstr "urn:mace:terena.org:attribute-def:schacExpiryDate"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.17"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.17"
+
+msgid "urn:schac:attribute-def:schacExpiryDate"
+msgstr "urn:schac:attribute-def:schacExpiryDate"
+
+msgid "schacGender"
+msgstr "schacGender"
+
+msgid "urn:mace:terena.org:attribute-def:schacGender"
+msgstr "urn:mace:terena.org:attribute-def:schacGender"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.2"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.2"
+
+msgid "urn:schac:attribute-def:schacGender"
+msgstr "urn:schac:attribute-def:schacGender"
+
+msgid "schacHomeOrganization"
+msgstr "Lebitso la domeine ya khampani"
+
+msgid "urn:mace:terena.org:attribute-def:schacHomeOrganization"
+msgstr "Lebitso la domeine ya khampani"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.9"
+msgstr "Lebitso la domeine ya khampani"
+
+msgid "urn:schac:attribute-def:schacHomeOrganization"
+msgstr "Lebitso la domeine ya khampani"
+
+msgid "schacHomeOrganizationType"
+msgstr "schacHomeOrganizationType"
+
+msgid "urn:mace:terena.org:attribute-def:schacHomeOrganizationType"
+msgstr "urn:mace:terena.org:attribute-def:schacHomeOrganizationType"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.10"
+
+msgid "urn:schac:attribute-def:schacHomeOrganizationType"
+msgstr "urn:schac:attribute-def:schacHomeOrganizationType"
+
+msgid "schacMotherTongue"
+msgstr "schacMotherTongue"
+
+msgid "urn:mace:terena.org:attribute-def:schacMotherTongue"
+msgstr "urn:mace:terena.org:attribute-def:schacMotherTongue"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.1"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.1"
+
+msgid "urn:schac:attribute-def:schacMotherTongue"
+msgstr "urn:schac:attribute-def:schacMotherTongue"
+
+msgid "schacPersonalPosition"
+msgstr "schacPersonalPosition"
+
+msgid "urn:mace:terena.org:attribute-def:schacPersonalPosition"
+msgstr "urn:mace:terena.org:attribute-def:schacPersonalPosition"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.13"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.13"
+
+msgid "urn:schac:attribute-def:schacPersonalPosition"
+msgstr "urn:schac:attribute-def:schacPersonalPosition"
+
+msgid "schacPersonalTitle"
+msgstr "schacPersonalTitle"
+
+msgid "urn:mace:terena.org:attribute-def:schacPersonalTitle"
+msgstr "urn:mace:terena.org:attribute-def:schacPersonalTitle"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.8"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.8"
+
+msgid "urn:schac:attribute-def:schacPersonalTitle"
+msgstr "urn:schac:attribute-def:schacPersonalTitle"
+
+msgid "schacPersonalUniqueCode"
+msgstr "schacPersonalUniqueCode"
+
+msgid "urn:mace:terena.org:attribute-def:schacPersonalUniqueCode"
+msgstr "urn:mace:terena.org:attribute-def:schacPersonalUniqueCode"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.14"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.14"
+
+msgid "urn:schac:attribute-def:schacPersonalUniqueCode"
+msgstr "urn:schac:attribute-def:schacPersonalUniqueCode"
+
+msgid "schacPersonalUniqueID"
+msgstr "schacPersonalUniqueID"
+
+msgid "urn:mace:terena.org:attribute-def:schacPersonalUniqueID"
+msgstr "urn:mace:terena.org:attribute-def:schacPersonalUniqueID"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.15"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.15"
+
+msgid "urn:schac:attribute-def:schacPersonalUniqueID"
+msgstr "urn:schac:attribute-def:schacPersonalUniqueID"
+
+msgid "schacPlaceOfBirth"
+msgstr "schacPlaceOfBirth"
+
+msgid "urn:mace:terena.org:attribute-def:schacPlaceOfBirth"
+msgstr "urn:mace:terena.org:attribute-def:schacPlaceOfBirth"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.4"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.4"
+
+msgid "urn:schac:attribute-def:schacPlaceOfBirth"
+msgstr "urn:schac:attribute-def:schacPlaceOfBirth"
+
+msgid "schacProjectMembership"
+msgstr "schacProjectMembership"
+
+msgid "urn:mace:terena.org:attribute-def:schacProjectMembership"
+msgstr "urn:mace:terena.org:attribute-def:schacProjectMembership"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.20"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.20"
+
+msgid "urn:schac:attribute-def:schacProjectMembership"
+msgstr "urn:schac:attribute-def:schacProjectMembership"
+
+msgid "schacProjectSpecificRole"
+msgstr "schacProjectSpecificRole"
+
+msgid "urn:mace:terena.org:attribute-def:schacProjectSpecificRole"
+msgstr "urn:mace:terena.org:attribute-def:schacProjectSpecificRole"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.21"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.21"
+
+msgid "urn:schac:attribute-def:schacProjectSpecificRole"
+msgstr "urn:schac:attribute-def:schacProjectSpecificRole"
+
+msgid "schacSn1"
+msgstr "schacSn1"
+
+msgid "urn:mace:terena.org:attribute-def:schacSn1"
+msgstr "urn:mace:terena.org:attribute-def:schacSn1"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.6"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.6"
+
+msgid "urn:schac:attribute-def:schacSn1"
+msgstr "urn:schac:attribute-def:schacSn1"
+
+msgid "schacSn2"
+msgstr "schacSn2"
+
+msgid "urn:mace:terena.org:attribute-def:schacSn2"
+msgstr "urn:mace:terena.org:attribute-def:schacSn2"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.7"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.7"
+
+msgid "urn:schac:attribute-def:schacSn2"
+msgstr "urn:schac:attribute-def:schacSn2"
+
+msgid "schacUserPresenceID"
+msgstr "schacUserPresenceID"
+
+msgid "urn:mace:terena.org:attribute-def:schacUserPresenceID"
+msgstr "urn:mace:terena.org:attribute-def:schacUserPresenceID"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.12"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.12"
+
+msgid "urn:schac:attribute-def:schacUserPresenceID"
+msgstr "urn:schac:attribute-def:schacUserPresenceID"
+
+msgid "schacUserPrivateAttribute"
+msgstr "Dielemente tsa tlhahisoleseding ya poraefete"
+
+msgid "urn:mace:terena.org:attribute-def:schacUserPrivateAttribute"
+msgstr "Dielemente tsa tlhahisoleseding ya poraefete"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.18"
+msgstr "Dielemente tsa tlhahisoleseding ya poraefete"
+
+msgid "urn:schac:attribute-def:schacUserPrivateAttribute"
+msgstr "Dielemente tsa tlhahisoleseding ya poraefete"
+
+msgid "schacUserStatus"
+msgstr "schacUserStatus"
+
+msgid "urn:mace:terena.org:attribute-def:schacUserStatus"
+msgstr "urn:mace:terena.org:attribute-def:schacUserStatus"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.2.19"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.2.19"
+
+msgid "urn:schac:attribute-def:schacUserStatus"
+msgstr "urn:schac:attribute-def:schacUserStatus"
+
+msgid "schacYearOfBirth"
+msgstr "schacYearOfBirth"
+
+msgid "urn:mace:terena.org:attribute-def:schacYearOfBirth"
+msgstr "urn:mace:terena.org:attribute-def:schacYearOfBirth"
+
+msgid "urn:oid:1.3.6.1.4.1.25178.1.0.2.3"
+msgstr "urn:oid:1.3.6.1.4.1.25178.1.0.2.3"
+
+msgid "urn:schac:attribute-def:schacYearOfBirth"
+msgstr "urn:schac:attribute-def:schacYearOfBirth"
+
+msgid "searchGuide"
+msgstr "searchGuide"
+
+msgid "urn:mace:dir:attribute-def:searchGuide"
+msgstr "urn:mace:dir:attribute-def:searchGuide"
+
+msgid "urn:oid:2.5.4.14"
+msgstr "urn:oid:2.5.4.14"
+
+msgid "secretary"
+msgstr "secretary"
+
+msgid "urn:mace:dir:attribute-def:secretary"
+msgstr "urn:mace:dir:attribute-def:secretary"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.21"
+msgstr "urn:oid:0.9.2342.19200300.100.1.21"
+
+msgid "seeAlso"
+msgstr "seeAlso"
+
+msgid "urn:mace:dir:attribute-def:seeAlso"
+msgstr "urn:mace:dir:attribute-def:seeAlso"
+
+msgid "urn:oid:2.5.4.34"
+msgstr "urn:oid:2.5.4.34"
+
+msgid "serialNumber"
+msgstr "serialNumber"
+
+msgid "urn:mace:dir:attribute-def:serialNumber"
+msgstr "urn:mace:dir:attribute-def:serialNumber"
+
+msgid "urn:oid:2.5.4.5"
+msgstr "urn:oid:2.5.4.5"
+
+msgid "singleLevelQuality"
+msgstr "singleLevelQuality"
+
+msgid "urn:mace:dir:attribute-def:singleLevelQuality"
+msgstr "urn:mace:dir:attribute-def:singleLevelQuality"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.50"
+msgstr "urn:oid:0.9.2342.19200300.100.1.50"
+
+msgid "sisSchoolGrade"
+msgstr "sisSchoolGrade"
+
+msgid "urn:mace:dir:attribute-def:sisSchoolGrade"
+msgstr "urn:mace:dir:attribute-def:sisSchoolGrade"
+
+msgid "urn:oid:1.2.752.194.10.2.2"
+msgstr "urn:oid:1.2.752.194.10.2.2"
+
+msgid "sisLegalGuardianFor"
+msgstr "sisLegalGuardianFor"
+
+msgid "urn:mace:dir:attribute-def:sisLegalGuardianFor"
+msgstr "urn:mace:dir:attribute-def:sisLegalGuardianFor"
+
+msgid "urn:oid:1.2.752.194.10.2.1"
+msgstr "urn:oid:1.2.752.194.10.2.1"
+
+msgid "sn"
+msgstr "Difane"
+
+msgid "urn:mace:dir:attribute-def:sn"
+msgstr "Difane"
+
+msgid "urn:oid:2.5.4.4"
+msgstr "Difane"
+
+msgid "st"
+msgstr "st"
+
+msgid "urn:mace:dir:attribute-def:st"
+msgstr "urn:mace:dir:attribute-def:st"
+
+msgid "urn:oid:2.5.4.8"
+msgstr "urn:oid:2.5.4.8"
+
+msgid "stateOrProvinceName"
+msgstr "stateOrProvinceName"
+
+msgid "urn:mace:dir:attribute-def:stateOrProvinceName"
+msgstr "urn:mace:dir:attribute-def:stateOrProvinceName"
+
+msgid "Seterata"
+msgstr "Seterata"
+
+msgid "urn:mace:dir:attribute-def:street"
+msgstr "Seterata"
+
+msgid "urn:oid:2.5.4.9"
+msgstr "Seterata"
+
+msgid "streetAddress"
+msgstr "streetAddress"
+
+msgid "urn:mace:dir:attribute-def:streetAddress"
+msgstr "urn:mace:dir:attribute-def:streetAddress"
+
+msgid "subject-id"
+msgstr "Pseudonymous ID at home organization"
+
+msgid "urn:oasis:names:tc:SAML:attribute:subject-id"
+msgstr "Pseudonymous ID at home organization"
+
+msgid "subtreeMaximumQuality"
+msgstr "subtreeMaximumQuality"
+
+msgid "urn:mace:dir:attribute-def:subtreeMaximumQuality"
+msgstr "urn:mace:dir:attribute-def:subtreeMaximumQuality"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.52"
+msgstr "urn:oid:0.9.2342.19200300.100.1.52"
+
+msgid "subtreeMinimumQuality"
+msgstr "subtreeMinimumQuality"
+
+msgid "urn:mace:dir:attribute-def:subtreeMinimumQuality"
+msgstr "urn:mace:dir:attribute-def:subtreeMinimumQuality"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.51"
+msgstr "urn:oid:0.9.2342.19200300.100.1.51"
+
+msgid "supportedAlgorithms"
+msgstr "supportedAlgorithms"
+
+msgid "urn:mace:dir:attribute-def:supportedAlgorithms"
+msgstr "urn:mace:dir:attribute-def:supportedAlgorithms"
+
+msgid "urn:oid:2.5.4.52"
+msgstr "urn:oid:2.5.4.52"
+
+msgid "supportedApplicationContext"
+msgstr "supportedApplicationContext"
+
+msgid "urn:mace:dir:attribute-def:supportedApplicationContext"
+msgstr "urn:mace:dir:attribute-def:supportedApplicationContext"
+
+msgid "urn:oid:2.5.4.30"
+msgstr "urn:oid:2.5.4.30"
+
+msgid "Difane"
+msgstr "Difane"
+
+msgid "urn:mace:dir:attribute-def:surname"
+msgstr "urn:mace:dir:attribute-def:surname"
+
+msgid "telephoneNumber"
+msgstr "Nomoro ya founu"
+
+msgid "urn:mace:dir:attribute-def:telephoneNumber"
+msgstr "Nomoro ya founu"
+
+msgid "urn:oid:2.5.4.20"
+msgstr "Nomoro ya founu"
+
+msgid "teletexTerminalIdentifier"
+msgstr "teletexTerminalIdentifier"
+
+msgid "urn:mace:dir:attribute-def:teletexTerminalIdentifier"
+msgstr "urn:mace:dir:attribute-def:teletexTerminalIdentifier"
+
+msgid "urn:oid:2.5.4.22"
+msgstr "urn:oid:2.5.4.22"
+
+msgid "telexNumber"
+msgstr "telexNumber"
+
+msgid "urn:mace:dir:attribute-def:telexNumber"
+msgstr "urn:mace:dir:attribute-def:telexNumber"
+
+msgid "urn:oid:2.5.4.21"
+msgstr "urn:oid:2.5.4.21"
+
+msgid "textEncodedORAddress"
+msgstr "textEncodedORAddress"
+
+msgid "urn:mace:dir:attribute-def:textEncodedORAddress"
+msgstr "urn:mace:dir:attribute-def:textEncodedORAddress"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.2"
+msgstr "urn:oid:0.9.2342.19200300.100.1.2"
+
+msgid "title"
+msgstr "Thaetlele"
+
+msgid "urn:mace:dir:attribute-def:title"
+msgstr "Thaetlele"
+
+msgid "urn:oid:2.5.4.12"
+msgstr "Thaetlele"
+
+msgid "uid"
+msgstr "ID ya Mosebedisi"
+
+msgid "urn:mace:dir:attribute-def:uid"
+msgstr "ID ya Mosebedisi"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.1"
+msgstr "ID ya Mosebedisi"
+
+msgid "uniqueIdentifier"
+msgstr "uniqueIdentifier"
+
+msgid "urn:mace:dir:attribute-def:uniqueIdentifier"
+msgstr "urn:mace:dir:attribute-def:uniqueIdentifier"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.44"
+msgstr "urn:oid:0.9.2342.19200300.100.1.44"
+
+msgid "uniqueMember"
+msgstr "uniqueMember"
+
+msgid "urn:mace:dir:attribute-def:uniqueMember"
+msgstr "urn:mace:dir:attribute-def:uniqueMember"
+
+msgid "urn:oid:2.5.4.50"
+msgstr "urn:oid:2.5.4.50"
+
+msgid "userCertificate"
+msgstr "userCertificate"
+
+msgid "urn:mace:dir:attribute-def:userCertificate"
+msgstr "urn:mace:dir:attribute-def:userCertificate"
+
+msgid "urn:oid:2.5.4.36"
+msgstr "urn:oid:2.5.4.36"
+
+msgid "userClass"
+msgstr "userClass"
+
+msgid "urn:mace:dir:attribute-def:userClass"
+msgstr "urn:mace:dir:attribute-def:userClass"
+
+msgid "urn:oid:0.9.2342.19200300.100.1.8"
+msgstr "urn:oid:0.9.2342.19200300.100.1.8"
+
+msgid "userPKCS12"
+msgstr "userPKCS12"
+
+msgid "urn:mace:dir:attribute-def:userPKCS12"
+msgstr "urn:mace:dir:attribute-def:userPKCS12"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.216"
+msgstr "urn:oid:2.16.840.1.113730.3.1.216"
+
+msgid "userPassword"
+msgstr "Hesh ya phasewete ya mosebedisi"
+
+msgid "urn:mace:dir:attribute-def:userPassword"
+msgstr "Hesh ya phasewete ya mosebedisi"
+
+msgid "urn:oid:2.5.4.35"
+msgstr "Hesh ya phasewete ya mosebedisi"
+
+msgid "userSMIMECertificate"
+msgstr "userSMIMECertificate"
+
+msgid "urn:mace:dir:attribute-def:userSMIMECertificate"
+msgstr "urn:mace:dir:attribute-def:userSMIMECertificate"
+
+msgid "urn:oid:2.16.840.1.113730.3.1.40"
+msgstr "urn:oid:2.16.840.1.113730.3.1.40"
+
+msgid "userid"
+msgstr "userid"
+
+msgid "urn:mace:dir:attribute-def:userid"
+msgstr "urn:mace:dir:attribute-def:userid"
+
+msgid "x121Address"
+msgstr "x121Address"
+
+msgid "urn:mace:dir:attribute-def:x121Address"
+msgstr "urn:mace:dir:attribute-def:x121Address"
+
+msgid "urn:oid:2.5.4.24"
+msgstr "urn:oid:2.5.4.24"
+
+msgid "x500UniqueIdentifier"
+msgstr "x500UniqueIdentifier"
+
+msgid "urn:mace:dir:attribute-def:x500UniqueIdentifier"
+msgstr "urn:mace:dir:attribute-def:x500UniqueIdentifier"
+
+msgid "urn:oid:2.5.4.45"
+msgstr "urn:oid:2.5.4.45"
+
+msgid "facebook_cn"
+msgstr "Lebitso le tlwaelehileng"
+
+msgid "http://axschema.org/contact/country/home"
+msgstr "http://axschema.org/contact/country/home"
+
+msgid "openid.sreg.country"
+msgstr "openid.sreg.country"
+
+msgid "facebook.about_me"
+msgstr "facebook.about_me"
+
+msgid "linkedin.summary"
+msgstr "linkedin.summary"
+
+msgid "twitter.description"
+msgstr "twitter.description"
+
+msgid "facebook.name"
+msgstr "Lebitso le bontshwang"
+
+msgid "http://axschema.org/namePerson/friendly"
+msgstr "Lebitso le bontshwang"
+
+msgid "openid.sreg.nickname"
+msgstr "Lebitso le bontshwang"
+
+msgid "http://axschema.org/namePerson"
+msgstr "Lebitso le bontshwang"
+
+msgid "openid.sreg.fullname"
+msgstr "Lebitso le bontshwang"
+
+msgid "twitter.name"
+msgstr "Lebitso le bontshwang"
+
+msgid "windowslive.displayName"
+msgstr "Lebitso le bontshwang"
+
+msgid "facebook_user"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "linkedin_user"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "twitter_screen_n_realm"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "windowslive_user"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "windowslive.userPrincipalName"
+msgstr "Lebitso la sehlooho la motho khampaning ya habo"
+
+msgid "facebook_targetedID"
+msgstr "ID e phehellang ya lebitso la boiqapelo"
+
+msgid "linkedin_targetedID"
+msgstr "ID e phehellang ya lebitso la boiqapelo"
+
+msgid "twitter_targetedID"
+msgstr "ID e phehellang ya lebitso la boiqapelo"
+
+msgid "windowslive_targetedID"
+msgstr "ID e phehellang ya lebitso la boiqapelo"
+
+msgid "http://axschema.org/contact/phone/fax"
+msgstr "Nomoro ya fekse"
+
+msgid "facebook.first_name"
+msgstr "Lebitso le fanweng"
+
+msgid "linkedin.firstName"
+msgstr "Lebitso le fanweng"
+
+msgid "http://axschema.org/namePerson/first"
+msgstr "Lebitso le fanweng"
+
+msgid "windowslive.FirstName"
+msgstr "Lebitso le fanweng"
+
+msgid "windowslive.givenName"
+msgstr "Lebitso le fanweng"
+
+msgid "http://axschema.org/contact/phone/home"
+msgstr "Founu ya lapeng"
+
+msgid "windowslive.Location"
+msgstr "Tulo"
+
+msgid "facebook.profile_url"
+msgstr "Ya Leibole ya URI"
+
+msgid "twitter.url"
+msgstr "Ya Leibole ya URI"
+
+msgid "facebook.email"
+msgstr "Poso"
+
+msgid "http://axschema.org/contact/email"
+msgstr "Poso"
+
+msgid "openid.sreg.email"
+msgstr "Poso"
+
+msgid "windowslive_mail"
+msgstr "Poso"
+
+msgid "windowslive.mail"
+msgstr "Poso"
+
+msgid "http://axschema.org/contact/phone/cell"
+msgstr "E tsamayang"
+
+msgid "http://axschema.org/company/name"
+msgstr "Lebitso la khampani"
+
+msgid "http://axschema.org/namePerson/prefix"
+msgstr "http://axschema.org/namePerson/prefix"
+
+msgid "http://axschema.org/contact/postalCode/home"
+msgstr "Khoutu ya poso"
+
+msgid "openid.sreg.postcode"
+msgstr "Khoutu ya poso"
+
+msgid "facebook.locale"
+msgstr "Puo e kgethwang"
+
+msgid "http://axschema.org/pref/language"
+msgstr "Puo e kgethwang"
+
+msgid "openid.sreg.language"
+msgstr "Puo e kgethwang"
+
+msgid "twitter.lang"
+msgstr "Puo e kgethwang"
+
+msgid "windowslive.preferredLanguage"
+msgstr "Puo e kgethwang"
+
+msgid "facebook.last_name"
+msgstr "Difane"
+
+msgid "linkedin.lastName"
+msgstr "Difane"
+
+msgid "http://axschema.org/namePerson/last"
+msgstr "Difane"
+
+msgid "windowslive.LastName"
+msgstr "Difane"
+
+msgid "windowslive.surname"
+msgstr "Difane"
+
+msgid "http://axschema.org/contact/phone/default"
+msgstr "Nomoro ya founu"
+
+msgid "http://axschema.org/contact/phone/business"
+msgstr "Nomoro ya founu"
+
+msgid "linkedin.headline"
+msgstr "Thaetlele"
+
+msgid "http://axschema.org/company/title"
+msgstr "Thaetlele"
+
+msgid "facebook.username"
+msgstr "ID ya Mosebedisi"
+
+msgid "linkedin.id"
+msgstr "ID ya Mosebedisi"
+
+msgid "twitter.screen_name"
+msgstr "ID ya Mosebedisi"
+
+msgid "windowslive_uid"
+msgstr "ID ya Mosebedisi"
+
+msgid "windowslive.id"
+msgstr "ID ya Mosebedisi"

--- a/locales/st/LC_MESSAGES/messages.po
+++ b/locales/st/LC_MESSAGES/messages.po
@@ -1,0 +1,1127 @@
+
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: SimpleSAMLphp 1.15\n"
+"Report-Msgid-Bugs-To: simplesamlphp-translation@googlegroups.com\n"
+"POT-Creation-Date: 2019-12-12 15:44+0200\n"
+"PO-Revision-Date: 2019-12-12 15:44+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+msgid ""
+"You accessed the Assertion Consumer Service interface, but did not "
+"provide a SAML Authentication Response. Please note that this endpoint is"
+" not intended to be accessed directly."
+msgstr ""
+"O fihletse kopano ya Tiiso ya Tshebeletso ya Bareki, empa ha o a fana ka "
+"Karabelo ya Netefatso ya SAML. Ka kopo lemoha hore ntlha ena ya bofelo ha"
+" e a rerelwa ho fihlellwa ka kotloloho."
+
+msgid "Return to service"
+msgstr "E kgutlela tshebeletsong"
+
+msgid "{general:yes}"
+msgstr "E"
+
+msgid "{errors:title_PROCESSAUTHNREQUEST}"
+msgstr "Phoso ho sebetseng kopo ho tswa ho Mofani wa Tshebeletso"
+
+msgid ""
+"One or more of the services you are logged into <i>do not support "
+"logout</i>. To ensure that all your sessions are closed, you are "
+"encouraged to <i>close your webbrowser</i>."
+msgstr ""
+"E le nngwe kapa ho feta ya ditshebeletso tseo o keneng ho tsona <i>ha e "
+"tshehetse ho tswa</i>. Ho netefatsa hore diseshene tsohle tsa hao di "
+"kwetswe, o kgothaletswa ho <i>kwala sebadi sa webo sa hao</i>."
+
+msgid "E-mail address:"
+msgstr "Aterese ya imeile:"
+
+msgid "{logout:logout_all_question}"
+msgstr "Na o batla ho tswa ditshebeletsong tsohle tse ka hodimo moo?"
+
+msgid "{errors:howto_header}"
+msgstr "Ka moo o ka fumanang thuso"
+
+msgid "Help! I don't remember my password."
+msgstr "Thuso! Ha ke hopole phasewete ya ka."
+
+msgid "{logout:title}"
+msgstr "O ntshitswe"
+
+msgid "{errors:descr_PROCESSASSERTION}"
+msgstr "Ha re a amohela karabelo ho tswa ho Mofani wa Boitsebiso."
+
+msgid "{errors:title_BADREQUEST}"
+msgstr "Kopo e mpe e amohetswe"
+
+msgid "{errors:title_RESPONSESTATUSNOSUCCESS}"
+msgstr "Phoso e amohetswe ho tswa ho Mofani wa Boitsebiso"
+
+msgid "No access"
+msgstr "Ha ho phihlello"
+
+msgid "{status:logout}"
+msgstr "Ho tswa"
+
+msgid "{errors:descr_SLOSERVICEPARAMS}"
+msgstr ""
+"O fihletse tshebeletsano ya SingleLogoutService, empa ha o a fana ka SAML"
+" LogoutRequest kapa LogoutResponse. Ka kopo lemoha hore ntlha ena ya "
+"bofelo ha e a rerelwa ho fihlellwa ka kotloloho."
+
+msgid "Organization"
+msgstr "Khampani"
+
+msgid "{login:organization}"
+msgstr "Khampani"
+
+msgid "{errors:title_WRONGUSERPASS}"
+msgstr "Lebitso la mosebedisi kapa phasewete e fosahetseng"
+
+msgid "{disco:previous_auth}"
+msgstr "O qadile ka ho kgetha netefatso ho"
+
+msgid "{logout:hold}"
+msgstr "Tshwarisitswe"
+
+msgid "Authentication source error"
+msgstr "Phoso ya netefatso ya mohlodi"
+
+msgid "{errors:debuginfo_header}"
+msgstr "Tlhahisoleseding ya debug"
+
+msgid ""
+"The Identity Provider responded with an error. (The status code in the "
+"SAML Response was not success)"
+msgstr ""
+"Mofani wa Boitsebiso o arabetse ka phoso. (Khoutu ya boemo Karabelong ya "
+"SAML ha e a atleha)"
+
+msgid "{login:contact_info}"
+msgstr "Tlhahisoleseding ya boikopanyo:"
+
+msgid "{errors:descr_ARSPARAMS}"
+msgstr ""
+"O fihletse kopano ya Tshebeletso ya Tlhakiso ya Athifekte, empa ha o a "
+"fana ka molaetsa wa SAML ArtifactResolve. Ka kopo lemoha hore ntlha ena "
+"ya bofelo ha e a rerelwa ho fihlellwa ka kotloloho."
+
+msgid "{errors:descr_GENERATEAUTHNRESPONSE}"
+msgstr ""
+"Ha mofani enwa wa boitsebiso a leka ho theha karabelo ya netefatso, phoso"
+" e bile teng."
+
+msgid "Remember"
+msgstr "Hopola"
+
+msgid "{errors:title_SLOSERVICEPARAMS}"
+msgstr "Ha ho molaetsa wa SAML o fanweng"
+
+msgid "You have successfully logged out from all services listed above."
+msgstr ""
+"O tswile ka katleho ditshebeletsong tsohle tse thathamisitsweng ka hodimo"
+" mona."
+
+msgid "{errors:title_DISCOPARAMS}"
+msgstr "Kopo e mpe bakeng sa tshebeletso ya tshibollo"
+
+msgid "{logout:failed}"
+msgstr "Ho tswa ho hlolehile"
+
+msgid "{errors:title_CONFIG}"
+msgstr "Phoso ya Netefatso"
+
+msgid "{errors:title_CREATEREQUEST}"
+msgstr "Phoso ho thehweng ha kopo"
+
+msgid "The error report has been sent to the administrators."
+msgstr "Tlaleho ya phoso e rometswe ho batsamaisi."
+
+msgid "{errors:title_UNKNOWNCERT}"
+msgstr "Setifikeiti se sa tsejweng"
+
+msgid "{general:service_provider}"
+msgstr "Mofani wa Tshebeletso"
+
+msgid "{general:no_cancel}"
+msgstr "Tjhe, hlakola"
+
+msgid "{logout:logging_out_from}"
+msgstr "E tswa ditshebeletsong tse latelang:"
+
+msgid "{login:help_desk_email}"
+msgstr "Romela imeile ho ba deske ya thuso"
+
+msgid "{login:change_home_org_title}"
+msgstr "Fetola khampani ya lehae ya heno"
+
+msgid "{errors:descr_UNKNOWNCERT}"
+msgstr ""
+"Netefatso e hlolehile: setifikeiti se rometsweng ke sebadi sa hao ha se "
+"tsejwe"
+
+msgid "{errors:title_ACSPARAMS}"
+msgstr "Ha ho karabelo ya SAML e fanweng"
+
+msgid "{errors:report_text}"
+msgstr ""
+"Ka boikgethelo o ka kenya aterse ya imeile ya hao, bakeng sa batsamaisi "
+"hore ba kgone ho ikopanya le wena mabapi le dipotso tse ding ka ditaba "
+"tsa hao:"
+
+msgid "Incorrect username or password"
+msgstr "Lebitso la mosebedisi kapa phasewete e fosahetseng"
+
+msgid "Bad request to discovery service"
+msgstr "Kopo e mpe bakeng sa tshebeletso ya tshibollo"
+
+msgid "{errors:report_header}"
+msgstr "Tlaleha diphoso"
+
+msgid "Select"
+msgstr "Kgetha"
+
+msgid "{errors:descr_SSOPARAMS}"
+msgstr ""
+"O fihletse tshebeletsano ya Tshaeno ya Hang, empa ha o a fan aka Kopo ya "
+"Netefatso ya SAML. Ka kopo lemoha hore ntlha ena ya bofelo ha e a rerelwa"
+" ho fihlellwa ka kotloloho."
+
+msgid "Format"
+msgstr "Fomata"
+
+msgid "Contact information:"
+msgstr "Tlhahisoleseding ya boikopanyo:"
+
+msgid "Authentication error in source %AUTHSOURCE%. The reason was: %REASON%"
+msgstr "Phoso ya tiiso mohloding %AUTHSOURCE%. Lebaka e bile: %REASON%"
+
+msgid "{errors:title_UNHANDLEDEXCEPTION}"
+msgstr "Mokgelo o sa rarollwang"
+
+msgid "{errors:title_NORELAYSTATE}"
+msgstr "Ha ho RelayState"
+
+msgid "{status:subject_format}"
+msgstr "Fomata"
+
+msgid "Password"
+msgstr "Phasewete"
+
+msgid "{errors:title_AUTHSOURCEERROR}"
+msgstr "Phoso ya netefatso ya mohlodi"
+
+msgid "Debug information"
+msgstr "Tlhahisoleseding ya debug"
+
+msgid "{logout:success}"
+msgstr ""
+"O tswile ka katleho ditshebeletsong tsohle tse thathamisitsweng ka hodimo"
+" mona."
+
+msgid "Remember my choice"
+msgstr "Hopola kgetho ya ka"
+
+msgid ""
+"You accessed the SingleLogoutService interface, but did not provide a "
+"SAML LogoutRequest or LogoutResponse. Please note that this endpoint is "
+"not intended to be accessed directly."
+msgstr ""
+"O fihletse tshebeletsano ya SingleLogoutService, empa ha o a fana ka SAML"
+" LogoutRequest kapa LogoutResponse. Ka kopo lemoha hore ntlha ena ya "
+"bofelo ha e a rerelwa ho fihlellwa ka kotloloho."
+
+msgid "{errors:title_NOTSET}"
+msgstr "Phasewete ha e a setwa"
+
+msgid "{errors:report_explain}"
+msgstr "Hlalosa seo o se entseng ha phoso ena e ne e hlaha..."
+
+msgid ""
+"If you report this error, please also report this tracking number which "
+"makes it possible to locate your session in the logs available to the "
+"system administrator:"
+msgstr ""
+"Haeba o tlaleha phoso ena, ka kopo tlaleha hape nomoro ena ya ho sala "
+"morao e kgonahatsang hore o fumane seshene ya hao ho di-log ts "
+"efumanehang ho sistimi ya motsamaisi:"
+
+msgid "{logout:logout_all}"
+msgstr "E, ditshebeletso tsohle"
+
+msgid "{login:error_wrongpassword}"
+msgstr "Lebitso la mosebedisi kapa phasewete e fosahetse."
+
+msgid "SAML Subject"
+msgstr "Taba ya SAML"
+
+msgid "{logout:failedsps}"
+msgstr ""
+"Ha e kgone ho tswa tshebeletsong e le nngwe kapa ho feta. Ho netefatsa "
+"hore diseshene tsohle tsa hao di kwetswe, o kgothaletswa ho <i>kwala "
+"sebadi sa webo sa hao</i>."
+
+msgid "Completed"
+msgstr "E phethilwe"
+
+msgid "No RelayState"
+msgstr "Ha ho RelayState"
+
+msgid "Explain what you did when this error occurred..."
+msgstr "Hlalosa seo o se entseng ha phoso ena e ne e hlaha..."
+
+msgid ""
+"A service has requested you to authenticate yourself. Please enter your "
+"username and password in the form below."
+msgstr ""
+"Tshebeletso  e kopile hore o inetefatse. Ka kopo kenya lebitso la "
+"mosebedisi le phasewete ya hao foromong e ka tlase mona."
+
+msgid "{login:user_pass_header}"
+msgstr "Kenya lebitso la mosebedisi le phasewete"
+
+msgid ""
+"Either no user with the given username could be found, or the password "
+"you gave was wrong. Please check the username and try again."
+msgstr ""
+"Ekaba mosebedisi wa lebitso la mosebedisi le fanweng ha a fumanwe, kapa "
+"phasewete eo o e fananeng e fosahetse. Ka kopo hlahloba lebitso la "
+"mosebedisi la hao, ebe o leka hape."
+
+msgid "Change your home organization"
+msgstr "Fetola khampani ya lehae ya heno"
+
+msgid "Processing..."
+msgstr "E a sebetsa..."
+
+msgid "Metadata not found"
+msgstr "Metadata ha e a fumanwa"
+
+#, python-format
+msgid "Unable to locate metadata for %ENTITYID%"
+msgstr "Ha e kgone ho fumana metadata bakeng sa %ID YA SETHEO%"
+
+msgid "{status:some_error_occurred}"
+msgstr "Ho na le phoso e etsahetseng"
+
+msgid "{errors:debuginfo_text}"
+msgstr ""
+"Tlhahisoleseding ya debug e ka tlase mona e  ka nna ya kgahla motsamaisi "
+"/ deske ya thuso:"
+
+msgid "CAS Error"
+msgstr "Phoso ya CAS"
+
+msgid "The given page was not found. The reason was: %REASON%  The URL was: %URL%"
+msgstr ""
+"Leqephe le fanweng ha le a fumanwa. Lebaka e bile: %LEBAKA%  URL e bile: "
+"%URL%"
+
+msgid "Authentication failed: the certificate your browser sent is unknown"
+msgstr ""
+"Netefatso e hlolehile: setifikeiti se rometsweng ke sebadi sa hao ha se "
+"tsejwe"
+
+msgid ""
+"You sent something to the login page, but for some reason the password "
+"was not sent. Try again please."
+msgstr ""
+"o Rometse se seng leqepheng la ho kena, empa ka lebaka le sa tsejweng "
+"phaewete ha e a romelwa. Ka kopo leka hape."
+
+msgid "{errors:descr_CONFIG}"
+msgstr "SimpleSAMLphp e bonahala e hlophisitswe hampe."
+
+msgid "Page not found"
+msgstr "Leqephe ha le a fumanwa"
+
+msgid "{logout:logged_out_text}"
+msgstr "O ntshitswe."
+
+msgid "Error loading metadata"
+msgstr "Phoso ya ho louta metadata"
+
+msgid "{disco:selectidp}"
+msgstr "Kgetha mofani wa boitsebiso wa hao"
+
+msgid ""
+"This Identity Provider received an Authentication Request from a Service "
+"Provider, but an error occurred when trying to process the request."
+msgstr ""
+"Mofani enwa wa Boitsebiso o fumane Kopo ya Netefatso ho tswa ho Mofani wa"
+" Tshebeletso, empa ho bile le phoso ha ho leka ho fihlellwa kopo."
+
+msgid "{errors:descr_LDAPERROR}"
+msgstr ""
+"LDAP ke dathabeise ya mosebedisi, mme ha o leka ho kena, re hloka ho "
+"ikopanya le dathabeise ya LDAP. Phoso e hlahile ha re e leka lekgelong "
+"lena."
+
+msgid "{status:attributes_header}"
+msgstr "Makgabane a hao"
+
+msgid "{errors:report_email}"
+msgstr "Aterese ya imeile:"
+
+msgid ""
+"The parameters sent to the discovery service were not according to "
+"specifications."
+msgstr ""
+"Dipharamitha tse rometsweng tshebeltsong ya tshibollo di ne di se ho "
+"latela ditekanyetso."
+
+msgid "Remember my username"
+msgstr "Hopola lebitso la ka la mosebedisi"
+
+msgid ""
+"When this identity provider tried to create an authentication response, "
+"an error occurred."
+msgstr ""
+"Ha mofani enwa wa boitsebiso a leka ho theha karabelo ya netefatso, phoso"
+" e bile teng."
+
+msgid "{errors:title_METADATA}"
+msgstr "Phoso ya ho louta metadata"
+
+msgid "{errors:descr_NOTFOUND}"
+msgstr "Leqephe le fanweng ha le a fumanwa. URL e bile: %URL%"
+
+msgid "{errors:title_NOTFOUNDREASON}"
+msgstr "Leqephe ha le a fumanwa"
+
+msgid "{disco:select}"
+msgstr "Kgetha"
+
+msgid "{errors:descr_NOACCESS}"
+msgstr ""
+"Ntlha ya bofelo ha e a bulelwa. Hlahloba dikgetho tse tlhophisong ya hao "
+"ya SimpleSAMLphp."
+
+msgid "An error occurred when trying to create the SAML request."
+msgstr "Phoso e hlahile ha o leka ho theha kopo ya SAML."
+
+msgid "Yes, all services"
+msgstr "E, ditshebeletso tsohle"
+
+msgid "SimpleSAMLphp appears to be misconfigured."
+msgstr "SimpleSAMLphp e bonahala e hlophisitswe hampe."
+
+msgid "{errors:descr_NOCERT}"
+msgstr "Netefatso e hlolehile: sebadi sa hao ha se a romela setifikeiti sa letho"
+
+msgid "Password not set"
+msgstr "Phasewete ha e a setwa"
+
+msgid "Authentication aborted"
+msgstr "Netefatso e kgaoditswe"
+
+msgid "The authentication was aborted by the user"
+msgstr "Netefatso e kgaoditswe ke mosebedisi"
+
+msgid "Error processing response from Identity Provider"
+msgstr "Phoso ho sebetseng karabelo ho tswa ho Mofani wa Boitsebiso"
+
+msgid "{errors:report_submit}"
+msgstr "Romela tlaleho ya phoso"
+
+msgid "{errors:title_LDAPERROR}"
+msgstr "Phoso ya LDAP"
+
+msgid "{logout:progress}"
+msgstr "E a tswa..."
+
+msgid "Report errors"
+msgstr "Tlaleha diphoso"
+
+msgid "Login"
+msgstr "Ho kena"
+
+msgid "{errors:descr_USERABORTED}"
+msgstr "Netefatso e kgaoditswe ke mosebedisi"
+
+msgid "{logout:no}"
+msgstr "Tjhe"
+
+msgid "{disco:selectidp_full}"
+msgstr "Ka kopo kgetha mofani wa boitsebiso moo o batlang ho netefatsa:"
+
+msgid "{errors:descr_AUTHSOURCEERROR}"
+msgstr "Phoso ya tiiso mohloding %AUTHSOURCE%. Lebaka e bile: %REASON%"
+
+msgid "You did not present a valid certificate."
+msgstr "Ha o a fana ka setifikeiti se nepahetseng."
+
+msgid "Please select the identity provider where you want to authenticate:"
+msgstr "Ka kopo kgetha mofani wa boitsebiso moo o batlang ho netefatsa:"
+
+msgid "On hold"
+msgstr "Tshwarisitswe"
+
+msgid "An unhandled exception was thrown."
+msgstr "Kgeloho e sa rarollwang e lahlilwe."
+
+msgid "{login:remember_me}"
+msgstr "Nkgopole"
+
+msgid "No SAML message provided"
+msgstr "Ha ho molaetsa wa SAML o fanweng"
+
+msgid "{errors:title_INVALIDCERT}"
+msgstr "Setifikeiti se sa nepahalang"
+
+msgid "AuthData"
+msgstr "AuthData"
+
+msgid ""
+"Unable to log out of one or more services. To ensure that all your "
+"sessions are closed, you are encouraged to <i>close your webbrowser</i>."
+msgstr ""
+"Ha e kgone ho tswa tshebeletsong e le nngwe kapa ho feta. Ho netefatsa "
+"hore diseshene tsohle tsa hao di kwetswe, o kgothaletswa ho <i>kwala "
+"sebadi sa webo sa hao</i>."
+
+msgid "{login:user_pass_text}"
+msgstr ""
+"Tshebeletso  e kopile hore o inetefatse. Ka kopo kenya lebitso la "
+"mosebedisi le phasewete ya hao foromong e ka tlase mona."
+
+msgid "No"
+msgstr "Tjhe"
+
+msgid ""
+"LDAP is the user database, and when you try to login, we need to contact "
+"an LDAP database. An error occurred when we tried it this time."
+msgstr ""
+"LDAP ke dathabeise ya mosebedisi, mme ha o leka ho kena, re hloka ho "
+"ikopanya le dathabeise ya LDAP. Phoso e hlahile ha re e leka lekgelong "
+"lena."
+
+msgid "{status:intro}"
+msgstr ""
+"Dumela, lena ke leqephe la boemo la SimpleSAMLphp. Mona o ka bona hore na"
+" seshene ya hao e feletswe ke nako na, hore e nka nako e kae hore e "
+"fellwe ke nako le makgabane ohle a hoketsweng sesheneng ya hao."
+
+msgid "Logging out of the following services:"
+msgstr "E tswa ditshebeletsong tse latelang:"
+
+msgid "{status:subject_header}"
+msgstr "Taba ya SAML"
+
+msgid "{errors:title_GENERATEAUTHNRESPONSE}"
+msgstr "Ha e a kgona ho theha karabelo ya ntefatso"
+
+msgid "{errors:title_NOACCESS}"
+msgstr "Ha ho phihlello"
+
+msgid "{errors:title_NOCERT}"
+msgstr "Ha ho setifikeiti"
+
+msgid "{disco:remember}"
+msgstr "Hopola kgetho ya ka"
+
+msgid "{logout:completed}"
+msgstr "E phethilwe"
+
+msgid ""
+"This endpoint is not enabled. Check the enable options in your "
+"configuration of SimpleSAMLphp."
+msgstr ""
+"Ntlha ya bofelo ha e a bulelwa. Hlahloba dikgetho tse tlhophisong ya hao "
+"ya SimpleSAMLphp."
+
+msgid "{login:error_nopassword}"
+msgstr ""
+"o Rometse se seng leqepheng la ho kena, empa ka lebaka le sa tsejweng "
+"phaewete ha e a romelwa. Ka kopo leka hape."
+
+msgid "{status:header_shib}"
+msgstr "Pontsho ya Shibboleth"
+
+msgid "Session size: %SIZE%"
+msgstr "Saese ya seshene: %SIZE%"
+
+msgid ""
+"Hi, this is the status page of SimpleSAMLphp. Here you can see if your "
+"session is timed out, how long it lasts until it times out and all the "
+"attributes that are attached to your session."
+msgstr ""
+"Dumela, lena ke leqephe la boemo la SimpleSAMLphp. Mona o ka bona hore na"
+" seshene ya hao e feletswe ke nako na, hore e nka nako e kae hore e "
+"fellwe ke nako le makgabane ohle a hoketsweng sesheneng ya hao."
+
+msgid "{general:no}"
+msgstr "Tjhe"
+
+msgid "{errors:title_NOTFOUND}"
+msgstr "Leqephe ha le a fumanwa"
+
+msgid ""
+"You accessed the Single Sign On Service interface, but did not provide a "
+"SAML Authentication Request. Please note that this endpoint is not "
+"intended to be accessed directly."
+msgstr ""
+"O fihletse tshebeletsano ya Tshaeno ya Hang, empa ha o a fan aka Kopo ya "
+"Netefatso ya SAML. Ka kopo lemoha hore ntlha ena ya bofelo ha e a rerelwa"
+" ho fihlellwa ka kotloloho."
+
+msgid "LDAP Error"
+msgstr "Phoso ya LDAP"
+
+msgid "You are now successfully logged out from %SP%."
+msgstr "Jwale o ntshitswe ka katleho ho %SP%."
+
+msgid "Error creating request"
+msgstr "Phoso ho thehweng ha kopo"
+
+msgid "We did not accept the response sent from the Identity Provider."
+msgstr "Ha re a amohela karabelo ho tswa ho Mofani wa Boitsebiso."
+
+msgid "{errors:title_SSOPARAMS}"
+msgstr "Ha ho kopo ya SAML e fanweng"
+
+msgid ""
+"You have chosen <b>%HOMEORG%</b> as your home organization. If this is "
+"wrong you may choose another one."
+msgstr ""
+"O kgethile <b>%HOMEORG%</b> jwalo ka khampani ya lehae ya heno. Haeba "
+"sena se fosahetse o ka kgetha e nngwe hape."
+
+msgid "{logout:logout_only}"
+msgstr "Tjhe, %SP% feela"
+
+msgid "There is an error in the request to this page. The reason was: %REASON%"
+msgstr "Ho na le phoso kopong e leqepheng lena. Lebaka e bile: %REASON%"
+
+msgid "{status:authData_header}"
+msgstr "AuthData"
+
+msgid "{errors:descr_WRONGUSERPASS}"
+msgstr ""
+"Ekaba mosebedisi wa lebitso la mosebedisi le fanweng ha a fumanwe, kapa "
+"phasewete eo o e fananeng e fosahetse. Ka kopo hlahloba lebitso la "
+"mosebedisi la hao, ebe o leka hape."
+
+msgid "Unknown certificate"
+msgstr "Setifikeiti se sa tsejweng"
+
+msgid "SimpleSAMLphp Diagnostics"
+msgstr "Dimanollo tsa SimpleSAMLphp"
+
+msgid "{login:help_header}"
+msgstr "Thuso! Ha ke hopole phasewete ya ka."
+
+msgid "Incorrect username or password."
+msgstr "Lebitso la mosebedisi kapa phasewete e fosahetse."
+
+msgid "{errors:descr_NOTSET}"
+msgstr ""
+"Phasewete ya tlhophiso (auth.adminpassword) ha e a fetolwa ho tswa palong"
+" ya tlwaelo. Ka kopo edita faele ya tlhophiso."
+
+msgid "{login:next}"
+msgstr "E latelang"
+
+msgid "Shibboleth demo"
+msgstr "Pontsho ya Shibboleth"
+
+msgid "{logout:incapablesps}"
+msgstr ""
+"E le nngwe kapa ho feta ya ditshebeletso tseo o keneng ho tsona <i>ha e "
+"tshehetse ho tswa</i>. Ho netefatsa hore diseshene tsohle tsa hao di "
+"kwetswe, o kgothaletswa ho <i>kwala sebadi sa webo sa hao</i>."
+
+msgid "{status:subject_notset}"
+msgstr "ha e a setwa"
+
+msgid "{disco:login_at}"
+msgstr "Kena ho"
+
+msgid "Could not create authentication response"
+msgstr "Ha e a kgona ho theha karabelo ya ntefatso"
+
+msgid "Some error occurred"
+msgstr "Ho na le phoso e etsahetseng"
+
+msgid ""
+"You accessed the Artifact Resolution Service interface, but did not "
+"provide a SAML ArtifactResolve message. Please note that this endpoint is"
+" not intended to be accessed directly."
+msgstr ""
+"O fihletse kopano ya Tshebeletso ya Tlhakiso ya Athifekte, empa ha o a "
+"fana ka molaetsa wa SAML ArtifactResolve. Ka kopo lemoha hore ntlha ena "
+"ya bofelo ha e a rerelwa ho fihlellwa ka kotloloho."
+
+msgid "{errors:title_CASERROR}"
+msgstr "Phoso ya CAS"
+
+msgid "SimpleSAMLphp error"
+msgstr "Phoso ya SimpleSAMLphp"
+
+msgid "{errors:errorreport_text}"
+msgstr "Tlaleho ya phoso e rometswe ho batsamaisi."
+
+msgid "{errors:title_NOSTATE}"
+msgstr "Tlhahisoleseding ya provense e lahlehile"
+
+msgid "{errors:descr_CASERROR}"
+msgstr "Phoso e bile teng ka seva ya CAS."
+
+msgid "{errors:descr_ACSPARAMS}"
+msgstr ""
+"O fihletse kopano ya Tiiso ya Tshebeletso ya Bareki, empa ha o a fana ka "
+"Karabelo ya Netefatso ya SAML. Ka kopo lemoha hore ntlha ena ya bofelo ha"
+" e a rerelwa ho fihlellwa ka kotloloho."
+
+msgid "Service Provider"
+msgstr "Mofani wa Tshebeletso"
+
+msgid "{login:error_header}"
+msgstr "Phoso"
+
+msgid ""
+"Without your username and password you cannot authenticate yourself for "
+"access to the service. There may be someone that can help you. Consult "
+"the help desk at your organization!"
+msgstr ""
+"Ntle le lebitso l ahao la mosebedisi le phasewete o ke ke wa inetefatsa "
+"bakeng sa phihlello ho tshebeletso. Ho ka nna ha ba le motho ya ka o "
+"thusang. Ikopanye le ba deske ya thuso khampaning ya heno!"
+
+msgid "{login:password}"
+msgstr "Phasewete"
+
+msgid "not set"
+msgstr "ha e a setwa"
+
+msgid ""
+"The information about the current logout operation has been lost. You "
+"should return to the service you were trying to log out from and try to "
+"log out again. This error can be caused by the logout information "
+"expiring. The logout information is stored for a limited amout of time - "
+"usually a number of hours. This is longer than any normal logout "
+"operation should take, so this error may indicate some other error with "
+"the configuration. If the problem persists, contact your service "
+"provider."
+msgstr ""
+"Tlhahisoleseding e mabapi le tshebetos ya ho tswa ya hajwale e lahlehile."
+" O tlameha ho kgutlela tshebeletsong eo o neng o leka ho tswa ho yona le "
+"ho leka ho tswa hape. Phoso ena e ka bakwa ke phelo nako ya "
+"tlhahisoleseding ya ho tswa. Tlhahisoleseding ya ho tswa e bolokwa nako e"
+" lekantsweng - ka tlwaelo ke palo ya dihora. Sena se setelele ho feta "
+"nako eo tshebetso efe kapa efe ya tlwaelo ya ho tswa e tlamehang ho e "
+"nka, ka hona phoso ena e ka nna ya bontsha phoso e nngwe ka tlhophiso "
+"esele. Haeba bothata bo phehella, ikopanye le mofani wa tshebeletso wa "
+"hao."
+
+msgid "{general:yes_continue}"
+msgstr "E, tswela pele"
+
+msgid "{login:help_text}"
+msgstr ""
+"Ntle le lebitso l ahao la mosebedisi le phasewete o ke ke wa inetefatsa "
+"bakeng sa phihlello ho tshebeletso. Ho ka nna ha ba le motho ya ka o "
+"thusang. Ikopanye le ba deske ya thuso khampaning ya heno!"
+
+msgid "Next"
+msgstr "E latelang"
+
+msgid "Your attributes"
+msgstr "Makgabane a hao"
+
+msgid "{login:help_desk_link}"
+msgstr "Leqephe la lapeng la ba deske ya thuso"
+
+msgid "Logout failed"
+msgstr "Ho tswa ho hlolehile"
+
+msgid "You have been logged out."
+msgstr "O ntshitswe."
+
+msgid ""
+"There is some misconfiguration of your SimpleSAMLphp installation. If you"
+" are the administrator of this service, you should make sure your "
+"metadata configuration is correctly setup."
+msgstr ""
+"Ho na le tlhophiso e fosahetseng ya kenyo ya ho instola SimpleSAMLphp ya "
+"hao. Haeba o motsamaisi wa tshebeletso ena, o tlameha ho etsa bonnete ba "
+"hore tlhophiso ya metadata ya hao e setilwe ka nepo."
+
+msgid "Authentication failed: your browser did not send any certificate"
+msgstr "Netefatso e hlolehile: sebadi sa hao ha se a romela setifikeiti sa letho"
+
+msgid "{login:processing}"
+msgstr "E a sebetsa..."
+
+msgid "Send e-mail to help desk"
+msgstr "Romela imeile ho ba deske ya thuso"
+
+msgid "{errors:descr_BADREQUEST}"
+msgstr "Ho na le phoso kopong e leqepheng lena. Lebaka e bile: %REASON%"
+
+msgid "How to get help"
+msgstr "Ka moo o ka fumanang thuso"
+
+msgid "Choose your home organization"
+msgstr "Kgetha khampani ya lehae ya hao"
+
+msgid "Go back to SimpleSAMLphp installation page"
+msgstr "Kgutlela leqepheng la ho instola la SimpleSAMLphp"
+
+msgid "{errors:title_NOTVALIDCERT}"
+msgstr "Setifikeiti se sa tshwaneleheng"
+
+msgid "Cannot retrieve session data"
+msgstr "Ha e a kgona ho fumana datha ya seshene"
+
+msgid "{disco:icon_prefered_idp}"
+msgstr "[Kgetho e kgethwang]"
+
+msgid "{login:login_button}"
+msgstr "Ho kena"
+
+msgid "Do you want to logout from all the services above?"
+msgstr "Na o batla ho tswa ditshebeletsong tsohle tse ka hodimo moo?"
+
+msgid "{errors:descr_UNHANDLEDEXCEPTION}"
+msgstr "Kgeloho e sa rarollwang e lahlilwe."
+
+msgid "{errors:descr_DISCOPARAMS}"
+msgstr ""
+"Dipharamitha tse rometsweng tshebeltsong ya tshibollo di ne di se ho "
+"latela ditekanyetso."
+
+msgid "{errors:descr_MEMCACHEDOWN}"
+msgstr ""
+"Datha ya seshene ya hao ha e kgone ho fumanwa hona jwale ka lebaka la "
+"mathata a sethekeniki. Ka kopo leka hape kamora metsotso e mmalwa."
+
+msgid "Error received from Identity Provider"
+msgstr "Phoso e amohetswe ho tswa ho Mofani wa Boitsebiso"
+
+msgid "Configuration error"
+msgstr "Phoso ya Netefatso"
+
+msgid "Send error report"
+msgstr "Romela tlaleho ya phoso"
+
+msgid "Logout information lost"
+msgstr "Tlhahisoleseding ya ho tswa e lahlehile"
+
+msgid "{status:header_diagnostics}"
+msgstr "Dimanollo tsa SimpleSAMLphp"
+
+msgid "{errors:report_trackid}"
+msgstr ""
+"Haeba o tlaleha phoso ena, ka kopo tlaleha hape nomoro ena ya ho sala "
+"morao e kgonahatsang hore o fumane seshene ya hao ho di-log ts "
+"efumanehang ho sistimi ya motsamaisi:"
+
+msgid "Bad request received"
+msgstr "Kopo e mpe e amohetswe"
+
+msgid "{errors:descr_PROCESSAUTHNREQUEST}"
+msgstr ""
+"Mofani enwa wa Boitsebiso o fumane Kopo ya Netefatso ho tswa ho Mofani wa"
+" Tshebeletso, empa ho bile le phoso ha ho leka ho fihlellwa kopo."
+
+msgid "State information lost"
+msgstr "Tlhahisoleseding ya provense e lahlehile"
+
+msgid "The given page was not found. The URL was: %URL%"
+msgstr "Leqephe le fanweng ha le a fumanwa. URL e bile: %URL%"
+
+msgid "{errors:descr_RESPONSESTATUSNOSUCCESS}"
+msgstr ""
+"Mofani wa Boitsebiso o arabetse ka phoso. (Khoutu ya boemo Karabelong ya "
+"SAML ha e a atleha)"
+
+msgid "{login:change_home_org_button}"
+msgstr "Kgetha khampani ya lehae"
+
+msgid "SAML 2.0 SP Demo Example"
+msgstr "Mohlala wa Pontsho wa SAML 2.0 SP"
+
+msgid "{logout:also_from}"
+msgstr "Hape o kene ditshebeletsong tsena:"
+
+msgid "{errors:howto_text}"
+msgstr ""
+"Mohlomong phoso ena e ka lebaka la boitshwaro bo itseng bo sa lebellwang "
+"kapa tlhophiso e fosahetseng ya SimpleSAMLphp. Ikopanye le motsamaisi wa "
+"tshebeletso ena ya ho kena, ebe o romela molaetsa wa phoso ka hodimo "
+"mona."
+
+msgid "You are also logged in on these services:"
+msgstr "Hape o kene ditshebeletsong tsena:"
+
+msgid "No certificate"
+msgstr "Ha ho setifikeiti"
+
+msgid ""
+"This error probably is due to some unexpected behaviour or to "
+"misconfiguration of SimpleSAMLphp. Contact the administrator of this "
+"login service, and send them the error message above."
+msgstr ""
+"Mohlomong phoso ena e ka lebaka la boitshwaro bo itseng bo sa lebellwang "
+"kapa tlhophiso e fosahetseng ya SimpleSAMLphp. Ikopanye le motsamaisi wa "
+"tshebeletso ena ya ho kena, ebe o romela molaetsa wa phoso ka hodimo "
+"mona."
+
+msgid "{errors:errorreport_header}"
+msgstr "Tlaleho ya phoso e rometswe"
+
+msgid "Logged out"
+msgstr "O ntshitswe"
+
+msgid "{login:remember_username}"
+msgstr "Hopola lebitso la ka la mosebedisi"
+
+msgid "No SAML request provided"
+msgstr "Ha ho kopo ya SAML e fanweng"
+
+msgid "{errors:title_USERABORTED}"
+msgstr "Netefatso e kgaoditswe"
+
+msgid "{errors:title_PROCESSASSERTION}"
+msgstr "Phoso ho sebetseng karabelo ho tswa ho Mofani wa Boitsebiso"
+
+msgid "Enter your username and password"
+msgstr "Kenya lebitso la mosebedisi le phasewete"
+
+msgid "[Preferred choice]"
+msgstr "[Kgetho e kgethwang]"
+
+msgid "{status:header_saml20_sp}"
+msgstr "Mohlala wa Pontsho wa SAML 2.0 SP"
+
+msgid "{logout:loggedoutfrom}"
+msgstr "Jwale o ntshitswe ka katleho ho %SP%."
+
+msgid "{status:sessionsize}"
+msgstr "Saese ya seshene: %SIZE%"
+
+msgid "{status:validfor}"
+msgstr ""
+"Seshene ya hao e na le matla feela bakeng sa metsotswana e %SECONDS% ho "
+"tloha hona jwale."
+
+msgid "Help desk homepage"
+msgstr "Leqephe la lapeng la ba deske ya thuso"
+
+msgid "{login:username}"
+msgstr "Lebitso la mosebedisi"
+
+msgid "{errors:descr_NOTFOUNDREASON}"
+msgstr ""
+"Leqephe le fanweng ha le a fumanwa. Lebaka e bile: %LEBAKA%  URL e bile: "
+"%URL%"
+
+msgid "{errors:error_header}"
+msgstr "Phoso ya SimpleSAMLphp"
+
+msgid ""
+"The password in the configuration (auth.adminpassword) is not changed "
+"from the default value. Please edit the configuration file."
+msgstr ""
+"Phasewete ya tlhophiso (auth.adminpassword) ha e a fetolwa ho tswa palong"
+" ya tlwaelo. Ka kopo edita faele ya tlhophiso."
+
+msgid "Error processing request from Service Provider"
+msgstr "Phoso ho sebetseng kopo ho tswa ho Mofani wa Tshebeletso"
+
+msgid "Login at"
+msgstr "Kena ho"
+
+msgid ""
+"The debug information below may be of interest to the administrator / "
+"help desk:"
+msgstr ""
+"Tlhahisoleseding ya debug e ka tlase mona e  ka nna ya kgahla motsamaisi "
+"/ deske ya thuso:"
+
+msgid ""
+"Authentication failed: the certificate your browser sent is invalid or "
+"cannot be read"
+msgstr ""
+"Netefatso e hlolehile: setifikeiti seo sebadi sa hao se se rometseng ha "
+"se a nepahala kapa ha se balehe"
+
+msgid "{errors:descr_INVALIDCERT}"
+msgstr ""
+"Netefatso e hlolehile: setifikeiti seo sebadi sa hao se se rometseng ha "
+"se a nepahala kapa ha se balehe"
+
+msgid "No, only %SP%"
+msgstr "Tjhe, %SP% feela"
+
+msgid "Invalid certificate"
+msgstr "Setifikeiti se sa nepahalang"
+
+msgid "Logging out..."
+msgstr "E a tswa..."
+
+msgid "Error processing the Logout Request"
+msgstr "Phoso ho sebetseng Kopo ya Ho Tswa"
+
+msgid ""
+"The initiator of this request did not provide a RelayState parameter "
+"indicating where to go next."
+msgstr ""
+"Moqadi wa kopo ena ha a fana pharamitha ya RelayState e bontshang hore ho"
+" uwe kae ho tloha mona."
+
+msgid "Remember me"
+msgstr "Nkgopole"
+
+msgid "{errors:descr_LOGOUTINFOLOST}"
+msgstr ""
+"Tlhahisoleseding e mabapi le tshebetos ya ho tswa ya hajwale e lahlehile."
+" O tlameha ho kgutlela tshebeletsong eo o neng o leka ho tswa ho yona le "
+"ho leka ho tswa hape. Phoso ena e ka bakwa ke phelo nako ya "
+"tlhahisoleseding ya ho tswa. Tlhahisoleseding ya ho tswa e bolokwa nako e"
+" lekantsweng - ka tlwaelo ke palo ya dihora. Sena se setelele ho feta "
+"nako eo tshebetso efe kapa efe ya tlwaelo ya ho tswa e tlamehang ho e "
+"nka, ka hona phoso ena e ka nna ya bontsha phoso e nngwe ka tlhophiso "
+"esele. Haeba bothata bo phehella, ikopanye le mofani wa tshebeletso wa "
+"hao."
+
+msgid "{errors:descr_NOTVALIDCERT}"
+msgstr "Ha o a fana ka setifikeiti se nepahetseng."
+
+msgid "State information lost, and no way to restart the request"
+msgstr ""
+"Tlhahisoleeding ya porofensi e lahlehile, mmeha ho tsela ya ho qala kopo "
+"botjha"
+
+msgid "Error report sent"
+msgstr "Tlaleho ya phoso e rometswe"
+
+msgid "Select your identity provider"
+msgstr "Kgetha mofani wa boitsebiso wa hao"
+
+msgid ""
+"Your session data cannot be retrieved right now due to technical "
+"difficulties. Please try again in a few minutes."
+msgstr ""
+"Datha ya seshene ya hao ha e kgone ho fumanwa hona jwale ka lebaka la "
+"mathata a sethekeniki. Ka kopo leka hape kamora metsotso e mmalwa."
+
+msgid "{errors:descr_NORELAYSTATE}"
+msgstr ""
+"Moqadi wa kopo ena ha a fana pharamitha ya RelayState e bontshang hore ho"
+" uwe kae ho tloha mona."
+
+msgid "{errors:descr_LOGOUTREQUEST}"
+msgstr "Phoso e hlahile ha e leka ho sebetsa Kopo ya Ho Tswa."
+
+msgid "{errors:title_LOGOUTREQUEST}"
+msgstr "Phoso ho sebetseng Kopo ya Ho Tswa"
+
+msgid "{errors:title_ARSPARAMS}"
+msgstr "Ha ho molaetsa wa SAML o fanweng"
+
+#, python-format
+msgid "Your session is valid for %SECONDS% seconds from now."
+msgstr ""
+"Seshene ya hao e na le matla feela bakeng sa metsotswana e %SECONDS% ho "
+"tloha hona jwale."
+
+msgid "{errors:title_LOGOUTINFOLOST}"
+msgstr "Tlhahisoleseding ya ho tswa e lahlehile"
+
+msgid "You have previously chosen to authenticate at"
+msgstr "O qadile ka ho kgetha netefatso ho"
+
+msgid "{login:change_home_org_text}"
+msgstr ""
+"O kgethile <b>%HOMEORG%</b> jwalo ka khampani ya lehae ya heno. Haeba "
+"sena se fosahetse o ka kgetha e nngwe hape."
+
+msgid "Choose home organization"
+msgstr "Kgetha khampani ya lehae"
+
+msgid "Error"
+msgstr "Phoso"
+
+msgid "{errors:descr_METADATANOTFOUND}"
+msgstr "Ha e kgone ho fumana metadata bakeng sa %ID YA SETHEO%"
+
+msgid "{errors:title_METADATANOTFOUND}"
+msgstr "Metadata ha e a fumanwa"
+
+msgid "{logout:return}"
+msgstr "E kgutlela tshebeletsong"
+
+msgid "{errors:descr_CREATEREQUEST}"
+msgstr "Phoso e hlahile ha o leka ho theha kopo ya SAML."
+
+msgid "Unhandled exception"
+msgstr "Mokgelo o sa rarollwang"
+
+msgid "{status:authData_summary}"
+msgstr "Tlelika ho sheba AuthData"
+
+msgid "No SAML response provided"
+msgstr "Ha ho karabelo ya SAML e fanweng"
+
+msgid "Click to view AuthData"
+msgstr "Tlelika ho sheba AuthData"
+
+msgid "{logout:default_link_text}"
+msgstr "Kgutlela leqepheng la ho instola la SimpleSAMLphp"
+
+msgid "Logout"
+msgstr "Ho tswa"
+
+msgid ""
+"Optionally enter your email address, for the administrators to be able "
+"contact you for further questions about your issue:"
+msgstr ""
+"Ka boikgethelo o ka kenya aterse ya imeile ya hao, bakeng sa batsamaisi "
+"hore ba kgone ho ikopanya le wena mabapi le dipotso tse ding ka ditaba "
+"tsa hao:"
+
+msgid "{general:remember}"
+msgstr "Hopola"
+
+msgid "An error occurred when trying to process the Logout Request."
+msgstr "Phoso e hlahile ha e leka ho sebetsa Kopo ya Ho Tswa."
+
+msgid "{errors:descr_METADATA}"
+msgstr ""
+"Ho na le tlhophiso e fosahetseng ya kenyo ya ho instola SimpleSAMLphp ya "
+"hao. Haeba o motsamaisi wa tshebeletso ena, o tlameha ho etsa bonnete ba "
+"hore tlhophiso ya metadata ya hao e setilwe ka nepo."
+
+msgid "Yes, continue"
+msgstr "E"
+
+msgid "{errors:descr_NOSTATE}"
+msgstr ""
+"Tlhahisoleeding ya porofensi e lahlehile, mmeha ho tsela ya ho qala kopo "
+"botjha"
+
+msgid "{errors:title_MEMCACHEDOWN}"
+msgstr "Ha e a kgona ho fumana datha ya seshene"
+
+msgid "Username"
+msgstr "Lebitso la mosebedisi"
+
+msgid "{login:select_home_org}"
+msgstr "Kgetha khampani ya lehae ya hao"
+
+msgid "Error when communicating with the CAS server."
+msgstr "Phoso e bile teng ka seva ya CAS."
+
+msgid "No, cancel"
+msgstr "Tjhe"
+

--- a/modules/core/dictionaries/cardinality.translation.json
+++ b/modules/core/dictionaries/cardinality.translation.json
@@ -6,6 +6,7 @@
     "no": "Ugyldige atributter",
     "zu": "Izici Ezingalungile",
     "xh": "Iimpawu Ezingachanekanga",
+    "st": "Makgabane a Fosahetseng",
     "ca": "Atributs incorrectes"
   },
   "cardinality_text": {
@@ -15,6 +16,7 @@
     "no": "Én eller flere atributter levert av din identitetsleverandør har ikke så mange verdier som forventes.",
     "zu": "Isici esisodwa noma ngaphezulu esinikezwe umhlinzeki wakho kamazisi asizange siqukathe inani lezinombolo ezilindelwe.",
     "xh": "Uphawu olunye okanye olungakumbi olunikelwe ngumboonelei wesazisi sakho aluqulethanga inani lamaxabiso alindelekileyo.",
+    "st": "E le nngwe kapa ho feta ya makgabane a fanweng ke wena ke mofani wa boitsebiso wa hao ha e na lenane le nepahetseng la dipalo.",
     "ca": "Un o més dels atributs facilitats pel vostre proveïdor d’identitat no contenia el nombre de valors esperat."
   },
   "problematic_attributes": {
@@ -24,6 +26,7 @@
     "no": "De ugyldige atributter er:",
     "zu": "Isici(izici) esiyinkinga sithi:",
     "xh": "Iimpawu eziyingxaki zezi:",
+    "st": "Makgabane a nang le mathata ke:",
     "ca": "Els atributs problemàtics són:"
   },
   "got_want": {
@@ -33,6 +36,7 @@
     "no": "har %GOT% verdier, forventer %WANT%",
     "zu": "uthole amanani angu-%GOT%, ufuna %WANT%",
     "xh": "kukho amaxabiso e-%GOT%, sifuna %WANT%",
+    "st": "o fumane dipalo tse %GOT%, o batla tse %WANT%",
     "ca": "tens %GOT% valors, desitjats %WANT%"
   }
 }

--- a/modules/core/dictionaries/no_cookie.translation.json
+++ b/modules/core/dictionaries/no_cookie.translation.json
@@ -32,6 +32,7 @@
 		"el": "\u03a0\u03c1\u03cc\u03b2\u03bb\u03b7\u03bc\u03b1 \u03bb\u03b5\u03b9\u03c4\u03bf\u03c5\u03c1\u03b3\u03af\u03b1\u03c2 cookie",
 		"xh": "Ikhuki engekhoyo",
 		"zu": "Ikhukhi engatholakali",
+		"st": "Khukhi e siyo",
 		"ca": "Falta la cookie"
 	},
 	"description": {
@@ -67,6 +68,7 @@
 		"el": "\u0395\u03bd\u03b4\u03ad\u03c7\u03b5\u03c4\u03b1\u03b9 \u03c4\u03b1 cookie \u03c4\u03bf\u03c5 \u03c0\u03c1\u03bf\u03b3\u03c1\u03ac\u03bc\u03bc\u03b1\u03c4\u03bf\u03c2 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03ae\u03c2 \u03c3\u03b1\u03c2 \u03bd\u03b1 \u03ad\u03c7\u03bf\u03c5\u03bd \u03b1\u03c0\u03b5\u03bd\u03b5\u03c1\u03b3\u03bf\u03c0\u03bf\u03b9\u03b7\u03b8\u03b5\u03af. \u03a0\u03b1\u03c1\u03b1\u03ba\u03b1\u03bb\u03bf\u03cd\u03bc\u03b5 \u03b5\u03bb\u03ad\u03b3\u03be\u03c4\u03b5 \u03c4\u03b9\u03c2 \u03c3\u03c7\u03b5\u03c4\u03b9\u03ba\u03ad\u03c2 \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03b9\u03c2 \u03ba\u03b1\u03b9 \u03ba\u03b1\u03b9 \u03b4\u03bf\u03ba\u03b9\u03bc\u03ac\u03c3\u03c4\u03b5 \u03be\u03b1\u03bd\u03ac.",
 		"xh": "Ubonakala uzenze azasebenza iikhuki kwibhrawuza yakho. Nceda ujonge iisetingi ezikwibhrawuza yakho, uzame kwakhona.",
 		"zu": "Kubonakala sengathi uyekise amakhukhi kusiphequluli sakho. Sicela uhlole amasethingi kusiphequluli sakho, bese uzame futhi.",
+		"st": "O bonahala o kwetse dikhukhi sebading sa hao. Ka kopo hlahloba disetting sebading sa hao.",
 		"ca": "Sembla que heu desactivat les cookies al vostre navegador. Comproveu la configuració del vostre navegador i torneu-ho a provar."
 	},
 	"retry": {
@@ -102,6 +104,7 @@
 		"el": "\u0394\u03bf\u03ba\u03b9\u03bc\u03ac\u03c3\u03c4\u03b5 \u03be\u03b1\u03bd\u03ac",
 		"zu": "Zama futhi",
 		"xh": "Zama kwakhona",
+		"st": "Khukhi e siyo",
 		"ca": "Torna a provar"
 	}
 }

--- a/modules/core/dictionaries/no_metadata.translation.json
+++ b/modules/core/dictionaries/no_metadata.translation.json
@@ -31,6 +31,7 @@
 		"el": "\u0394\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b1\u03bd \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03b1",
 		"zu": "Imethadatha ayitholakali",
 		"xh": "I-Metadata ayifunyenwanga",
+		"st": "Metadata ha e a fumanwa",
 		"ca": "No s'han trobat les metadades"
 	},
 	"not_found_for": {
@@ -65,6 +66,7 @@
 		"el": "\u0394\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03cc \u03bd\u03b1 \u03b2\u03c1\u03b5\u03b8\u03bf\u03cd\u03bd \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03b1 \u03b3\u03b9\u03b1 \u03c4\u03b7\u03bd \u03bf\u03bd\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1:",
 		"xh": "Asikwazanga ukufumana imetadata ye-entithi:",
 		"zu": "Asikwazanga ukuthola imethadatha yenhlangano:",
+		"st": "Ha re a kgona ho fumana metadata bakeng sa setheo:",
 		"ca": "No hem pogut localitzar les metadades de l’entitat:"
 	},
 	"config_problem": {
@@ -99,6 +101,7 @@
 		"el": "\u0391\u03c5\u03c4\u03cc \u03c5\u03c0\u03bf\u03b4\u03b5\u03b9\u03ba\u03bd\u03cd\u03b5\u03b9 \u03c0\u03c1\u03cc\u03b2\u03bb\u03b7\u03bc\u03b1 \u03bc\u03b5 \u03c4\u03b9\u03c2 \u03c1\u03c5\u03b8\u03bc\u03af\u03c3\u03b5\u03b9\u03c2 \u03b5\u03af\u03c4\u03b5 \u03c4\u03bf\u03c5 \u03c0\u03b1\u03c1\u03cc\u03c7\u03bf\u03c5 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd \u03b5\u03af\u03c4\u03b5 \u03c4\u03bf\u03c5 \u03c0\u03b1\u03c1\u03cc\u03c7\u03bf\u03c5 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2.",
 		"xh": "Kusenokwenzeka yingxaki yolungiselelo kumboneleli wenkonzo okanye umboneleli wesazisi.",
 		"zu": "Lokhu kungenzeka ukuthi kubangelwa inkinga yomiso yomhlinzeki wesevisi noma umhlinzeki kamazisi.",
+		"st": "Bona ke bothata bo ka kgonahalang ka ho fetisisa ho mofani wa tshebeletso kapa mofani wa tshebeletso.",
 		"ca": "Aquest és probablement un problema de configuració del proveïdor de serveis o del proveïdor d’identitat."
 	},
 	"suggestion_user_link": {
@@ -133,6 +136,7 @@
 		"el": "\u0391\u03bd \u03bb\u03ac\u03b2\u03b1\u03c4\u03b5 \u03b1\u03c5\u03c4\u03cc \u03c4\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03b1\u03ba\u03bf\u03bb\u03bf\u03c5\u03b8\u03ce\u03bd\u03c4\u03b1\u03c2 \u03ad\u03bd\u03b1\u03bd \u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03bc\u03bf \u03c3\u03b5 \u03ba\u03ac\u03c0\u03bf\u03b9\u03bf\u03bd \u03b9\u03c3\u03c4\u03cc\u03c4\u03bf\u03c0\u03bf, \u03b8\u03b1 \u03c0\u03c1\u03ad\u03c0\u03b5\u03b9 \u03bd\u03b1 \u03c4\u03bf \u03b1\u03bd\u03b1\u03c6\u03ad\u03c1\u03b5\u03c4\u03b5 \u03c3\u03c4\u03bf\u03bd \u03b9\u03b4\u03b9\u03bf\u03ba\u03c4\u03ae\u03c4\u03b7 \u03c4\u03bf\u03c5 \u03b5\u03bd \u03bb\u03cc\u03b3\u03c9 \u03b9\u03c3\u03c4\u03cc\u03c4\u03bf\u03c0\u03bf\u03c5.",
 		"xh": "Ukuba ngaba ungumsebenzisi ofumene le mpazamo emva kokulandela ilinki kwisayithi, ufanele uchaze le mpazamo kumnini walo sayithi.",
 		"zu": "Uma ungumsebenzisi othole leli phutha ngemva kokulandela ilinki ekusayithi, kufanele ubike leli phutha kumnikazi waleyo sayithi.",
+		"st": "Haeba o le mosebedisi ya fumaneng phoso ena kamora ho latela lehokela le setsing, o tlameha ho tlaleha phoso ena ho monga setsi.",
 		"ca": "Si sou un usuari que ha rebut aquest error després de seguir un enllaç d’un lloc, haureu d’informar d’aquest error al propietari del lloc."
 	},
 	"suggestion_developer": {
@@ -167,6 +171,7 @@
 		"el": "\u0395\u03ac\u03bd \u03b5\u03af\u03c3\u03c4\u03b5 \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ae\u03c2 \u03c4\u03b7\u03c2 \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03af\u03b1\u03c2 \u03c4\u03b1\u03c5\u03c4\u03bf\u03c0\u03bf\u03af\u03b7\u03c3\u03b7\u03c2 \u03ba\u03b1\u03b9 \u03b5\u03be\u03bf\u03c5\u03c3\u03b9\u03bf\u03b4\u03cc\u03c4\u03b7\u03c3\u03b7\u03c2, \u03c4\u03cc\u03c4\u03b5 \u03b1\u03bd\u03c4\u03b9\u03bc\u03b5\u03c4\u03c9\u03c0\u03af\u03b6\u03b5\u03c4\u03b5 \u03ba\u03ac\u03c0\u03bf\u03b9\u03bf \u03c0\u03c1\u03cc\u03b2\u03bb\u03b7\u03bc\u03b1 \u03bc\u03b5 \u03c4\u03b7 \u03b4\u03b9\u03b1\u03bc\u03cc\u03c1\u03c6\u03c9\u03c3\u03b7 \u03c4\u03c9\u03bd \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03c9\u03bd. \u0392\u03b5\u03b2\u03b1\u03b9\u03c9\u03b8\u03b5\u03af\u03c4\u03b5 \u03cc\u03c4\u03b9 \u03c4\u03b1 \u03bc\u03b5\u03c4\u03b1\u03b4\u03b5\u03b4\u03bf\u03bc\u03ad\u03bd\u03b1 \u03ad\u03c7\u03bf\u03c5\u03bd \u03c1\u03c5\u03b8\u03bc\u03b9\u03c3\u03c4\u03b5\u03af \u03c3\u03c9\u03c3\u03c4\u03ac \u03c4\u03cc\u03c3\u03bf \u03c3\u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 \u03cc\u03c3\u03bf \u03ba\u03b1\u03b9 \u03c3\u03c4\u03bf\u03bd \u03c0\u03ac\u03c1\u03bf\u03c7\u03bf \u03c5\u03c0\u03b7\u03c1\u03b5\u03c3\u03b9\u03ce\u03bd.",
 		"xh": "Ukuba ungumvelisi osebenzisa isisombululo sokusayina ungene kanye, unengxaki nolungiselelo lwe-metadata. Qinisekisa ukuba i-metadata ilungiselelwe ngokuchanekileyo kuzo zombini umbonelei wesazisi nomboneleli wenkonzo.",
 		"zu": "Uma ungunjiniyela osebenzisa isixazululo sokusayinela ukungena esisodwa, unenkinga ngomiso lwemethadatha. Qinisekisa ukuthi imethadatha imiswe ngendlela efanele kokubili kumhlinzeki womazisi nomhlinzeki wesevisi.",
+		"st": "Haeba o mohlahisi ya sebedisang tharollo ya ho saena hang, o na le bothata ka phetolo ya metadata. Netefatsa hore metadata e hlophiswe ka ho nepahala ho bobedi mofani wa boitsebiso le mofani wa tshebeletso.",
 		"ca": "Si sou un desenvolupador que està desplegant una solució d'inici de sessió únic, teniu un problema amb la configuració de metadades. Verifiqueu que les metadades estiguin configurades correctament tant al proveïdor d’identitat com al proveïdor de serveis."
 	}
 }

--- a/modules/core/dictionaries/no_state.translation.json
+++ b/modules/core/dictionaries/no_state.translation.json
@@ -29,6 +29,7 @@
 		"el": "\u0394\u03b5\u03bd \u03b2\u03c1\u03ad\u03b8\u03b7\u03ba\u03b1\u03bd \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03ba\u03b1\u03c4\u03ac\u03c3\u03c4\u03b1\u03c3\u03b7\u03c2",
 		"zu": "Ulwazi lwesifunda lulahlekile",
 		"xh": "Inkcazelo yobume ilahlekile",
+		"st": "Tlhahisoleseding ya provense e lahlehile",
 		"ca": "Informació d'estat perduda"
 	},
 	"description": {
@@ -61,6 +62,7 @@
 		"el": "\u0394\u03b5\u03bd \u03ae\u03c4\u03b1\u03bd \u03b4\u03c5\u03bd\u03b1\u03c4\u03cc \u03bd\u03b1 \u03b5\u03bd\u03c4\u03bf\u03c0\u03b9\u03c3\u03c4\u03bf\u03cd\u03bd \u03c0\u03bb\u03b7\u03c1\u03bf\u03c6\u03bf\u03c1\u03af\u03b5\u03c2 \u03ba\u03b1\u03c4\u03ac\u03c3\u03c4\u03b1\u03c3\u03b7\u03c2 \u03b3\u03b9\u03b1 \u03c4\u03bf \u03c4\u03c1\u03ad\u03c7\u03bf\u03bd \u03b1\u03af\u03c4\u03b7\u03bc\u03b1.",
 		"xh": "Asikwazanga ukufumana inkcazelo yobume yesicelo sangoku.",
 		"zu": "Asikwazanga ukuthola ulwazi lwesifunda lwesicelo samanje.",
+		"st": "Ha re kgone ho fumana tlhahisoleseding ka provenseng bakeng sa kopo ya ha jwale.",
 		"ca": "No hem pogut localitzar la informació de l’estat per a la sol·licitud actual."
 	},
 	"suggestions": {
@@ -93,6 +95,7 @@
 		"el": "\u03a0\u03c1\u03bf\u03c4\u03ac\u03c3\u03b5\u03b9\u03c2 \u03b3\u03b9\u03b1 \u03c4\u03b7\u03bd \u03b5\u03c0\u03af\u03bb\u03c5\u03c3\u03b7 \u03b1\u03c5\u03c4\u03bf\u03cd \u03c4\u03bf\u03c5 \u03c0\u03c1\u03bf\u03b2\u03bb\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2:",
 		"zu": "Iziphakamiso zokuxazulula le nkinga:",
 		"xh": "Iingcebiso zokulungisa le ngxaki:",
+		"st": "Ditlhahiso bakeng sa ho rarolla bothata bona:",
 		"ca": "Suggeriments per resoldre aquest problema:"
 	},
 	"suggestion_badlink": {
@@ -130,6 +133,7 @@
 		"el": "\u0395\u03c0\u03b9\u03c3\u03c4\u03c1\u03ad\u03c8\u03c4\u03b5 \u03c3\u03c4\u03b7\u03bd \u03c0\u03c1\u03bf\u03b7\u03b3\u03bf\u03cd\u03bc\u03b5\u03bd\u03b7 \u03c3\u03b5\u03bb\u03af\u03b4\u03b1 \u03ba\u03b1\u03b9 \u03c0\u03c1\u03bf\u03c3\u03c0\u03b1\u03b8\u03ae\u03c3\u03c4\u03b5 \u03be\u03b1\u03bd\u03ac.",
 		"zu": "Buyela emuva ekhasini langaphambilini bese uzame futhi.",
 		"xh": "Buyela emva kwikhasi elidlulileyo uzame kwakhona.",
+		"st": "Kgutlela leqepheng le fetileng ebe o leka hape.",
 		"ca": "Torneu a la pàgina anterior i torneu-ho a provar."
 	},
 	"suggestion_closebrowser": {
@@ -162,6 +166,7 @@
 		"el": "\u039a\u03bb\u03b5\u03af\u03c3\u03c4\u03b5 \u03c4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 \u03b9\u03c3\u03c4\u03bf\u03cd (web browser) \u03ba\u03b1\u03b9 \u03c0\u03c1\u03bf\u03c3\u03c0\u03b1\u03b8\u03ae\u03c3\u03c4\u03b5 \u03be\u03b1\u03bd\u03ac",
 		"zu": "Vala isiphequluli sewebhu, bese uzame futhi.",
 		"xh": "Vala ibhrawuza yewebhu, uzame kwakhona.",
+		"st": "Kwala sebadi sa webe, ebe o leka hape.",
 		"ca": "Tanqueu el navegador web i torneu-ho a provar."
 	},
 	"causes": {
@@ -194,6 +199,7 @@
 		"el": "\u0391\u03c5\u03c4\u03cc \u03c4\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03bc\u03c0\u03bf\u03c1\u03b5\u03af \u03bd\u03b1 \u03c0\u03c1\u03bf\u03ba\u03cd\u03c8\u03b5\u03b9, \u03b5\u03ac\u03bd:",
 		"zu": "Leli phutha kungenzeka libangelwa ukuthi:",
 		"xh": "Le mpazamo isenokuba ibangelwe:",
+		"st": "Phoso ena e ka bakwa ke:",
 		"ca": "Aquest error pot ser causat per:"
 	},
 	"cause_badlink": {
@@ -231,6 +237,7 @@
 		"el": "\u039c\u03b5\u03c4\u03b1\u03b2\u03ae\u03ba\u03b1\u03c4\u03b5 \u03c0\u03af\u03c3\u03c9 \u03ba\u03b1\u03b9 \u03b5\u03bc\u03c0\u03c1\u03cc\u03c2 \u03c3\u03c4\u03bf \u03b9\u03c3\u03c4\u03bf\u03c1\u03b9\u03ba\u03cc \u03c4\u03bf\u03c5 \u03c0\u03c1\u03bf\u03b3\u03c1\u03ac\u03bc\u03bc\u03b1\u03c4\u03bf\u03c2 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 \u03b9\u03c3\u03c4\u03bf\u03cd.",
 		"zu": "Ukusebenzisa izinkinobho ezithi emuva naphambili kusiphequluli sewebhu.",
 		"xh": "Ukusebenzisa amaqhosha okuya emva naphambili kwibhrawuza yewebhu.",
+		"st": "Ho sebedisa dikonopo tsa pele le morao sebading sa webo.",
 		"ca": "Utilitzant els botons enrere i endavant del navegador web."
 	},
 	"cause_openbrowser": {
@@ -263,6 +270,7 @@
 		"el": "\u0391\u03bd\u03bf\u03af\u03be\u03b1\u03c4\u03b5 \u03c4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 \u03b9\u03c3\u03c4\u03bf\u03cd \u03ba\u03b1\u03b9 \u03b5\u03c0\u03b1\u03bd\u03b1\u03c6\u03ad\u03c1\u03b1\u03c4\u03b5 \u03ba\u03b1\u03c1\u03c4\u03ad\u03bb\u03b5\u03c2 \u03c0\u03c1\u03bf\u03b7\u03b3\u03bf\u03cd\u03bc\u03b5\u03bd\u03b7\u03c2 \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1\u03c2.",
 		"xh": "Kuvulwe ibhrawuza yewebhu ngeethebhu eziseyivwe kwiseshoni edlulileyo.",
 		"zu": "Kuvulwe isiphequluli sewebhu ngamathebhu alondolozwe kuseshini yangaphambilini.",
+		"st": "O butse sebadi sa webe ka di-tab tse bolokilweng sesheneng e fetileng.",
 		"ca": "S'ha obert el navegador web amb pestanyes desades de la sessió anterior."
 	},
 	"cause_nocookie": {
@@ -295,6 +303,7 @@
 		"el": "\u0397 \u03bb\u03b5\u03b9\u03c4\u03bf\u03c5\u03c1\u03b3\u03af\u03b1 cookie \u03b5\u03af\u03bd\u03b1\u03b9 \u03b1\u03c0\u03b5\u03bd\u03b5\u03c1\u03b3\u03bf\u03c0\u03bf\u03b9\u03b7\u03bc\u03ad\u03bd\u03b7 \u03c3\u03c4\u03bf \u03c0\u03c1\u03cc\u03b3\u03c1\u03b1\u03bc\u03bc\u03b1 \u03c0\u03b5\u03c1\u03b9\u03ae\u03b3\u03b7\u03c3\u03b7\u03c2 \u03b9\u03c3\u03c4\u03bf\u03cd.",
 		"xh": "Iikhuki zisenokwenziwa zingasebenzi kwibhrawuza yewebhu.",
 		"zu": "Amakhukhi kungenzeka ukuthi ayekisiwe kusiphequluli sewebhu.",
+		"st": "Dikhuki di ka nna tsa kwalwa sebading sa webe.",
 		"ca": "Les cookies poden estar desactivades al navegador web."
 	},
 	"report_header": {
@@ -327,6 +336,7 @@
 		"el": "\u0391\u03bd\u03b1\u03c6\u03bf\u03c1\u03ac \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1\u03c4\u03bf\u03c2",
 		"xh": "Chaza le mpazamo",
 		"zu": "Bika leli phutha",
+		"st": "Tlaleha phoso ena",
 		"ca": "Informeu d'aquest error"
 	},
 	"report_text": {
@@ -359,6 +369,7 @@
 		"el": "\u0391\u03bd \u03c4\u03bf \u03c0\u03c1\u03cc\u03b2\u03bb\u03b7\u03bc\u03b1 \u03b5\u03be\u03b1\u03ba\u03bf\u03bb\u03bf\u03c5\u03b8\u03b5\u03af \u03bd\u03b1 \u03c5\u03c6\u03af\u03c3\u03c4\u03b1\u03c4\u03b1\u03b9, \u03bc\u03c0\u03bf\u03c1\u03b5\u03af\u03c4\u03b5 \u03bd\u03b1 \u03c4\u03bf \u03b1\u03bd\u03b1\u03c6\u03ad\u03c1\u03b5\u03c4\u03b5 \u03c3\u03c4\u03bf\u03c5\u03c2 \u03b4\u03b9\u03b1\u03c7\u03b5\u03b9\u03c1\u03b9\u03c3\u03c4\u03ad\u03c2 \u03c4\u03bf\u03c5 \u03c3\u03c5\u03c3\u03c4\u03ae\u03bc\u03b1\u03c4\u03bf\u03c2.",
 		"xh": "Ukuba le ngxaki iyaqhubeka, ungayichaza kubalawuli besistim.",
 		"zu": "Uma le nkinga iphikelela, ungayibika kubalawuli besistimu.",
+		"st": "Haeba bothata bona bo phehella, o ka bo tlaleha ho batsamaisi ba sistimi.",
 		"ca": "Si aquest problema continua, podeu informar als administradors del sistema."
 	}
 }

--- a/modules/core/locales/st/LC_MESSAGES/core.po
+++ b/modules/core/locales/st/LC_MESSAGES/core.po
@@ -1,0 +1,192 @@
+
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: SimpleSAMLphp 1.15\n"
+"Report-Msgid-Bugs-To: simplesamlphp-translation@googlegroups.com\n"
+"POT-Creation-Date: 2019-12-12 12:32+0200\n"
+"PO-Revision-Date: 2019-12-12 12:32+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+msgid "{core:no_metadata:config_problem}"
+msgstr ""
+"Bona ke bothata bo ka kgonahalang ka ho fetisisa ho mofani wa tshebeletso"
+" kapa mofani wa tshebeletso."
+
+msgid "{core:no_state:description}"
+msgstr ""
+"Ha re kgone ho fumana tlhahisoleseding ka provenseng bakeng sa kopo ya ha"
+" jwale."
+
+msgid "{core:no_metadata:suggestion_user_link}"
+msgstr ""
+"Haeba o le mosebedisi ya fumaneng phoso ena kamora ho latela lehokela le "
+"setsing, o tlameha ho tlaleha phoso ena ho monga setsi."
+
+msgid "Metadata not found"
+msgstr "Metadata ha e a fumanwa"
+
+msgid "{core:cardinality:cardinality_text}"
+msgstr ""
+"E le nngwe kapa ho feta ya makgabane a fanweng ke wena ke mofani wa "
+"boitsebiso wa hao ha e na lenane le nepahetseng la dipalo."
+
+msgid "This error may be caused by:"
+msgstr "Phoso ena e ka bakwa ke:"
+
+msgid "We were unable to locate the state information for the current request."
+msgstr ""
+"Ha re kgone ho fumana tlhahisoleseding ka provenseng bakeng sa kopo ya ha"
+" jwale."
+
+msgid "Using the back and forward buttons in the web browser."
+msgstr "Ho sebedisa dikonopo tsa pele le morao sebading sa webo."
+
+msgid "{core:no_state:causes}"
+msgstr "Phoso ena e ka bakwa ke:"
+
+msgid ""
+"This is most likely a configuration problem on either the service "
+"provider or identity provider."
+msgstr ""
+"Bona ke bothata bo ka kgonahalang ka ho fetisisa ho mofani wa tshebeletso"
+" kapa mofani wa tshebeletso."
+
+msgid "Opened the web browser with tabs saved from the previous session."
+msgstr "O butse sebadi sa webe ka di-tab tse bolokilweng sesheneng e fetileng."
+
+#, python-format
+msgid "got %GOT% values, want %WANT%"
+msgstr "o fumane dipalo tse %GOT%, o batla tse %WANT%"
+
+msgid ""
+"If you are an user who received this error after following a link on a "
+"site, you should report this error to the owner of that site."
+msgstr ""
+"Haeba o le mosebedisi ya fumaneng phoso ena kamora ho latela lehokela le "
+"setsing, o tlameha ho tlaleha phoso ena ho monga setsi."
+
+msgid "{core:no_state:cause_openbrowser}"
+msgstr "O butse sebadi sa webe ka di-tab tse bolokilweng sesheneng e fetileng."
+
+msgid "{core:no_cookie:description}"
+msgstr ""
+"O bonahala o kwetse dikhukhi sebading sa hao. Ka kopo hlahloba disetting "
+"sebading sa hao."
+
+msgid "{core:no_metadata:not_found_for}"
+msgstr "Ha re a kgona ho fumana metadata bakeng sa setheo:"
+
+msgid "{core:cardinality:cardinality_header}"
+msgstr "Makgabane a Fosahetseng"
+
+msgid "{core:no_state:report_text}"
+msgstr "Haeba bothata bona bo phehella, o ka bo tlaleha ho batsamaisi ba sistimi."
+
+msgid "The problematic attribute(s) are:"
+msgstr "Makgabane a nang le mathata ke:"
+
+msgid "{core:no_state:suggestion_goback}"
+msgstr "Kgutlela leqepheng le fetileng ebe o leka hape."
+
+msgid "Report this error"
+msgstr "Tlaleha phoso ena"
+
+msgid ""
+"You appear to have disabled cookies in your browser. Please check the "
+"settings in your browser, and try again."
+msgstr ""
+"O bonahala o kwetse dikhukhi sebading sa hao. Ka kopo hlahloba disetting "
+"sebading sa hao."
+
+msgid "If this problem persists, you can report it to the system administrators."
+msgstr "Haeba bothata bona bo phehella, o ka bo tlaleha ho batsamaisi ba sistimi."
+
+msgid "{core:no_state:report_header}"
+msgstr "Tlaleha phoso ena"
+
+msgid "{core:no_cookie:header}"
+msgstr "Khukhi e siyo"
+
+msgid "{core:no_metadata:suggestion_developer}"
+msgstr ""
+"Haeba o mohlahisi ya sebedisang tharollo ya ho saena hang, o na le "
+"bothata ka phetolo ya metadata. Netefatsa hore metadata e hlophiswe ka ho"
+" nepahala ho bobedi mofani wa boitsebiso le mofani wa tshebeletso."
+
+msgid "State information lost"
+msgstr "Tlhahisoleseding ya provense e lahlehile"
+
+msgid "{core:no_state:suggestion_closebrowser}"
+msgstr "Kwala sebadi sa webe, ebe o leka hape."
+
+msgid "Incorrect Attributes"
+msgstr "Makgabane a Fosahetseng"
+
+msgid "{core:no_metadata:header}"
+msgstr "Metadata ha e a fumanwa"
+
+msgid "{core:no_state:cause_nocookie}"
+msgstr "Dikhuki di ka nna tsa kwalwa sebading sa webe."
+
+msgid "Close the web browser, and try again."
+msgstr "Kwala sebadi sa webe, ebe o leka hape."
+
+msgid "Go back to the previous page and try again."
+msgstr "Kgutlela leqepheng le fetileng ebe o leka hape."
+
+msgid "{core:no_cookie:retry}"
+msgstr "Khukhi e siyo"
+
+msgid "{core:cardinality:problematic_attributes}"
+msgstr "Makgabane a nang le mathata ke:"
+
+msgid ""
+"If you are a developer who is deploying a single sign-on solution, you "
+"have a problem with the metadata configuration. Verify that metadata is "
+"configured correctly on both the identity provider and service provider."
+msgstr ""
+"Haeba o mohlahisi ya sebedisang tharollo ya ho saena hang, o na le "
+"bothata ka phetolo ya metadata. Netefatsa hore metadata e hlophiswe ka ho"
+" nepahala ho bobedi mofani wa boitsebiso le mofani wa tshebeletso."
+
+msgid "{core:cardinality:got_want}"
+msgstr "o fumane dipalo tse %GOT%, o batla tse %WANT%"
+
+msgid "Retry"
+msgstr "Khukhi e siyo"
+
+msgid "{core:no_state:suggestions}"
+msgstr "Ditlhahiso bakeng sa ho rarolla bothata bona:"
+
+msgid "{core:no_state:cause_backforward}"
+msgstr "Ho sebedisa dikonopo tsa pele le morao sebading sa webo."
+
+msgid "Cookies may be disabled in the web browser."
+msgstr "Dikhuki di ka nna tsa kwalwa sebading sa webe."
+
+msgid "We were unable to locate the metadata for the entity:"
+msgstr "Ha re a kgona ho fumana metadata bakeng sa setheo:"
+
+msgid "{core:no_state:header}"
+msgstr "Tlhahisoleseding ya provense e lahlehile"
+
+msgid "Missing cookie"
+msgstr "Khukhi e siyo"
+
+msgid ""
+"One or more of the attributes supplied by your identity provider did not "
+"contain the expected number of values."
+msgstr ""
+"E le nngwe kapa ho feta ya makgabane a fanweng ke wena ke mofani wa "
+"boitsebiso wa hao ha e na lenane le nepahetseng la dipalo."
+
+msgid "Suggestions for resolving this problem:"
+msgstr "Ditlhahiso bakeng sa ho rarolla bothata bona:"
+

--- a/modules/multiauth/dictionaries/multiauth.translation.json
+++ b/modules/multiauth/dictionaries/multiauth.translation.json
@@ -33,6 +33,7 @@
 		"pl": "Wybierz \u017aród\u0142o autentykacji",
 		"xh": "Khetha umthombo wongqinisiso",
 		"zu": "Khetha umthombo wokuqinisekisa",
+        "st": "Kgetha mohlodi wa netafatso",
 		"ca": "Seleccioneu una font d’autenticació"
 	},
 	"select_source_text": {
@@ -69,6 +70,7 @@
 		"pl": "Wybrane \u017aród\u0142o zostanie u\u017Cyte do autentykacji i stworzenia sesji",
 		"zu": "Umthombo wokuqinisekisa okhethiwe uzosetshenziswa ukuze uqinisekiswe futhi kwakhiwe iseshini esebenzayo.",
 		"xh": "Umthombo wongqinisiso okhethiweyo uza kusetyenziswa ukukungqinisisa nokuyila iseshoni esebenzayo.",
+        "st": "Mohlodi wa netefatso o kgethilweng o tla sebediswa ho netefatsa wena le ho theha seshene e nepahetseng.",
 		"ca": "La font d’autenticació seleccionada s’utilitzarà per autenticar-vos i crear una sessió vàlida."
 	}
 }

--- a/modules/multiauth/locales/st/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/st/LC_MESSAGES/multiauth.po
@@ -1,0 +1,34 @@
+
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: SimpleSAMLphp 1.15\n"
+"Report-Msgid-Bugs-To: simplesamlphp-translation@googlegroups.com\n"
+"POT-Creation-Date: 2019-12-12 12:30+0200\n"
+"PO-Revision-Date: 2019-12-12 12:30+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+msgid ""
+"The selected authentication source will be used to authenticate you and "
+"and to create a valid session."
+msgstr ""
+"Mohlodi wa netefatso o kgethilweng o tla sebediswa ho netefatsa wena le "
+"ho theha seshene e nepahetseng."
+
+msgid "{multiauth:multiauth:select_source_text}"
+msgstr ""
+"Mohlodi wa netefatso o kgethilweng o tla sebediswa ho netefatsa wena le "
+"ho theha seshene e nepahetseng."
+
+msgid "Select an authentication source"
+msgstr "Kgetha mohlodi wa netafatso"
+
+msgid "{multiauth:multiauth:select_source_header}"
+msgstr "Kgetha mohlodi wa netafatso"
+

--- a/modules/saml/dictionaries/proxy.translation.json
+++ b/modules/saml/dictionaries/proxy.translation.json
@@ -1,16 +1,18 @@
 {
   "invalid_idp": {
-    "zh-tw": "\u7121\u6548\u7684\u9a57\u8b49\u63d0\u4f9b\u8005",
-    "es": "Proveedor de Identidad inválido",
-    "zu": "Umhlinzeki Kamazisi Ongalungile",
-    "xh": "Isiboneleli Sesazisi Esingasebenziyo",
-    "ca": "Proveïdor d’identitat no vàlid"
+	"zh-tw": "\u7121\u6548\u7684\u9a57\u8b49\u63d0\u4f9b\u8005",
+	"es": "Proveedor de Identidad inválido",
+	"zu": "Umhlinzeki Kamazisi Ongalungile",
+	"xh": "Isiboneleli Sesazisi Esingasebenziyo",
+	"st": "Mofani wa Boitsebiso ha Nepahala",
+	"ca": "Proveïdor d’identitat no vàlid"
   },
   "invalid_idp_description": {
-    "zh-tw": "\u60a8\u5df2\u7d93\u64c1\u6709\u4e00\u500b\u9a57\u8b49\u63d0\u4f9b\u8005 (<em>%IDP%</em>) \u7684\u6709\u6548\u7684\u9023\u7dda\uff0c\u4f46\u8a72\u9023\u7dda\u7121\u6cd5\u88ab <em>%SP%</em> \u6240\u63a5\u53d7\u3002\u60a8\u662f\u5426\u60f3\u8981\u767b\u51fa\u65e2\u6709\u7684\u9023\u7dda\u4e26\u91cd\u65b0\u7531\u5176\u4ed6\u9a57\u8b49\u63d0\u4f9b\u8005\u9032\u884c\u767b\u5165\uff1f",
-    "es": "Ya existe una sesión válida con un proveedor de identidad (<em>%IDP%</em>) que <em>%SP%</em> no acepta. ¿Desea cerrar su sesión actual e iniciar una nueva con otro proveedor de identidad?",
-    "zu": "Kakade uneseshini evumelekile nomhlinzeki kamazisi (<em>%IDP%</em>) engamukelwa okuthi <em>%SP%</em>. Ungathanda ukuphuma kuseshini yakho ekhona kakade futhi uphinde ungene ngomunye umhlinzeki kamazisi?",
-    "xh": "Sele unayo iseshoni esebenzayo nomboneleli wesazisi (<em>%IDP%</em>) engamkelwanga yi-<em>%SP%</em>. Ingaba ungathanda ukuphuma kwiseshoni yakho esele ikho uze ungene kwakhona ngomnye umboneleli wesazisi?",
-    "ca": "Ja teniu una sessió vàlida amb un proveïdor d’identitats (<em>%IDP%</em>) que no es acceptada per <em>%SP%</em>. Voleu sortir de la sessió existent i tornar a iniciar sessió amb un altre proveïdor d’identitat?"
+	"zh-tw": "\u60a8\u5df2\u7d93\u64c1\u6709\u4e00\u500b\u9a57\u8b49\u63d0\u4f9b\u8005 (<em>%IDP%</em>) \u7684\u6709\u6548\u7684\u9023\u7dda\uff0c\u4f46\u8a72\u9023\u7dda\u7121\u6cd5\u88ab <em>%SP%</em> \u6240\u63a5\u53d7\u3002\u60a8\u662f\u5426\u60f3\u8981\u767b\u51fa\u65e2\u6709\u7684\u9023\u7dda\u4e26\u91cd\u65b0\u7531\u5176\u4ed6\u9a57\u8b49\u63d0\u4f9b\u8005\u9032\u884c\u767b\u5165\uff1f",
+	"es": "Ya existe una sesión válida con un proveedor de identidad (<em>%IDP%</em>) que <em>%SP%</em> no acepta. ¿Desea cerrar su sesión actual e iniciar una nueva con otro proveedor de identidad?",
+	"zu": "Kakade uneseshini evumelekile nomhlinzeki kamazisi (<em>%IDP%</em>) engamukelwa okuthi <em>%SP%</em>. Ungathanda ukuphuma kuseshini yakho ekhona kakade futhi uphinde ungene ngomunye umhlinzeki kamazisi?",
+	"xh": "Sele unayo iseshoni esebenzayo nomboneleli wesazisi (<em>%IDP%</em>) engamkelwanga yi-<em>%SP%</em>. Ingaba ungathanda ukuphuma kwiseshoni yakho esele ikho uze ungene kwakhona ngomnye umboneleli wesazisi?",
+	"st": "O se ntse o na le seshene e sebetsang ho mofani wa boitsebiso (<em>%IDP%</em>) ya sa amohelweng ke<em>%SP%</em>. Na o ka lakatsa ho tswa sesheneng ya hao e teng mme o kene ka mofani wa boitsebiso e mong?",
+	"ca": "Ja teniu una sessió vàlida amb un proveïdor d’identitats (<em>%IDP%</em>) que no es acceptada per <em>%SP%</em>. Voleu sortir de la sessió existent i tornar a iniciar sessió amb un altre proveïdor d’identitat?"
   }
 }

--- a/modules/saml/locales/st/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/st/LC_MESSAGES/saml.po
@@ -1,0 +1,38 @@
+
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: SimpleSAMLphp 1.15\n"
+"Report-Msgid-Bugs-To: simplesamlphp-translation@googlegroups.com\n"
+"POT-Creation-Date: 2019-12-12 13:23+0200\n"
+"PO-Revision-Date: 2019-12-12 13:23+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+msgid ""
+"You already have a valid session with an identity provider "
+"(<em>%IDP%</em>) that is not accepted by <em>%SP%</em>. Would you like to"
+" log out from your existing session and log in again with another "
+"identity provider?"
+msgstr ""
+"O se ntse o na le seshene e sebetsang ho mofani wa boitsebiso "
+"(<em>%IDP%</em>) ya sa amohelweng ke<em>%SP%</em>. Na o ka lakatsa ho "
+"tswa sesheneng ya hao e teng mme o kene ka mofani wa boitsebiso e mong?"
+
+msgid "{saml:proxy:invalid_idp_description}"
+msgstr ""
+"O se ntse o na le seshene e sebetsang ho mofani wa boitsebiso "
+"(<em>%IDP%</em>) ya sa amohelweng ke<em>%SP%</em>. Na o ka lakatsa ho "
+"tswa sesheneng ya hao e teng mme o kene ka mofani wa boitsebiso e mong?"
+
+msgid "Invalid Identity Provider"
+msgstr "Mofani wa Boitsebiso ha Nepahala"
+
+msgid "{saml:proxy:invalid_idp}"
+msgstr "Mofani wa Boitsebiso ha Nepahala"
+

--- a/templates/includes/header.php
+++ b/templates/includes/header.php
@@ -175,6 +175,7 @@ if (array_key_exists('autofocus', $this->data)) {
                 'af' => 'Afrikaans', // Afrikaans
                 'zu' => 'IsiZulu', // Zulu
                 'xh' => 'isiXhosa', // Xhosa
+                'st' => 'Sesotho', // Sesotho
             ];
 
             $textarray = [];


### PR DESCRIPTION
This pull request adds a partial Sesotho translation.

Sesotho is one of the eleven South African official languages, covering the second of the two dominant Southern Bantu language grouping in Southern African (Tswana-Sotho).  It is spoken by about 4million South Africans. It has a very high level of mutual intelligibility with other Tswana-Sotho group languages, including Tswana and Northern Sotho (Sepedi). These are also official languages of South Africa and share a partially standardised orthography with Sesotho.

The translation was commissioned by TENET/SAFIRE, and was done by a professional translation company. It is incomplete because the intent was to cover the parts of the user interface (rather than the admin interface) that we're currently presenting to end-users, on the basis that most of the administrators of these systems will understand English. We're also aware that some of this will fall away with the advent of the new UI, and have made provision to update the four translations we've contributed {zu, xh, af, st} when this has stabilised a bit.