### PR TITLE
Ignore invalid hook names

### DIFF
--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -490,7 +490,7 @@ class Module
                 continue;
             }
 
-            if (!preg_match('/hook_(\w+)\.php/', $file, $matches)) {
+            if (!preg_match('/^hook_(\w+)\.php$/', $file, $matches)) {
                 continue;
             }
             $hook_name = $matches[1];

--- a/tests/lib/SimpleSAML/ModuleTest.php
+++ b/tests/lib/SimpleSAML/ModuleTest.php
@@ -112,4 +112,26 @@ class ModuleTest extends TestCase
             '\SimpleSAML\Auth\ProcessingFilter'
         ));
     }
+
+    /**
+     * Test for SimpleSAML\Module::getModuleHooks(). It covers happy path.
+     */
+    public function testGetModuleHooks(): void
+    {
+        $hooks = Module::getModuleHooks('saml');
+        $this->assertArrayHasKey('metadata_hosted', $hooks);
+        $this->assertEquals('saml_hook_metadata_hosted', $hooks['metadata_hosted']['func']);
+        $expectedFile = dirname(__DIR__, 3) . '/modules/saml/hooks/hook_metadata_hosted.php';
+        $this->assertEquals($expectedFile, $hooks['metadata_hosted']['file']);
+    }
+
+    /**
+     * Test for SimpleSAML\Module::getModuleHooks(). It covers invalid hook names
+     */
+    public function testGetModuleHooksIgnoresInvalidHooks(): void
+    {
+        $hooks = Module::getModuleHooks('../tests/modules/unittest');
+        $this->assertArrayHasKey('valid', $hooks, 'hooks=' . var_export($hooks, true));
+        $this->assertCount(1, $hooks, "Invalid hooks should be ignored");
+    }
 }

--- a/tests/modules/unittest/README.md
+++ b/tests/modules/unittest/README.md
@@ -1,0 +1,1 @@
+For some unit tests we need a module that has a specific setup or issues.

--- a/tests/modules/unittest/hooks/hook_invalid.php.orig
+++ b/tests/modules/unittest/hooks/hook_invalid.php.orig
@@ -1,0 +1,3 @@
+<?php
+
+// Hook detection should not load this file since it does not conform to the hook naming scheme

--- a/tests/modules/unittest/hooks/hook_valid.php
+++ b/tests/modules/unittest/hooks/hook_valid.php
@@ -1,0 +1,14 @@
+<?php
+
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Auth;
+
+/**
+ * Hook to for use with unit tests
+ *
+ * @param array &$data  Some data
+ */
+function unittest_hook_valid(array &$data)
+{
+    $data['summary'][] = 'success';
+}

--- a/tests/modules/unittest/hooks/invalid_hook_prefix.php
+++ b/tests/modules/unittest/hooks/invalid_hook_prefix.php
@@ -1,0 +1,3 @@
+<?php
+
+// Hook detection should not load this file since it does not conform to the hook naming scheme


### PR DESCRIPTION
Sometimes we patch or edit a hook to meet our specific needs.
Somtimes this leaves behind a file like FILENAME.orig. The hook
detection login still runs these other files, making for confusing
debugging issues. Use a stricter match on what makes a valid hook name
to avoid these issues.