### PR TITLE
Check recipient/destination metadata before sender/source metadata wh…

### DIFF
--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -98,14 +98,14 @@ class Message
     ): void {
         $signingEnabled = null;
         if ($message instanceof LogoutRequest || $message instanceof LogoutResponse) {
-            $signingEnabled = $srcMetadata->getBoolean('sign.logout', null);
+            $signingEnabled = $dstMetadata->getBoolean('sign.logout', null);
             if ($signingEnabled === null) {
-                $signingEnabled = $dstMetadata->getBoolean('sign.logout', null);
+                $signingEnabled = $srcMetadata->getBoolean('sign.logout', null);
             }
         } elseif ($message instanceof AuthnRequest) {
-            $signingEnabled = $srcMetadata->getBoolean('sign.authnrequest', null);
+            $signingEnabled = $dstMetadata->getBoolean('sign.authnrequest', null);
             if ($signingEnabled === null) {
-                $signingEnabled = $dstMetadata->getBoolean('sign.authnrequest', null);
+                $signingEnabled = $srcMetadata->getBoolean('sign.authnrequest', null);
             }
         }
 


### PR DESCRIPTION
Check recipient/destination metadata before sender/source metadata when determining whether or not to sign messages (sign.authnrequest/sign.logout) in the HTTP-REDIRECT profile.  If in IdP metadata, allows the SP that would normally sign authn requests/logout requests (because these options are 'true' in its own metadata) to not do so if the IdP doesn't want it.  When in SP metadata, allows an IdP to that would normally want to logout requests/responses (because these options are 'true' in its own metadata) to not do so if the SP doesn't want it.
The documentation seems to suggest that this should already be the case but it turns out the code doesn't respect those rules because each side checks its own metadata first before determining if the recipient/destination has the option.

Fix for issue (I closed the older PR referenced in issue):
https://github.com/simplesamlphp/simplesamlphp/issues/687