### PR TITLE
core/loginuserpass: Fix login button translation

### DIFF
--- a/modules/core/templates/loginuserpass.twig
+++ b/modules/core/templates/loginuserpass.twig
@@ -114,7 +114,7 @@
 
             <button class="pure-button pure-button-red pure-input-1-2 pure-input-sm-1-1 right" id="submit_button"
                     type="submit" tabindex="6" data-processing="{% trans %}Processing...{% endtrans %}">
-              {% trans %}Log in{% endtrans %}
+              {% trans %}Login{% endtrans %}
             </button>
         </form>
     </div><!--center-->


### PR DESCRIPTION
Fixes 336b7abef59e47c6e16c3587a703af558871072a which changed the label from
'Login' to a single-use 'Log in' whilste the translations only have 'Login'.

modules/core/templates/loginuserpass.twig:              {% trans %}Log in{% endtrans %}
modules/exampleauth/lib/Auth/Source/External.php:     * Log in using an external authentication helper.
modules/exampleauth/lib/Auth/Source/StaticSource.php:     * Log in using static attributes.
modules/exampleauth/templates/authenticate.twig:      <p><input type="submit" value="Log in"></p>
modules/multiauth/docs/multiauth.md:                    'en' => 'Log in using a SAML SP',
modules/multiauth/docs/multiauth.md:                    'en' => 'Log in using the admin password',