### PR TITLE
Fix authproc/authsource in externalized module being usable illegally

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -16,6 +16,7 @@ Released TBD
   * Fixed a bug in the logger that would break encoded urls in the message
   * Return a proper HTTP/405 code when incorrect method is used (#1400)
   * Fixed the 'rememberenabled' config setting of the built-in IdP discovery.
+  * Fixed a bug where code from external modules would run even though the module is explicitly enabled (#1463)
 
 ### adfs
   * Fixed several issues that rendered the old UI useless for this module (v0.9.8)

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -436,6 +436,12 @@ class Module
             if (!class_exists($className)) {
                 throw new \Exception("Could not resolve '$id': no class named '$className'.");
             }
+        } elseif (!in_array($tmp[0], self::getModules())) {
+            // Module not installed
+            throw new \Exception('No module named \'' . $tmp[0]. '\' has been installed.');
+        } elseif (!self::isModuleEnabled($tmp[0])) {
+            // Module installed, but not enabled
+            throw new \Exception('The module \'' . $tmp[0]. '\' is not enabled.');
         } else {
             // should be a module
             // make sure empty types are handled correctly


### PR DESCRIPTION
External modules could still be used even when not explicitly enabled.
Master was not affected by this bug.