### PR TITLE
SP Metadata compliance Improvements

### DIFF
--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -1119,6 +1119,7 @@ class Configuration implements Utils\ClearableState
         return $ret;
     }
 
+
     /**
      * Get the fingerprint for provided certificateData
      *
@@ -1127,13 +1128,15 @@ class Configuration implements Utils\ClearableState
      * @return string|null Given certificate's fingerprint
      *
      */
-    public static function extractKeyNameFromCertData(string $certData) : ?string {
+    public static function extractKeyNameFromCertData(string $certData) : ?string
+    {
         $certFingerPrint = openssl_x509_fingerprint($certData, 'sha1');
         if ($certFingerPrint === false) {
-            return NULL;
+            return null;
         }
         return $certFingerPrint;
     }
+
 
     /**
      * Get public key from metadata.
@@ -1160,7 +1163,7 @@ class Configuration implements Utils\ClearableState
                 }
                 if (isset($key['X509Certificate'])) {
                     $certData = preg_replace('/\s+/', '', $key['X509Certificate']);
-                    $pem = "-----BEGIN CERTIFICATE-----\n".$certData."\n-----END CERTIFICATE-----\n";
+                    $pem = "-----BEGIN CERTIFICATE-----\n" . $certData . "\n-----END CERTIFICATE-----\n";
                     $keyName = self::extractKeyNameFromCertData($pem);
 
                     // Strip whitespace from key
@@ -1173,7 +1176,7 @@ class Configuration implements Utils\ClearableState
         } elseif ($this->hasValue($prefix . 'certData')) {
             $certData = $this->getString($prefix . 'certData');
             $certData = preg_replace('/\s+/', '', $certData);
-            $pem = "-----BEGIN CERTIFICATE-----\n".$certData."\n-----END CERTIFICATE-----\n";
+            $pem = "-----BEGIN CERTIFICATE-----\n" . $certData  ."\n-----END CERTIFICATE-----\n";
             $keyName = self::extractKeyNameFromCertData($pem);
             return [
                 [

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -1130,7 +1130,7 @@ class Configuration implements Utils\ClearableState
      */
     public static function extractKeyNameFromCertData(string $certData) : ?string
     {
-        $certFingerPrint = openssl_x509_fingerprint($certData, 'sha1');
+        $certFingerPrint = @openssl_x509_fingerprint($certData, 'sha1');
         if ($certFingerPrint === false) {
             return null;
         }

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -698,6 +698,8 @@ class SAMLBuilder
     private function addX509KeyDescriptor(RoleDescriptor $rd, string $use, string $x509data, ?string $keyName = null): void
     {
         Assert::oneOf($use, ['encryption', 'signing']);
+        Assert::nullOrNotWhitespaceOnly($keyName);
+        Assert::regex('/^[a-zA-Z_][\w.-]*$/', $keyName, "KeyName should be valid for usage in an ID atttribute, e.g. not start with a digit, no whitespace.");
 
         $keyDescriptor = \SAML2\Utils::createKeyDescriptor($x509data, $keyName);
         $keyDescriptor->setUse($use);

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -381,12 +381,12 @@ class SAMLBuilder
                     }
 
                     $ep['index'] = $maxIndex + 1;
-                    if (isset($ep['isDefault'])) {
-                        $t->setIsDefault($ep['isDefault']);
-                    }
                 }
 
                 $t->setIndex($ep['index']);
+                if (isset($ep['isDefault'])) {
+                    $t->setIsDefault($ep['isDefault']);
+                }
             } else {
                 $t = new EndpointType();
             }

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -721,14 +721,20 @@ class SAMLBuilder
                 continue;
             }
 
-            //make sure the key is unique, even when used for multiple entities
-            $keyName = '_' . sha1( $this->entityDescriptor->getEntityID() . $key['keyName']) ?? null;
+            // Make sure the key is unique, even when used for multiple entities
+            $keyName = null;
+            if ($key['keyName'] !== null) {
+                $configUtils = new Utils\Config();
+                $salt = $configUtils->getSecretSalt();
+                $entityId = $this->entityDescriptor->getEntityID();
+                $keyName = '_' . hash('sha256', $salt . $entityId . $key['keyName'], false);
+            }
 
             if (!isset($key['signing']) || $key['signing'] === true) {
-                $this->addX509KeyDescriptor($rd, 'signing', $key['X509Certificate'], $keyName );
+                $this->addX509KeyDescriptor($rd, 'signing', $key['X509Certificate'], $keyName);
             }
             if (!isset($key['encryption']) || $key['encryption'] === true) {
-                $this->addX509KeyDescriptor($rd, 'encryption', $key['X509Certificate'], $keyName );
+                $this->addX509KeyDescriptor($rd, 'encryption', $key['X509Certificate'], $keyName);
             }
         }
 

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -77,6 +77,9 @@ $eps = [];
 $supported_protocols = [];
 foreach ($assertionsconsumerservices as $services) {
     $acsArray = ['index' => $index];
+    if ($index == 0) {
+        $acsArray['isDefault'] = TRUE;
+    }
     switch ($services) {
         case 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST':
             $acsArray['Binding'] = Constants::BINDING_HTTP_POST;

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -77,9 +77,6 @@ $eps = [];
 $supported_protocols = [];
 foreach ($assertionsconsumerservices as $services) {
     $acsArray = ['index' => $index];
-    if ($index == 0) {
-        $acsArray['isDefault'] = TRUE;
-    }
     switch ($services) {
         case 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST':
             $acsArray['Binding'] = Constants::BINDING_HTTP_POST;

--- a/tests/modules/admin/lib/Controller/FederationTest.php
+++ b/tests/modules/admin/lib/Controller/FederationTest.php
@@ -72,7 +72,8 @@ class FederationTest extends TestCase
                 'enable.saml20-idp' => true,
                 'enable.adfs-idp' => true,
                 'language.default' => 'fr',
-                'language.get_language_function' => [$this, 'getLanguage']
+                'language.get_language_function' => [$this, 'getLanguage'],
+                'secretsalt' => 'abc123',
             ],
             '[ARRAY]',
             'simplesaml'


### PR DESCRIPTION
- Now setting keyName of KeyInfo. This is derived from both the certificate fingerprint and the entityId.
- Now setting IsDefault argument for first ACS in SP metadata generation.