### PR TITLE
Filter multiauth authentication sources from SP using AuthnContextClassRef

### DIFF
--- a/modules/multiauth/docs/multiauth.md
+++ b/modules/multiauth/docs/multiauth.md
@@ -79,7 +79,7 @@ compatible fashion so both cases should work.
 
 Each source in the sources array has a key and a value. As
 mentioned above the key is the authsource identifier and the value
-is another array with optional keys: 'text', 'css-class', 'help', and 'ContextClassRef'.
+is another array with optional keys: 'text', 'css-class', 'help', and 'AuthnContextClassRef'.
 The text element is another array with localized strings for one
 or more languages. These texts will be shown in the selectsource.php
 view. Note that you should at least enter the text in the default
@@ -91,7 +91,7 @@ replaced by dashes. So in the previous example, the css class used
 in the 'example-admin' authentication source would be
 'core-AdminPassword'. The help element is another array with localized
 strings for one or more languages. These texts will be shown in the
-selectsource.php view. The ContextClassRef is either a string or
+selectsource.php view. The AuthnContextClassRef is either a string or
 an array of strings containing [context class ref names](https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf).
 If an SP sets AuthnContextClassRef the list of authsources will be
 filtered to only those containing context class refs that are part of the list set by the SP.

--- a/modules/multiauth/docs/multiauth.md
+++ b/modules/multiauth/docs/multiauth.md
@@ -36,12 +36,14 @@ authentication source:
                     'es' => 'Entrar usando un SP SAML',
                 ),
                 'css-class' => 'SAML',
+                'AuthnContextClassRef' => array('urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI', 'urn:oasis:names:tc:SAML:2.0:ac:classes:MobileTwoFactorContract'),
             ),
             'example-admin' => array(
                 'text' => array(
                     'en' => 'Log in using the admin password',
                     'es' => 'Entrar usando la contraseña de administrador',
                 ),
+                'AuthnContextClassRef' => 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
             ),
         ),
     ),
@@ -77,7 +79,7 @@ compatible fashion so both cases should work.
 
 Each source in the sources array has a key and a value. As
 mentioned above the key is the authsource identifier and the value
-is another array with two optional keys: 'text' and 'css-class'.
+is another array with optional keys: 'text', 'css-class', 'help', and 'ContextClassRef'.
 The text element is another array with localized strings for one
 or more languages. These texts will be shown in the selectsource.php
 view. Note that you should at least enter the text in the default
@@ -87,7 +89,14 @@ the &lt;li> element in the selectsource.php view. By default the
 authtype of the authsource is used as the css class with colons
 replaced by dashes. So in the previous example, the css class used
 in the 'example-admin' authentication source would be
-'core-AdminPassword'.
+'core-AdminPassword'. The help element is another array with localized
+strings for one or more languages. These texts will be shown in the
+selectsource.php view. The ContextClassRef is either a string or
+an array of strings containing [context class ref names](https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf).
+If an SP sets AuthnContextClassRef the list of authsources will be
+filtered to only those containing context class refs that are part of the list set by the SP.
+If a single authsource results from this filtering the user will be taken directly to the
+authentication page for that source, and will never be shown the multiauth select page.
 
 It is possible to add the parameter `source` to the calling URL, 
 when accessing a service, to allow the user to preselect the

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\multiauth\Auth\Source;
 
+use SAML2\Constants;
 use Exception;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Auth;
@@ -12,6 +13,7 @@ use SimpleSAML\Error;
 use SimpleSAML\Module;
 use SimpleSAML\Session;
 use SimpleSAML\Utils;
