### PR TITLE
Now allowing Authsources to set validUntil and cacheDuration for Metadata.

### DIFF
--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -506,6 +506,8 @@ class SAMLBuilder
         Assert::notNull($metadata['entityid']);
         Assert::notNull($metadata['metadata-set']);
 
+        $this->setExpiration($metadata);
+
         $metadata = Configuration::loadFromArray($metadata, $metadata['entityid']);
 
         $e = new SPSSODescriptor();

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -50,34 +50,12 @@ class SAMLBuilder
 
 
     /**
-     * The maximum time in seconds the metadata should be cached.
-     *
-     * @var int|null
-     */
-    private ?int $maxCache = null;
-
-
-    /**
-     * The maximum time in seconds since the current time that this metadata should be considered valid.
-     *
-     * @var int|null
-     */
-    private ?int $maxDuration = null;
-
-
-    /**
      * Initialize the SAML builder.
      *
      * @param string   $entityId The entity id of the entity.
-     * @param int|null $maxCache The maximum time in seconds the metadata should be cached. Defaults to null
-     * @param int|null $maxDuration The maximum time in seconds this metadata should be considered valid. Defaults
-     * to null.
      */
-    public function __construct(string $entityId, int $maxCache = null, int $maxDuration = null)
+    public function __construct(string $entityId)
     {
-        $this->maxCache = $maxCache;
-        $this->maxDuration = $maxDuration;
-
         $this->entityDescriptor = new EntityDescriptor();
         $this->entityDescriptor->setEntityID($entityId);
     }
@@ -88,17 +66,11 @@ class SAMLBuilder
      */
     private function setExpiration(array $metadata): void
     {
-        if (array_key_exists('expire', $metadata)) {
-            if ($metadata['expire'] - time() < $this->maxDuration) {
-                $this->maxDuration = $metadata['expire'] - time();
-            }
+        if (array_key_exists('cacheDuration', $metadata)) {
+            $this->entityDescriptor->setCacheDuration('PT' . $metadata['cacheDuration'] . 'S');
         }
-
-        if ($this->maxCache !== null) {
-            $this->entityDescriptor->setCacheDuration('PT' . $this->maxCache . 'S');
-        }
-        if ($this->maxDuration !== null) {
-            $this->entityDescriptor->setValidUntil(time() + $this->maxDuration);
+        if (array_key_exists('validUntil', $metadata)) {
+            $this->entityDescriptor->setValidUntil($metadata['validUntil']);
         }
     }
 

--- a/lib/SimpleSAML/Metadata/SAMLParser.php
+++ b/lib/SimpleSAML/Metadata/SAMLParser.php
@@ -559,9 +559,11 @@ class SAMLParser
         // we currently only look at the first SPDescriptor which supports SAML 2.0
         $spd = $spd[0];
 
-        // add expire time to metadata
-        if (array_key_exists('expire', $spd)) {
-            $ret['expire'] = $spd['expire'];
+        if (array_key_exists('validUntil', $spd)) {
+            $ret['validUntil'] = $spd['validUntil'];
+        }
+        if (array_key_exists('cacheDuration', $spd)) {
+            $ret['cacheDuration'] = $spd['cacheDuration'];
         }
 
         // find the assertion consumer service endpoints

--- a/modules/admin/lib/Controller/Federation.php
+++ b/modules/admin/lib/Controller/Federation.php
@@ -360,7 +360,7 @@ class Federation
                 $source->getMetadata()->getLocalizedString('OrganizationDisplayName', $source->getAuthId())
             );
 
-            $builder = new SAMLBuilder($source->getEntityId(), $metadata['maxCache'] ?? null, $metadata['maxDuration'] ?? null);
+            $builder = new SAMLBuilder($source->getEntityId(), $metadata['validUntil'] ?? null, $metadata['cacheDuration'] ?? null);
             $builder->addMetadataSP20($metadata, $source->getSupportedProtocols());
             $builder->addOrganizationInfo($metadata);
             $xml = $builder->getEntityDescriptorText(true);

--- a/modules/admin/lib/Controller/Federation.php
+++ b/modules/admin/lib/Controller/Federation.php
@@ -360,7 +360,7 @@ class Federation
                 $source->getMetadata()->getLocalizedString('OrganizationDisplayName', $source->getAuthId())
             );
 
-            $builder = new SAMLBuilder($source->getEntityId());
+            $builder = new SAMLBuilder($source->getEntityId(), $metadata['maxCache'] ?? null, $metadata['maxDuration'] ?? null);
             $builder->addMetadataSP20($metadata, $source->getSupportedProtocols());
             $builder->addOrganizationInfo($metadata);
             $xml = $builder->getEntityDescriptorText(true);

--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -245,11 +245,11 @@ Options
 :   IsPassive allows you to enable passive authentication by default for this SP.
 
 
-`maxCache`
-:   maxCache allows you to set the `validUntil` in the SP's metadata. It's an integer representing the amount of seconds.
+`validUntil`
+:   validUntil allows you to set the `validUntil` in the SP's metadata. It's an integer representing the amount of seconds since current time.
 
-`maxDuration`
-:   maxDuration allows you to set the `cacheDuration` in the SP's metadata. It's an integer representing the amount of seconds.
+`cacheDuration`
+:   cacheDuration allows you to set the `cacheDuration` in the SP's metadata. It's an integer representing the amount of seconds.
 
 `name`
 :   The name of this SP.

--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -245,6 +245,12 @@ Options
 :   IsPassive allows you to enable passive authentication by default for this SP.
 
 
+`maxCache`
+:   maxCache allows you to set the `validUntil` in the SP's metadata. It's an integer representing the amount of seconds.
+
+`maxDuration`
+:   maxDuration allows you to set the `cacheDuration` in the SP's metadata. It's an integer representing the amount of seconds.
+
 `name`
 :   The name of this SP.
     Will be added to the generated metadata, in an AttributeConsumingService element.

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -136,13 +136,13 @@ class SP extends \SimpleSAML\Auth\Source
             'AssertionConsumerService' => $this->getACSEndpoints(),
         ];
 
-        // add maxCache / maxDuration
-        if ($this->metadata->hasValue('maxCache')) {
-            $metadata['maxCache'] = $this->metadata->getInteger('maxCache');
+        // add validUntil / cacheDuration
+        if ($this->metadata->hasValue('validUntil')) {
+            $metadata['validUntil'] = $this->metadata->getInteger('validUntil');
         }
 
-        if ($this->metadata->hasValue('maxDuration')) {
-            $metadata['maxDuration'] = $this->metadata->getInteger('maxDuration');
+        if ($this->metadata->hasValue('cacheDuration')) {
+            $metadata['cacheDuration'] = $this->metadata->getInteger('cacheDuration');
         }
 
         // add NameIDPolicy

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -136,6 +136,15 @@ class SP extends \SimpleSAML\Auth\Source
             'AssertionConsumerService' => $this->getACSEndpoints(),
         ];
 
+        // add maxCache / maxDuration
+        if ($this->metadata->hasValue('maxCache')) {
+            $metadata['maxCache'] = $this->metadata->getInteger('maxCache');
+        }
+
+        if ($this->metadata->hasValue('maxDuration')) {
+            $metadata['maxDuration'] = $this->metadata->getInteger('maxDuration');
+        }
+
         // add NameIDPolicy
         if ($this->metadata->hasValue('NameIDPolicy')) {
             $format = $this->metadata->getValue('NameIDPolicy');


### PR DESCRIPTION
Now allowing generation of SP metadata XML that includes @validuntil or @cacheDuration at EntityDescriptor.