### PR TITLE
SQL Store does not work with PostgreSQL DB that does not have latest kvstore table

### DIFF
--- a/lib/SimpleSAML/Store/SQL.php
+++ b/lib/SimpleSAML/Store/SQL.php
@@ -130,7 +130,7 @@ class SQL extends Store
                 'CREATE TABLE ' . $this->prefix .
                 '_kvstore (_type VARCHAR(30) NOT NULL, _key VARCHAR(50) NOT NULL, _value ' . $text_t .
                 ' NOT NULL, _expire ' . $time_field . ', PRIMARY KEY (_key, _type))',
-                $this->driver === 'sqlite' || $this->driver === 'sqlsrv' ?
+                $this->driver === 'sqlite' || $this->driver === 'sqlsrv' || $this->driver === 'pgsql' ?
                 'CREATE INDEX ' . $this->prefix . '_kvstore_expire ON ' . $this->prefix . '_kvstore (_expire)' :
                 'ALTER TABLE ' . $this->prefix . '_kvstore ADD INDEX ' . $this->prefix . '_kvstore_expire (_expire)'
             ],
@@ -153,7 +153,7 @@ class SQL extends Store
                 $this->driver === 'sqlsrv' ?
                 'EXEC sp_rename ' . $this->prefix . '_kvstore_new, ' . $this->prefix . '_kvstore' :
                 'ALTER TABLE ' . $this->prefix . '_kvstore_new RENAME TO ' . $this->prefix . '_kvstore',
-                $this->driver === 'sqlite' || $this->driver === 'sqlsrv' ?
+                $this->driver === 'sqlite' || $this->driver === 'sqlsrv' || $this->driver === 'pgsql' ?
                 'CREATE INDEX ' . $this->prefix . '_kvstore_expire ON ' . $this->prefix . '_kvstore (_expire)' :
                 'ALTER TABLE ' . $this->prefix . '_kvstore ADD INDEX ' . $this->prefix . '_kvstore_expire (_expire)'
             ]


### PR DESCRIPTION
SQL Store does not work with PostgreSQL DB because 'CREATE INDEX' should be used in PostgreSQL.


Reporting bugs questions answers:
How can we reproduce the bug?
    1. set 'store.type' to 'sql' in config.php
    2. configure 'pgsql' PDO
    3. run SimpleSamlphp with PostgreSQL against which should be run statements that updates 'kvstore' table
Is it reproducible in other environments (for example, on different browsers or devices)?
    I reproduced in folowing postgres docker images
        - postgres:12.1-alpine
        - postgres:11.6-alpine
        - postgres:10.11-alpine
        - postgres:9.6.16-alpine
What tags should the bug have?
    v1.18.*
How critical is this bug? Does it impact a large amount of users?
    this affects any user use PostgreSQL and does not have latest kvstore table.
Is this a security issue? 
    no.