### PR TITLE
Fixed incorrect translate for the 'Authentication' word

### DIFF
--- a/modules/core/locales/pl/LC_MESSAGES/core.po
+++ b/modules/core/locales/pl/LC_MESSAGES/core.po
@@ -86,7 +86,7 @@ msgid "{core:frontpage:loggedin_as_admin}"
 msgstr "Jesteś zalogowany jako administrator"
 
 msgid "{core:frontpage:auth}"
-msgstr "Autentykacja"
+msgstr "Uwierzytelnianie"
 
 msgid "{core:frontpage:show_metadata}"
 msgstr "Wyświetl metadane"
@@ -265,7 +265,7 @@ msgid "Shibboleth 1.3 SP example - test logging in through your Shib IdP"
 msgstr "Shibboleth 1.3 SP - przykład - test logowania przez Twoje Shib IdP"
 
 msgid "Authentication"
-msgstr "Autentykacja"
+msgstr "Uwierzytelnianie"
 
 msgid "Show metadata"
 msgstr "Wyświetl metadane"


### PR DESCRIPTION
In the Polish language, correct translate for the word 'Authentication' is 'Uwierzytelnianie'. Unfortunately, many people write/say 'Autentykacja'. This one doesn't exist in the Polish dictionary. 

**Source**: 

- "English 4 IT" (https://helion.pl/ksiazki/english-4-it-praktyczny-kurs-jezyka-angielskiego-dla-specjalistow-it-i-nie-tylko-beata-blaszczyk,anginf.htm#format/d)
- "Polish dictionary" (https://sjp.pl/Autentykacja)