+use SimpleSAML\Module\saml\Error\NoAuthnContext;
 
 /**
  * Authentication source which let the user chooses among a list of
@@ -179,8 +181,10 @@ class MultiAuth extends Auth\Source
                     $new_sources[] = $source;
                 }
             }
-            $this->sources = $new_sources;
-            if (count($new_sources) === 1) {
+            $number_of_sources = count($new_sources); 
+            if ($number_of_sources === 0) {
+                throw new NoAuthnContext(Constants::STATUS_RESPONDER, 'No authentication sources exist for the requested AuthnContextClassRefs: ' . implode(', ', $refs));
+            } else if ($number_of_sources === 1) {
                 $params['source'] = $new_sources[0]['source'];
             }
         }

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -115,7 +115,7 @@ class MultiAuth extends Auth\Source
                     $css_class = str_replace(":", "-", $authconfig[0]);
                 }
             }
-            
+
             $class_ref = [];
             if (array_key_exists('AuthnContextClassRef', $info)) {
                 $ref = $info['AuthnContextClassRef'];
@@ -164,15 +164,15 @@ class MultiAuth extends Auth\Source
                 }
             }
             $state[self::SOURCESID] = $new_sources;
-            
-            $number_of_sources = count($new_sources); 
+
+            $number_of_sources = count($new_sources);
             if ($number_of_sources === 0) {
                 throw new NoAuthnContext(Constants::STATUS_RESPONDER, 'No authentication sources exist for the requested AuthnContextClassRefs: ' . implode(', ', $refs));
             } else if ($number_of_sources === 1) {
                 MultiAuth::delegateAuthentication($new_sources[0]['source'], $state);
             }
         }
-        
+
         if (!array_key_exists('multiauth:preselect', $state) && is_string($this->preselect)) {
             $state['multiauth:preselect'] = $this->preselect;
         }

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -159,7 +159,10 @@ class MultiAuth extends Auth\Source
             $state['multiauth:preselect'] = $this->preselect;
         }
 
-        if (!is_null($state['saml:RequestedAuthnContext']) && array_key_exists('AuthnContextClassRef', $state['saml:RequestedAuthnContext'])) {
+        if (
+            !is_null($state['saml:RequestedAuthnContext'])
+            && array_key_exists('AuthnContextClassRef', $state['saml:RequestedAuthnContext'])
+        ) {
             $refs = array_values($state['saml:RequestedAuthnContext']['AuthnContextClassRef']);
             $new_sources = [];
             foreach ($this->sources as $source) {
@@ -171,7 +174,10 @@ class MultiAuth extends Auth\Source
 
             $number_of_sources = count($new_sources);
             if ($number_of_sources === 0) {
-                throw new NoAuthnContext(Constants::STATUS_RESPONDER, 'No authentication sources exist for the requested AuthnContextClassRefs: ' . implode(', ', $refs));
+                throw new NoAuthnContext(
+                    Constants::STATUS_RESPONDER,
+                    'No authentication sources exist for the requested AuthnContextClassRefs: ' . implode(', ', $refs)
+                );
             } else if ($number_of_sources === 1) {
                 MultiAuth::delegateAuthentication($new_sources[0]['source'], $state);
             }

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -155,6 +155,10 @@ class MultiAuth extends Auth\Source
         $state[self::AUTHID] = $this->authId;
         $state[self::SOURCESID] = $this->sources;
 
+        if (!array_key_exists('multiauth:preselect', $state) && is_string($this->preselect)) {
+            $state['multiauth:preselect'] = $this->preselect;
+        }
+
         if (!is_null($state['saml:RequestedAuthnContext']) && array_key_exists('AuthnContextClassRef', $state['saml:RequestedAuthnContext'])) {
             $refs = array_values($state['saml:RequestedAuthnContext']['AuthnContextClassRef']);
             $new_sources = [];
@@ -171,10 +175,6 @@ class MultiAuth extends Auth\Source
             } else if ($number_of_sources === 1) {
                 MultiAuth::delegateAuthentication($new_sources[0]['source'], $state);
             }
-        }
-
-        if (!array_key_exists('multiauth:preselect', $state) && is_string($this->preselect)) {
-            $state['multiauth:preselect'] = $this->preselect;
         }
 
         // Save the $state array, so that we can restore if after a redirect


### PR DESCRIPTION
This PR introduces the necessary changes to allow an SP to choose an authentication source of multiauth. It works even if there are redirects during the authentication process because it uses SAML2 standard AuthnContextClassRef. See #912 for more context.