### PR TITLE
Fix the front end modules URL generation in Module.php

### DIFF
--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -468,7 +468,7 @@ class Module
     {
         Assert::notSame($resource[0], '/');
 
-        $url = Utils\HTTP::getBaseURL() . 'module.php/' . $resource;
+        $url = Utils\HTTP::getBaseURL() . 'modules/' . $resource;
         if (!empty($parameters)) {
             $url = Utils\HTTP::addURLParameters($url, $parameters);
         }


### PR DESCRIPTION
The URL was bieng generated with the folder name (module) coming as module.php hence the front end pages could not load successfully.
This changes from module.php to modules