### PR TITLE
Allow Controllers to get the matched route

### DIFF
--- a/lib/SimpleSAML/Module/ControllerResolver.php
+++ b/lib/SimpleSAML/Module/ControllerResolver.php
@@ -102,6 +102,7 @@ class ControllerResolver extends SymfonyControllerResolver implements ArgumentRe
         try {
             $matcher = new UrlMatcher($this->routes, $ctxt);
             $this->params = $matcher->match($ctxt->getPathInfo());
+            $request->attributes->set('_routeparams', $this->params);
             list($class, $method) = explode('::', $this->params['_controller']);
             $this->container->register($class, $class)->setAutowired(true)->setPublic(true);
             $this->container->compile();


### PR DESCRIPTION
This allows a controller to call `$request->attributes->get('_routeparams')` to access any available parameters.