### PR TITLE
When downloading metadata, add a .xml extension

### DIFF
--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -70,6 +70,6 @@ if (array_key_exists('output', $_REQUEST) && $_REQUEST['output'] == 'xhtml') {
     $t->send();
 } else {
     header('Content-Type: application/samlmetadata+xml');
-    header('Content-Disposition: attachment; filename="' . $sourceId . '.xml"');
+    header('Content-Disposition: attachment; filename="' . basename($sourceId) . '.xml"');
     echo($xml);
 }

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -70,5 +70,6 @@ if (array_key_exists('output', $_REQUEST) && $_REQUEST['output'] == 'xhtml') {
     $t->send();
 } else {
     header('Content-Type: application/samlmetadata+xml');
+    header('Content-Disposition: attachment; filename="' . $sourceId . '.xml"');
     echo($xml);
 }

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -249,7 +249,7 @@ try {
         $t->send();
     } else {
         header('Content-Type: application/samlmetadata+xml');
-        header('Content-Disposition: attachment; filename="' . $idpentityid . '.xml"');
+        header('Content-Disposition: attachment; filename="' . basename($idpentityid) . '.xml"');
 
         echo $metaxml;
         exit(0);

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -249,6 +249,7 @@ try {
         $t->send();
     } else {
         header('Content-Type: application/samlmetadata+xml');
+        header('Content-Disposition: attachment; filename="' . $idpentityid . '.xml"');
 
         echo $metaxml;
         exit(0);


### PR DESCRIPTION
This adds a headers so when you visit a metadata url, it is donwloaded as `default-sp.xml` instead of `default-sp`. This makes it easier to open and upload in other systems.