### PR TITLE
Mention expectException instead of phpdoc annotations in TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -33,7 +33,7 @@ the ones prefixed with "test".
 
 You will usually make use of the `assert*()` methods provided by
 `PHPUnit\Framework\TestCase`, but you can also tell `phpunit` to expect
-an exception to be thrown using *phpdoc*. For example, if you want to
+an exception to be thrown using the `expectException()`-method. For example, if you want to
 ensure that the `SimpleSAML\Utils\HTTP::addURLParameters()` method
 throws an exception in a specific situation:
 


### PR DESCRIPTION
[#3d121](https://github.com/simplesamlphp/simplesamlphp/commit/3d121046c4839a99833fffd2ea78b45258b1bbae#diff-84889d0af78b35050da8d12673769eba) switched from using phpunit annotations to `expectException()` for asserting expected exceptions, but the documentation still mentions the annotation.