### PR TITLE
use Symfony VarExporter in metadata converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,10 +56,10 @@
         "symfony/http-foundation": "^4.0",
         "symfony/http-kernel": "^4.0",
         "symfony/routing": "^4.0",
+        "symfony/var-exporter": "^5.0",
         "symfony/yaml": "^4.0",
         "twig/twig": "~2.0",
         "webmozart/assert": "~1.7"
-        "symfony/var-exporter": "^5.0",
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "symfony/yaml": "^4.0",
         "twig/twig": "~2.0",
         "webmozart/assert": "~1.7"
+        "symfony/var-exporter": "^5.0",
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a322d0137e97d1981af0ddfbe325e75",
+    "content-hash": "4792f2e7d2ff0cd7cb7bb6e70868bfe4",
     "packages": [
         {
             "name": "gettext/gettext",

--- a/modules/admin/lib/Controller/Federation.php
+++ b/modules/admin/lib/Controller/Federation.php
@@ -22,6 +22,7 @@ use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\VarExporter\VarExporter;
 
 /**
  * Controller class for the admin module.
@@ -266,7 +267,7 @@ class Federation
                 unset($entity['metadata_array']['keys']);
             }
 
-            $entities[$index]['metadata_array'] = var_export($entity['metadata_array'], true);
+            $entities[$index]['metadata_array'] = VarExporter::export($entity['metadata_array']);
         }
 
         return $entities;
@@ -328,7 +329,7 @@ class Federation
                 'url' => $source->getMetadataURL(),
                 'name' => $name,
                 'metadata' => $xml,
-                'metadata_array' => var_export($metadata, true),
+                'metadata_array' => VarExporter::export($metadata),
                 'certificates' => $certificates,
             ];
         }
@@ -383,7 +384,7 @@ class Federation
                     unset($entityMetadata['entityDescriptor']);
 
                     $text .= '$metadata[' . var_export($entityId, true) . '] = '
-                        . var_export($entityMetadata, true) . ";\n";
+                        . VarExporter::export($entityMetadata) . ";\n";
                 }
                 $entities = $text;
             }
@@ -465,7 +466,7 @@ class Federation
 
         $t = new Template($this->config, 'admin:show_metadata.twig');
         $t->data['entityid'] = $entityId;
-        $t->data['metadata'] = var_export($metadata, true);
+        $t->data['metadata'] = VarExporter::export($metadata);
         return $t;
     }
 }

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -1,5 +1,7 @@
 <?php
 
+use Symfony\Component\VarExporter\VarExporter;
+
 if (!array_key_exists('PATH_INFO', $_SERVER)) {
     throw new \SimpleSAML\Error\BadRequest('Missing authentication source id in metadata URL');
 }
@@ -279,7 +281,7 @@ if (array_key_exists('output', $_REQUEST) && $_REQUEST['output'] == 'xhtml') {
     $t->data['headerString'] = \SimpleSAML\Locale\Translate::noop('metadata_saml20-sp');
     $t->data['metadata'] = htmlspecialchars($xml);
     $t->data['metadataflat'] = '$metadata[' . var_export($entityId, true)
-        . '] = ' . var_export($metaArray20, true) . ';';
+        . '] = ' . VarExporter::export($metaArray20) . ';';
     $t->data['metaurl'] = $source->getMetadataURL();
     $t->send();
 } else {

--- a/www/admin/metadata-converter.php
+++ b/www/admin/metadata-converter.php
@@ -2,6 +2,8 @@
 
 require_once('../_include.php');
 
+use Symfony\Component\VarExporter\VarExporter;
+
 // make sure that the user has admin access rights
 \SimpleSAML\Utils\Auth::requireAdmin();
 
@@ -40,7 +42,7 @@ if (!empty($xmldata)) {
             unset($entityMetadata['entityDescriptor']);
 
             $text .= '$metadata[' . var_export($entityId, true) . '] = ' .
-                var_export($entityMetadata, true) . ";\n";
+                VarExporter::export($entityMetadata) . ";\n";
         }
         $entities = $text;
     }

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -2,6 +2,8 @@
 
 require_once('../../_include.php');
 
+use Symfony\Component\VarExporter\VarExporter;
+
 use SAML2\Constants;
 use SimpleSAML\Module;
 use SimpleSAML\Utils\Auth as Auth;
@@ -210,7 +212,7 @@ try {
 
     $metaxml = $metaBuilder->getEntityDescriptorText();
 
-    $metaflat = '$metadata[' . var_export($idpentityid, true) . '] = ' . var_export($metaArray, true) . ';';
+    $metaflat = '$metadata[' . var_export($idpentityid, true) . '] = ' . VarExporter::export($metaArray) . ';';
 
     // sign the metadata if enabled
     $metaxml = \SimpleSAML\Metadata\Signer::sign($metaxml, $idpmeta->toArray(), 'SAML 2 IdP');


### PR DESCRIPTION
Instead of `var_export`, this provides nice, PSR-12 compliant output without explicit numeric array indices.