### PR TITLE
Move config file location docs

### DIFF
--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -110,7 +110,10 @@ startup indicating how and what you need to update. You should look through the 
 directory after the upgrade to see whether recommended defaults have been changed.
 
 
-### Alternative location for configuration files
+Configuration
+-------------
+
+### Location of configuration files
 
 By default, SimpleSAMLphp looks for its configuration in the `config` directory in the root of its own directory. This
 has some drawbacks, like making it harder to update SimpleSAMLphp or to install it as a composer dependency, or to 


### PR DESCRIPTION
Currently on https://simplesamlphp.org/docs/stable/simplesamlphp-install the section [3.3 Alternative location for configuration files](https://simplesamlphp.org/docs/stable/simplesamlphp-install#section_3) sits as a subheading beneath [3. Upgrading from a previous version of SimpleSAMLphp](https://simplesamlphp.org/docs/stable/simplesamlphp-install#section_3)

This change creates a section "Configuration" underneath the "Upgrading" section, moving "Location of configuration files" inside that section; then we continue with "Configuring Apache" ... as before.

I'm not familiar with the docs generation process for this project, but I expect this will result in a corresponding update to https://simplesamlphp.org/docs/stable/simplesamlphp-install

Hope this small change helps others to find that documentation detail more easily.