### PR TITLE
Improve backtraces configuration.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -237,9 +237,8 @@ $config = [
      * SAML messages will be logged, including plaintext versions of encrypted
      * messages.
      *
-     * - 'backtraces': this action controls the logging of error backtraces. If you
-     * want to log backtraces so that you can debug any possible errors happening in
-     * SimpleSAMLphp, enable this action (add it to the array or set it to true).
+     * - 'backtraces': this action controls the logging of error backtraces so you
+     * can debug any possible errors happening in SimpleSAMLphp.
      *
      * - 'validatexml': this action allows you to validate SAML documents against all
      * the relevant XML schemas. SAML 1.1 messages or SAML metadata parsed with

--- a/lib/SimpleSAML/Error/Exception.php
+++ b/lib/SimpleSAML/Error/Exception.php
@@ -201,18 +201,9 @@ class Exception extends \Exception
      */
     protected function logBacktrace(int $level = Logger::DEBUG): void
     {
-        // see if debugging is enabled for backtraces
-        $debug = Configuration::getInstance()->getArrayize('debug', ['backtraces' => false]);
-
-        if (
-            !(in_array('backtraces', $debug, true) // implicitly enabled
-            || (array_key_exists('backtraces', $debug)
-            && $debug['backtraces'] === true)
-            // explicitly set
-            // TODO: deprecate the old style and remove it in 2.0
-            || (array_key_exists(0, $debug)
-            && $debug[0] === true)) // old style 'debug' configuration option
-        ) {
+        // Do nothing if backtraces have been disabled in config.
+        $debug = Configuration::getInstance()->getArrayize('debug', ['backtraces' => true]);
+        if (array_key_exists('backtraces', $debug) && $debug['backtraces'] === false) {
             return;
         }
 


### PR DESCRIPTION
The previous situation was confusing with various contradicting (staments of) defaults, mixed with old style and new style
configuration.

This PR tries to solve it with the "flight forward" by deciding on a useful default (on) and making all configurations adhere to that, and only skip them when explicitly disabled in the new style config. Having backtraces on by default is very useful because it's the only sane way you can now do something when an SSP error occurs. It also is what we have now in the shipped config-template.

This change vastly simplifies the confusing code, and we can resolve a TODO of oldstyle vs newstyle handling so have repaid technical debt.

