### PR TITLE
add the possibility to specify one AuthSource to be shown

### DIFF
--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -10,6 +10,11 @@ $config = [
         'core:AdminPassword',
     ],
 
+    /* When multiple authentication sources are defined, you can specify here which one to show 
+     * and the others could be used with multiauth:MultiAuth
+     */
+    // 'showThisSource' = 'default-sp',
+
 
     // An authentication source which can authenticate against both SAML 2.0
     // and Shibboleth 1.3 IdPs.

--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -13,7 +13,7 @@ $config = [
     /* When multiple authentication sources are defined, you can specify here which one to show 
      * and the others could be used with multiauth:MultiAuth
      */
-    // 'showThisSource' = 'default-sp',
+    // 'showThisSource' = ['default-sp'],
 
 
     // An authentication source which can authenticate against both SAML 2.0

--- a/modules/core/lib/Controller.php
+++ b/modules/core/lib/Controller.php
@@ -128,9 +128,10 @@ class Controller
             $as = key($this->sources);
         }
 
-        if (array_key_exists('showThisSource', $this->sources) &&
-            array_key_exists($this->sources['showThisSource'], $this->sources)) {
-            $as = $this->sources['showThisSource'];
+        if (array_key_exists('showThisSource', $this->sources)) {
+            if (array_key_exists($this->sources['showThisSource'], $this->sources)) {
+                $as = $this->sources['showThisSource'];
+            }
             unset($this->sources['showThisSource']);
         }
 

--- a/modules/core/lib/Controller.php
+++ b/modules/core/lib/Controller.php
@@ -129,8 +129,8 @@ class Controller
         }
 
         if (array_key_exists('showThisSource', $this->sources)) {
-            if (array_key_exists($this->sources['showThisSource'], $this->sources)) {
-                $as = $this->sources['showThisSource'];
+            if (array_key_exists($this->sources['showThisSource'][0], $this->sources)) {
+                $as = $this->sources['showThisSource'][0];
             }
             unset($this->sources['showThisSource']);
         }

--- a/modules/core/lib/Controller.php
+++ b/modules/core/lib/Controller.php
@@ -128,6 +128,12 @@ class Controller
             $as = key($this->sources);
         }
 
+        if (array_key_exists('showThisSource', $this->sources) &&
+            array_key_exists($this->sources['showThisSource'], $this->sources)) {
+            $as = $this->sources['showThisSource'];
+            unset($this->sources['showThisSource']);
+        }
+
         if ($as === null) { // no authentication source specified
             $t = new Template($this->config, 'core:login.twig');
             $t->data['loginurl'] = Utils\Auth::getAdminLoginURL();


### PR DESCRIPTION
I have multiple AuthSources, but the User should be presented only one Login-Possibility. So I need to specify which authSource to use.

This change adds a pseudo authSource by the name 'showThisSource' which is used in the core-Controller to select only the one AS to be shown.