### PR TITLE
fixed warning when Warning: session_create_id(): Failed to create ID

### DIFF
--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -165,6 +165,7 @@ class SessionHandlerPHP extends SessionHandler
      */
     public function newSessionId(): string
     {
+        $sessionId = false;
         // generate new (secure) session id
         if (function_exists('session_create_id')) {
             $sid_length = (int) ini_get('session.sid_length');
@@ -174,7 +175,8 @@ class SessionHandlerPHP extends SessionHandler
                 Logger::warning("Unsafe defaults used for sessionId generation!");
             }
             $sessionId = session_create_id();
-        } else {
+        }
+        if(!$sessionId){
             $sessionId = bin2hex(openssl_random_pseudo_bytes(16));
         }
         Session::createSession($sessionId);

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -165,18 +165,17 @@ class SessionHandlerPHP extends SessionHandler
      */
     public function newSessionId(): string
     {
-        $sessionId = false;
         // generate new (secure) session id
-        if (function_exists('session_create_id')) {
-            $sid_length = (int) ini_get('session.sid_length');
-            $sid_bits_per_char = (int) ini_get('session.sid_bits_per_character');
+        $sid_length = (int) ini_get('session.sid_length');
+        $sid_bits_per_char = (int) ini_get('session.sid_bits_per_character');
 
-            if (($sid_length * $sid_bits_per_char) < 128) {
-                Logger::warning("Unsafe defaults used for sessionId generation!");
-            }
-            $sessionId = session_create_id();
+        if (($sid_length * $sid_bits_per_char) < 128) {
+            Logger::warning("Unsafe defaults used for sessionId generation!");
         }
-        if(!$sessionId){
+        $sessionId = session_create_id();
+
+        if (!$sessionId) {
+            Logger::warning("Secure session ID generation failed, falling back to custom ID generation.");
             $sessionId = bin2hex(openssl_random_pseudo_bytes(16));
         }
         Session::createSession($sessionId);


### PR DESCRIPTION
fixed this warning > Warning: session_create_id(): Failed to create new ID in /var/ssosp/lib/SimpleSAML/SessionHandlerPHP.php on line 176