### PR TITLE
Fix the old "admin" templates

### DIFF
--- a/www/admin/hostnames.php
+++ b/www/admin/hostnames.php
@@ -25,11 +25,11 @@ $attributes['getSelfHostWithPath()'] = [\SimpleSAML\Utils\HTTP::getSelfHostWithP
 $attributes['getFirstPathElement()'] = [\SimpleSAML\Utils\HTTP::getFirstPathElement()];
 $attributes['selfURL()'] = [\SimpleSAML\Utils\HTTP::getSelfURL()];
 
-$template = new \SimpleSAML\XHTML\Template($config, 'hostnames.php');
+$template = new \SimpleSAML\XHTML\Template($config, 'hostnames');
 
 $template->data['remaining']  = $session->getAuthData('admin', 'Expire') - time();
 $template->data['attributes'] = $attributes;
 $template->data['valid'] = 'na';
 $template->data['logout'] = null;
 
-$template->show();
+$template->send();

--- a/www/admin/index.php
+++ b/www/admin/index.php
@@ -28,4 +28,4 @@ $template->data['remaining']  = $session->getAuthData('admin', 'Expire') - time(
 $template->data['valid'] = 'na';
 $template->data['logouturl'] = $logouturl;
 
-$template->show();
+$template->send();

--- a/www/admin/metadata-converter.php
+++ b/www/admin/metadata-converter.php
@@ -51,8 +51,8 @@ if (!empty($xmldata)) {
     $output = [];
 }
 
-$template = new \SimpleSAML\XHTML\Template($config, 'metadata-converter.php', 'admin');
+$template = new \SimpleSAML\XHTML\Template($config, 'metadata-converter', 'admin');
 $template->data['clipboard.js'] = true;
 $template->data['xmldata'] = $xmldata;
 $template->data['output'] = $output;
-$template->show();
+$template->send();


### PR DESCRIPTION
**Describe the bug**
Seems like the old `/admin/metadata-converter.php` and `/admin/hostnames.php` are returning an error.

**To Reproduce**
Go to `simplesaml/admin/metadata-converter.php`

**Expected behavior**
Should show the actual admin page.

**Screenshots or logs**
```
Fatal error: Uncaught Exception: Template-file \"metadata-converter.php.twig\" does not exist. in /var/simplesamlphp/lib/SimpleSAML/XHTML/Template.php:272 Stack trace: #0 /var/simplesamlphp/lib/SimpleSAML/XHTML/Template.php(147): SimpleSAML\XHTML\Template->setupTwig() #1 /var/simplesamlphp/www/admin/metadata-converter.php(54): SimpleSAML\XHTML\Template->__construct(Object(SimpleSAML\Configuration), 'metadata-conver...', 'admin') #2 {main} thrown in /var/simplesamlphp/lib/SimpleSAML/XHTML/Template.php on line 272
```

After correcting the template name the output is
```
Fatal error: Uncaught Error: Call to undefined method SimpleSAML\XHTML\Template::show() in /var/simplesamlphp/www/admin/metadata-converter.php:58 Stack trace: #0 {main} thrown in /var/simplesamlphp/www/admin/metadata-converter.php on line 58
```

**Additional context**
This pages are listed in many 3rd party "how to integrate simplesamlphp" like [https://rocket.chat/docs/administrator-guides/authentication/saml/#simplesamlphp-idp-configuration](https://rocket.chat/docs/administrator-guides/authentication/saml/#simplesamlphp-idp-configuration).

Not sure if this is the best fix or should be more like the `admin/index.php` that has a redirect to the new one 
```
\SimpleSAML\Utils\HTTP::redirectTrustedURL(\SimpleSAML\Module::getModuleURL('admin/'));
```

Let me know if that is a better solution for you and I'll do in that way.

Thanks,
Vincenzo