### PR TITLE
Fix source code disclosure on case-insensitive file systems

### DIFF
--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -259,7 +259,7 @@ class Module
             throw new Error\NotFound('The URL wasn\'t found in the module.');
         }
 
-        if (substr($path, -4) === '.php') {
+        if (mb_strtolower(substr($path, -4), 'UTF-8') === '.php') {
             // PHP file - attempt to run it
 
             /* In some environments, $_SERVER['SCRIPT_NAME'] is already set with $_SERVER['PATH_INFO']. Check for that


### PR DESCRIPTION
If the file system containing the PHP code is case-insensitive, a
request containing an uppercase file extension will return the
contents of the PHP file to the browser instead of executing it.

E.g. a request for this URL will return the source code:

  https:/sp.example.org/simplesaml/module.php/core/frontpage_welcome.PHP

Fix that by converting the path to lowercase before checking the file
extension.

See the following page for details:

  https://github.com/simplesamlphp/simplesamlphp/security/advisories/GHSA-24m3-w8g9-jwpq