### PR TITLE
Remove trailing space in AuthState value

### DIFF
--- a/modules/multiauth/templates/selectsource.twig
+++ b/modules/multiauth/templates/selectsource.twig
@@ -6,7 +6,7 @@
     <p>{{ '{multiauth:multiauth:select_source_text}'| trans }}</p>
 
     <form action="{{ selfUrl|escape('html') }}" method="get">
-        <input type="hidden" name="AuthState" value="{{ authstate|escape('html') }} ">
+        <input type="hidden" name="AuthState" value="{{ authstate|escape('html') }}">
         <ul>
         {% for key, source in sources %}
             {% set name = ('src-' ~ source.source64) %}


### PR DESCRIPTION
MultiAuth source selection form has a hidden field AuthState to keep a session handler when user selects the actual authentication source.

The form is created based on the template at `modules/multiauth/templates/selectsource.twig`. AuthState value is subsituted to the template via *authstate* parameter. Apparently there's a trailing space in the value of the target field in the template what propagates to the final form and request, and then may effectively prevent restoration of the session.
