### PR TITLE
Replace LogLevel ints with strings

### DIFF
--- a/lib/SimpleSAML/Error/Exception.php
+++ b/lib/SimpleSAML/Error/Exception.php
@@ -195,9 +195,11 @@ class Exception extends \Exception
 
     /**
      * Print the backtrace to the log if the 'debug' option is enabled in the configuration.
-     * @param int $level
+     *
+     * @param string $level
+     * @return void
      */
-    protected function logBacktrace(int $level = Logger::DEBUG): void
+    protected function logBacktrace(string $level = Logger::DEBUG): void
     {
         // Do nothing if backtraces have been disabled in config.
         $debug = Configuration::getInstance()->getArrayize('debug', ['backtraces' => true]);
@@ -207,14 +209,7 @@ class Exception extends \Exception
 
         $backtrace = $this->formatBacktrace();
 
-        $callback = [Logger::class];
-        $functions = [
-            Logger::ERR     => 'error',
-            Logger::WARNING => 'warning',
-            Logger::INFO    => 'info',
-            Logger::DEBUG   => 'debug',
-        ];
-        $callback[] = $functions[$level];
+        $callback = [Logger::class, $level];
 
         foreach ($backtrace as $line) {
             call_user_func($callback, $line);
@@ -227,12 +222,13 @@ class Exception extends \Exception
      *
      * Override to allow errors extending this class to specify the log level themselves.
      *
-     * @param int $default_level The log level to use if this method was not overridden.
+     * @param string $default_level The log level to use if this method was not overridden.
+     * @return void
      */
-    public function log(int $default_level): void
+    public function log(string $default_level): void
     {
         $fn = [
-            Logger::ERR     => 'logError',
+            Logger::ERROR     => 'logError',
             Logger::WARNING => 'logWarning',
             Logger::INFO    => 'logInfo',
             Logger::DEBUG   => 'logDebug',
@@ -249,7 +245,7 @@ class Exception extends \Exception
     public function logError(): void
     {
         Logger::error($this->getClass() . ': ' . $this->getMessage());
-        $this->logBacktrace(Logger::ERR);
+        $this->logBacktrace(Logger::ERROR);
     }
 
 

--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML;
 
 use Exception;
+use Psr\Log\LogLevel;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Logger\ErrorLogLoggingHandler;
 use SimpleSAML\Logger\FileLoggingHandler;
@@ -17,7 +18,7 @@ use SimpleSAML\Logger\SyslogLoggingHandler;
  *
  * @package SimpleSAMLphp
  */
-class Logger
+class Logger extends LogLevel
 {
     /**
      * @var \SimpleSAML\Logger\LoggingHandlerInterface
@@ -30,9 +31,9 @@ class Logger
     private static bool $initializing = false;
 
     /**
-     * @var integer|null
+     * @var string|null
      */
-    private static ?int $logLevel = null;
+    private static ?string $logLevel = null;
 
     /**
      * @var boolean
@@ -129,30 +130,6 @@ class Logger
      */
     private static bool $shuttingDown = false;
 
-    /** @var int */
-    public const EMERG = 0;
-
-    /** @var int */
-    public const ALERT = 1;
-
-    /** @var int */
-    public const CRIT = 2;
-
-    /** @var int */
-    public const ERR = 3;
-
-    /** @var int */
-    public const WARNING = 4;
-
-    /** @var int */
-    public const NOTICE = 5;
-
-    /** @var int */
-    public const INFO = 6;
-
-    /** @var int */
-    public const DEBUG = 7;
-
 
     /**
      * Log an emergency message.
@@ -161,7 +138,7 @@ class Logger
      */
     public static function emergency(string $string): void
     {
-        self::log(self::EMERG, $string);
+        self::log(self::EMERGENCY, $string);
     }
 
 
@@ -172,7 +149,7 @@ class Logger
      */
     public static function critical(string $string): void
     {
-        self::log(self::CRIT, $string);
+        self::log(self::CRITICAL, $string);
     }
 
 
@@ -194,7 +171,7 @@ class Logger
      */
     public static function error(string $string): void
     {
-        self::log(self::ERR, $string);
+        self::log(self::ERROR, $string);
     }
 
 
@@ -371,11 +348,11 @@ class Logger
     /**
      * Defer a message for later logging.
      *
-     * @param int     $level The log level corresponding to this message.
+     * @param string     $level The log level corresponding to this message.
      * @param string  $message The message itself to log.
      * @param boolean $stats Whether this is a stats message or a regular one.
      */
-    private static function defer(int $level, string $message, bool $stats): void
+    private static function defer(string $level, string $message, bool $stats): void
     {
         // save the message for later
         self::$earlyLog[] = ['level' => $level, 'string' => $message, 'statsLog' => $stats];
@@ -439,17 +416,17 @@ class Logger
         } catch (Exception $e) {
             self::$loggingHandler = new ErrorLogLoggingHandler($config);
             self::$initializing = false;
-            self::log(self::CRIT, $e->getMessage(), false);
+            self::log(self::CRITICAL, $e->getMessage(), false);
         }
     }
 
 
     /**
-     * @param int $level
+     * @param string $level
      * @param string $string
      * @param bool $statsLog
      */
-    private static function log(int $level, string $string, bool $statsLog = false): void
+    private static function log(string $level, string $string, bool $statsLog = false): void
     {
         if (self::$initializing) {
             // some error occurred while initializing logging

--- a/lib/SimpleSAML/Logger/ErrorLogLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/ErrorLogLoggingHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Logger;
 
+use Psr\Log\LogLevel;
 use SimpleSAML\Configuration;
 use SimpleSAML\Logger;
 
@@ -20,14 +21,14 @@ class ErrorLogLoggingHandler implements LoggingHandlerInterface
      * @var array<int, string>
      */
     private static array $levelNames = [
-        Logger::EMERG   => 'EMERG',
-        Logger::ALERT   => 'ALERT',
-        Logger::CRIT    => 'CRIT',
-        Logger::ERR     => 'ERR',
-        Logger::WARNING => 'WARNING',
-        Logger::NOTICE  => 'NOTICE',
-        Logger::INFO    => 'INFO',
-        Logger::DEBUG   => 'DEBUG',
+        LogLevel::EMERGENCY,
+        LogLevel::ALERT,
+        LogLevel::CRITICAL,
+        LogLevel::ERROR,
+        LogLevel::WARNING,
+        LogLevel::NOTICE,
+        LogLevel::INFO,
+        LogLevel::DEBUG,
     ];
 
     /**
@@ -64,13 +65,13 @@ class ErrorLogLoggingHandler implements LoggingHandlerInterface
     /**
      * Log a message to syslog.
      *
-     * @param int $level The log level.
+     * @param string $level The log level.
      * @param string $string The formatted message to log.
      */
-    public function log(int $level, string $string): void
+    public function log(string $level, string $string): void
     {
-        if (array_key_exists($level, self::$levelNames)) {
-            $levelName = self::$levelNames[$level];
+        if (in_array($level, self::$levelNames, true)) {
+            $levelName = $level;
         } else {
             $levelName = sprintf('UNKNOWN%d', $level);
         }

--- a/lib/SimpleSAML/Logger/FileLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/FileLoggingHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Logger;
 
+use Psr\Log\LogLevel;
 use SimpleSAML\Configuration;
 use SimpleSAML\Logger;
 use SimpleSAML\Utils;
@@ -29,14 +30,14 @@ class FileLoggingHandler implements LoggingHandlerInterface
      * @var array<int, string>
      */
     private static $levelNames = [
-        Logger::EMERG   => 'EMERGENCY',
-        Logger::ALERT   => 'ALERT',
-        Logger::CRIT    => 'CRITICAL',
-        Logger::ERR     => 'ERROR',
-        Logger::WARNING => 'WARNING',
-        Logger::NOTICE  => 'NOTICE',
-        Logger::INFO    => 'INFO',
-        Logger::DEBUG   => 'DEBUG',
+        LogLevel::EMERGENCY,
+        LogLevel::ALERT,
+        LogLevel::CRITICAL,
+        LogLevel::ERROR,
+        LogLevel::WARNING,
+        LogLevel::NOTICE,
+        LogLevel::INFO,
+        LogLevel::DEBUG,
     ];
 
     /** @var string */
@@ -90,20 +91,21 @@ class FileLoggingHandler implements LoggingHandlerInterface
     /**
      * Log a message to the log file.
      *
-     * @param int    $level The log level.
+     * @param string    $level The log level.
      * @param string $string The formatted message to log.
      */
-    public function log(int $level, string $string): void
+    public function log(string $level, string $string): void
     {
         if (!is_null($this->logFile)) {
             // set human-readable log level. Copied from SimpleSAML\Logger\ErrorLogLoggingHandler.
             $levelName = sprintf('UNKNOWN%d', $level);
-            if (array_key_exists($level, self::$levelNames)) {
-                $levelName = self::$levelNames[$level];
+            if (in_array($level, self::$levelNames, true)) {
+                $levelName = $level;
             }
 
             $formats = ['%process', '%level'];
-            $replacements = [$this->processname, $levelName];
+            $replacements = [$this->processname];
+            $replacements[] = $levelName;
 
             $matches = [];
             if (preg_match('/%date(?:\{([^\}]+)\})?/', $this->format, $matches)) {

--- a/lib/SimpleSAML/Logger/LoggingHandlerInterface.php
+++ b/lib/SimpleSAML/Logger/LoggingHandlerInterface.php
@@ -25,10 +25,10 @@ interface LoggingHandlerInterface
     /**
      * Log a message to its destination.
      *
-     * @param int $level The log level.
+     * @param string $level The log level.
      * @param string $string The message to log.
      */
-    public function log(int $level, string $string): void;
+    public function log(string $level, string $string): void;
 
 
     /**

--- a/lib/SimpleSAML/Logger/SyslogLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/SyslogLoggingHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Logger;
 
+use Psr\Log\LogLevel;
 use SimpleSAML\Configuration;
 use SimpleSAML\Utils;
 
@@ -19,6 +20,22 @@ class SyslogLoggingHandler implements LoggingHandlerInterface
 
     /** @var string */
     protected string $format = "%b %d %H:%M:%S";
+
+    /**
+     * This array contains the mappings from syslog log level to names.
+     *
+     * @var array
+     */
+    private static $levelNames = [
+        LogLevel::EMERGENCY => 0,
+        LogLevel::ALERT => 1,
+        LogLevel::CRITICAL => 2,
+        LogLevel::ERROR => 3,
+        LogLevel::WARNING => 4,
+        LogLevel::NOTICE => 5,
+        LogLevel::INFO => 6,
+        LogLevel::DEBUG => 7,
+    ];
 
 
     /**
@@ -56,11 +73,13 @@ class SyslogLoggingHandler implements LoggingHandlerInterface
     /**
      * Log a message to syslog.
      *
-     * @param int $level The log level.
+     * @param string $level The log level.
      * @param string $string The formatted message to log.
      */
-    public function log(int $level, string $string): void
+    public function log(string $level, string $string): void
     {
+        $level = self::$levelNames[$level];
+
         // changing log level to supported levels if OS is Windows
         if ($this->isWindows) {
             if ($level <= 4) {


### PR DESCRIPTION
This checks one of the boxes in #371:
- [ ] Extract the log levels definition from \SimpleSAML\Logger and use the ones defined by Psr\Log\LogLevel instead.