### PR TITLE
Issue #1272 - SSP refuses to use temp dir if it doesn't own it, even though it can write to it

### DIFF
--- a/lib/SimpleSAML/Utils/System.php
+++ b/lib/SimpleSAML/Utils/System.php
@@ -103,7 +103,7 @@ class System
             throw new Error\Exception(
                 'Temporary directory "' . $tempDir .
                 '" cannot be written to by the current user' .
-                (function_exists('posix_getuid') ? ' "' .  posix_getuid() . '"' : '');
+                (function_exists('posix_getuid') ? ' "' .  posix_getuid() . '"' : '')
             );
         }
 

--- a/lib/SimpleSAML/Utils/System.php
+++ b/lib/SimpleSAML/Utils/System.php
@@ -67,12 +67,13 @@ class System
      * This function retrieves the path to a directory where temporary files can be saved.
      *
      * @return string Path to a temporary directory, without a trailing directory separator.
-     * @throws Error\Exception If the temporary directory cannot be created or it exists and does not belong
-     * to the current user.
+     * @throws Error\Exception If the temporary directory cannot be created or it exists and cannot be written
+     * to by the current user.
      *
      * @author Andreas Solberg, UNINETT AS <andreas.solberg@uninett.no>
      * @author Olav Morken, UNINETT AS <olav.morken@uninett.no>
      * @author Jaime Perez, UNINETT AS <jaime.perez@uninett.no>
+     * @author Aaron St. Clair, ECRS AS <astclair@ecrs.com>
      */
     public static function getTempDir(): string
     {
@@ -86,6 +87,10 @@ class System
             DIRECTORY_SEPARATOR
         );
 
+        /**
+         * If the temporary directory does not exist then attempt to create it. If the temporary directory
+         * already exists then verify the current user can write to it. Otherwise, throw an error.
+         */
         if (!is_dir($tempDir)) {
             if (!mkdir($tempDir, 0700, true)) {
                 $error = error_get_last();
@@ -94,14 +99,12 @@ class System
                     (is_array($error) ? $error['message'] : 'no error available')
                 );
             }
-        } elseif (function_exists('posix_getuid')) {
-            // check that the owner of the temp directory is the current user
-            $stat = lstat($tempDir);
-            if ($stat['uid'] !== posix_getuid()) {
-                throw new Error\Exception(
-                    'Temporary directory "' . $tempDir . '" does not belong to the current user.'
-                );
-            }
+        } elseif (!is_writable($tempDir)) {
+            throw new Error\Exception(
+                'Temporary directory "' . $tempDir .
+                '" cannot be written to by the current user' .
+                (function_exists('posix_getuid') ? ' "' .  posix_getuid() . '"' : '');
+            );
         }
 
         return $tempDir;

--- a/tests/lib/SimpleSAML/Utils/SystemTest.php
+++ b/tests/lib/SimpleSAML/Utils/SystemTest.php
@@ -267,23 +267,16 @@ class SystemTest extends TestCase
 
 
     /**
-     * @requires OS Linux
      * @covers \SimpleSAML\Utils\System::getTempDir
      * @test
      * @return void
      */
-    public function testGetTempDirBadOwner()
+    public function testGetTempDirBadPermissions()
     {
-        if (!function_exists('posix_getuid')) {
-            static::markTestSkipped('POSIX-functions not available;  skipping!');
-        }
-
-        $bad_uid = posix_getuid() + 1;
-
         $tempdir = $this->root_directory . DIRECTORY_SEPARATOR . self::DEFAULTTEMPDIR;
         $config = $this->setConfigurationTempDir($tempdir);
 
-        chown($tempdir, $bad_uid);
+        chmod($tempdir, 0440);
 
         $this->expectException(\SimpleSAML\Error\Exception::class);
         System::getTempDir();


### PR DESCRIPTION
This has been addressed using the `is_writable` function instead of checking for UID, which only works in a Linux environment.