### PR TITLE
Improve expired handling

### DIFF
--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -296,6 +296,7 @@ class Template extends Response
 
         $twig = new Twig_Environment($loader, $options);
         $twig->addExtension(new Twig_Extensions_Extension_I18n());
+        $twig->addExtension(new \Twig\Extensions\DateExtension());
 
         $twig->addFunction(new TwigFunction('moduleURL', [Module::class, 'getModuleURL']));
 

--- a/modules/admin/lib/Controller/Federation.php
+++ b/modules/admin/lib/Controller/Federation.php
@@ -442,6 +442,13 @@ class Federation
                          */
                         unset($entityMetadata['entityDescriptor']);
 
+                        /**
+                         * Remove any expire from the metadata. This is not so useful
+                         * for manually converted metadata and frequently gives rise
+                         * to unexpected results when copy-pased statically.
+                         */
+                        unset($entityMetadata['expire']);
+
                         $text .= '$metadata[' . var_export($entityId, true) . '] = '
                             . VarExporter::export($entityMetadata) . ";\n";
                     }

--- a/modules/admin/templates/federation.twig
+++ b/modules/admin/templates/federation.twig
@@ -116,16 +116,13 @@
           {{ entity.entityid|escape('html') }}
           {%- endif -%}
           </a>
-          {%- if entity.expire is defined %}
-            {%- if entity.expire < date().timestamp %}
-
-          <span class="entity-expired"> (expired {{ ((date().timestamp - entity.expire) / 3600) }} hours ago)</span>
-            {%- else %}
-              {%- set expiration = (entity.expire - date().timestamp) / 3600 %}
-
-          ({% trans %}expires in {{ expiration }} hours{% endtrans %})
-            {%- endif -%}
-          {%- endif -%}
+          {% if entity.expire is defined %}
+            {% if entity.expire < date().timestamp %}
+              <span class="entity-expired"> ({% trans %}expired{% endtrans %} {{ entity.expire | time_diff }})</span>
+            {% else %}
+              <span class="entity-expires"> ({% trans %}expires{% endtrans %} {{ entity.expire | time_diff }})</span>
+            {% endif %}
+          {% endif %}
         </li>
       {% endfor %}
       </ul>

--- a/tests/modules/admin/lib/Controller/FederationTest.php
+++ b/tests/modules/admin/lib/Controller/FederationTest.php
@@ -47,6 +47,9 @@ class FederationTest extends TestCase
     private $broken_metadata_xml = self::FRAMEWORK . '/metadata/xml/corrupted-metadata-selfsigned.xml';
 
     /** @var string */
+    private $expired_metadata_xml = self::FRAMEWORK . '/metadata/xml/expired-metadata.xml';
+
+    /** @var string */
     private $ssp_metadata = self::FRAMEWORK . '/metadata/simplesamlphp/saml20-idp-remote_cert_selfsigned.php';
 
     /**
@@ -222,6 +225,25 @@ class FederationTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertNull($response->data['error']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMetadataConverterSkipsExpires(): void
+    {
+        $request = Request::create(
+            '/federation/metadata-converter',
+            'POST',
+            ['xmldata' => file_get_contents($this->expired_metadata_xml)]
+        );
+
+        $c = new Controller\Federation($this->config);
+        $c->setAuthUtils($this->authUtils);
+        $response = $c->metadataConverter($request);
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertStringNotContainsString("'expire' =>", $response->data['output']['saml20-idp-remote']);
     }
 
 


### PR DESCRIPTION
Neater display of expire times in admin module.

Skip `expire` ouput in manual metadata conversion. This frequently gives problems when metadata was loaded successfully and everything works, but suddenly breaks days later. Theoretically including the expiration in manual conversion is ‘correct’, but pragmatically does not add much and does cause breakage.