### PR TITLE
Identifiers fix #2

### DIFF
--- a/modules/core/docs/authproc_pairwiseid.md
+++ b/modules/core/docs/authproc_pairwiseid.md
@@ -7,6 +7,10 @@ http://docs.oasis-open.org/security/saml-subject-id-attr/v1.0/saml-subject-id-at
 This filter will take an attribute and a scope as input and transforms this into a anonymized and scoped
 identifier that is globally unique for a given user & service provider combination.
 
+Note:
+Since the subject-id is specified as single-value attribute, only the first value of `identifyingAttribute`
+ and `scopeAttribute` are considered.
+
 Examples
 --------
 

--- a/modules/core/docs/authproc_subjectid.md
+++ b/modules/core/docs/authproc_subjectid.md
@@ -10,6 +10,10 @@ Note:
 -----
 If privacy is of your concern, you may want to use the PairwiseID-filter instead.
 
+Note:
+Since the subject-id is specified as single-value attribute, only the first value of `identifyingAttribute`
+ and `scopeAttribute` are considered.
+
 Examples
 --------
 

--- a/modules/core/lib/Auth/Process/PairwiseID.php
+++ b/modules/core/lib/Auth/Process/PairwiseID.php
@@ -20,6 +20,9 @@ use SimpleSAML\Utils;
  * This is generated from the attribute configured in 'identifyingAttribute' in the
  * authproc-configuration.
  *
+ * NOTE: since the subject-id is specified as single-value attribute, only the first value of `identifyingAttribute`
+ *       and `scopeAttribute` are considered.
+ *
  * Example - generate from attribute:
  * <code>
  * 'authproc' => [

--- a/modules/core/lib/Auth/Process/SubjectID.php
+++ b/modules/core/lib/Auth/Process/SubjectID.php
@@ -20,6 +20,9 @@ use SimpleSAML\Logger;
  * This is generated from the attribute configured in 'identifyingAttribute' in the
  * authproc-configuration.
  *
+ * NOTE: since the subject-id is specified as single-value attribute, only the first value of `identifyingAttribute`
+ *       and `scopeAttribute` are considered.
+ *
  * Example - generate from attribute:
  * <code>
  * 'authproc' => [
@@ -186,6 +189,13 @@ class SubjectID extends Auth\ProcessingFilter
 
             $scope = $state['Attributes'][$this->scopeAttribute][0];
             Assert::stringNotEmpty($scope, 'core' . static::NAME . ': \'scopeAttribute\' cannot be an empty string.');
+
+            // If the value is scoped, extract the scope from it
+            if (strpos($scope, '@') !== false) {
+                $scope = explode('@', $scope, 2);
+                $scope = $scope[1];
+            }
+
             Assert::regex(
                 $scope,
                 self::SCOPE_PATTERN,

--- a/tests/modules/core/lib/Auth/Process/PairwiseIDTest.php
+++ b/tests/modules/core/lib/Auth/Process/PairwiseIDTest.php
@@ -98,6 +98,30 @@ class PairwiseIDTest extends TestCase
 
 
     /**
+     * Test the most basic functionality, but with a scoped scope-attribute
+     */
+    public function testBasicScopedScope(): void
+    {
+        $config = ['identifyingAttribute' => 'uid', 'scopeAttribute' => 'scope'];
+        $request = [
+            'Attributes' => ['uid' => ['u=se-r2'], 'scope' => ['u=se-r2@ex-ample.org']],
+            'core:SP' => 'urn:sp',
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey(Constants::ATTR_PAIRWISE_ID, $attributes);
+        $this->assertRegExp(
+            PairwiseID::SPEC_PATTERN,
+            $attributes[Constants::ATTR_PAIRWISE_ID][0]
+        );
+        $this->assertEquals(
+            '53d4f7fe57fb597ada481e81e0f15048bc610774cbb5614ea38f08ea918ba199@ex-ample.org',
+            $attributes[Constants::ATTR_PAIRWISE_ID][0]
+        );
+    }
+
+
+    /**
      * Test the most basic functionality
      */
     public function testBasicOldScopeConfig(): void

--- a/tests/modules/core/lib/Auth/Process/SubjectIDTest.php
+++ b/tests/modules/core/lib/Auth/Process/SubjectIDTest.php
@@ -82,6 +82,26 @@ class SubjectIDTest extends TestCase
 
 
     /**
+     * Test the most basic functionality, but with a scoped scope-attribute
+     */
+    public function testScopedScope(): void
+    {
+        $config = ['identifyingAttribute' => 'uid', 'scopeAttribute' => 'scope'];
+        $request = [
+            'Attributes' => ['uid' => ['u=se-r2'], 'scope' => ['u=se-r2@ex-ample.org']],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey(Constants::ATTR_SUBJECT_ID, $attributes);
+        $this->assertRegExp(
+            SubjectID::SPEC_PATTERN,
+            $attributes[Constants::ATTR_SUBJECT_ID][0]
+        );
+        $this->assertEquals('u=se-r2@ex-ample.org', $attributes[Constants::ATTR_SUBJECT_ID][0]);
+    }
+
+
+    /**
      * Test the most basic functionality using old-style scope-setting
      */
     public function testBasicOldScopeConfig(): void


### PR DESCRIPTION
This rationalizes the behaviour and makes it work the same as the core:ScopeAttribute authproc.
Also additional docs

Closes #1459