### PR TITLE
Fix SQLServer ALTER syntax

### DIFF
--- a/modules/saml/lib/SP/LogoutStore.php
+++ b/modules/saml/lib/SP/LogoutStore.php
@@ -43,6 +43,11 @@ class LogoutStore
                         'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore ALTER COLUMN _expire TYPE TIMESTAMP'
                     ];
                     break;
+                case 'sqlsrv':
+                    $update = [
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore ALTER COLUMN _expire DATETIME NOT NULL'
+                    ];
+                    break;
                 case 'sqlite':
                     /**
                      * Because SQLite does not support field alterations, the approach is to:
@@ -119,6 +124,11 @@ class LogoutStore
                     $update = [
                         'ALTER TABLE ' . $store->prefix .
                         '_saml_LogoutStore ALTER COLUMN _authSource TYPE VARCHAR(255)'];
+                    break;
+               case 'sqlsrv':
+                    $update = [
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore ALTER COLUMN _authSource VARCHAR(255) NOT NULL'
+                    ];
                     break;
                 case 'sqlite':
                     /**


### PR DESCRIPTION
Fixes https://github.com/simplesamlphp/simplesamlphp/issues/1379

This fixes the incorrect `ALTER ... MODIFY` syntax for SQLServer (it's `ALTER ... ALTER`) which prevents the `LogoutStore` to migrate from version `1 -> 2` and from version `3 -> 4`. Previously, migrating the versions failed and the old version was kept. This caused a warning to be logged but no other effect from what I could see.

![image](https://user-images.githubusercontent.com/25909128/92972230-30ceb380-f482-11ea-9030-e07831a364e5.png)

I used https://github.com/simplesamlphp/docker-simplesamlphp along with a SQLServer image to verify that this fixes the problem, and I was able to successfully migrate the LogoutStore from version `1 -> 2` and from version `3 -> 4` (`2 -> 3` worked before this fix).