### PR TITLE
Make inResponseTo available in auth state

### DIFF
--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -262,6 +262,7 @@ if ($expire !== null) {
 $state['saml:sp:prevAuth'] = [
     'id'     => $response->getId(),
     'issuer' => $issuer,
+    'inResponseTo' => $response->getInResponseTo(),
 ];
 if (isset($state['\SimpleSAML\Auth\Source.ReturnURL'])) {
     $state['saml:sp:prevAuth']['redirect'] = $state['\SimpleSAML\Auth\Source.ReturnURL'];


### PR DESCRIPTION
Hi, thanks for all the hard work around SSP, greatly appreciated!

This pull request makes SAML Response 'InResponseTo' attribute value available in auth state array. The purpose is to make it easily accessible on the SP side after the user authn, for example using the method \SimpleSAML\Auth\Simple::getAuthDataArray.

Use case is the following: we have an SP which enables users to authenticate using Croatian national identity infrastructure (NIAS). They have released a new feature - possibility to include their own header, like a banner, into every SP, so that every service has the same look, so to say, regarding the header part of the site. To get this header, a separate request is needed, with one of the parameters being the value of the 'InResponseTo' attribute of the SAML Response.