### PR TITLE
Fix logic leading to negative expiry

### DIFF
--- a/modules/core/templates/frontpage_federation.twig
+++ b/modules/core/templates/frontpage_federation.twig
@@ -48,9 +48,9 @@
             {% endif -%}</a>
 
             {%- if entity.expire is defined %}
-            {% if entity.expire > date().timestamp %}
-            <span class="entity-expired"> (expired {{ ((date().timestamp - entity.expire) / 3600) }} hours ago)</span>
-            {% else %} (expires in {{ ((entity.expire - date().timestamp) / 3600) }} hours){% endif -%}{% endif %}
+            {% if ((entity.expire - date().timestamp) < 0) %}
+            <span class="entity-expired"> (expired {{ ((date().timestamp - entity.expire) / 3600) | round(2) }} hours ago)</span>
+            {% else %} (expires in {{ ((entity.expire - date().timestamp) / 3600) | round(2) }} hours){% endif -%}{% endif %}
             </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
The frontpage_federation template in 1.19 displays expiry dates in the future with a negative expiry:

`European University Cyprus (expired -95.59448483 hours ago)`

This has caused more than one brief moment of panic for metadata that still has a long way to go.

And since we're here, it also uses a precision such that we're measuring microseconds.