### PR TITLE
getEntityDisplayName to get entityID's name for display

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -734,41 +734,6 @@ $config = [
      *************************************/
 
     /*
-     * Language-related options.
-     */
-    'language' => [
-        /*
-         * An array in the form 'language' => <list of alternative languages>.
-         *
-         * Each key in the array is the ISO 639 two-letter code for a language,
-         * and its value is an array with a list of alternative languages that
-         * can be used if the given language is not available at some point.
-         * Each alternative language is also specified by its ISO 639 code.
-         *
-         * For example, for the "no" language code (Norwegian), we would have:
-         *
-         * 'priorities' => [
-         *      'no' => ['nb', 'nn', 'en', 'se'],
-         *      ...
-         * ],
-         *
-         * establishing that if a translation for the "no" language code is
-         * not available, we look for translations in "nb",
-         * and so on, in that order.
-         */
-        'priorities' => [
-            'no' => ['nb', 'nn', 'en', 'se'],
-            'nb' => ['no', 'nn', 'en', 'se'],
-            'nn' => ['no', 'nb', 'en', 'se'],
-            'se' => ['nb', 'no', 'nn', 'en'],
-            'nr' => ['zu', 'en'],
-            'nd' => ['zu', 'en'],
-            'tw' => ['st', 'en'],
-            'nso' => ['st', 'en'],
-        ],
-    ],
-
-    /*
      * Languages available, RTL languages, and what language is the default.
      */
     'language.available' => [

--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -49,3 +49,6 @@ Upgrade notes for SimpleSAMLphp 2.0
     - lib/SimpleSAML/Store/SQL.php has been renamed to lib/SimpleSAML/Store/SQLStore.php
     - lib/SimpleSAML/Store/Memcache.php has been renamed to lib/SimpleSAML/Store/MemcacheStore.php
     - lib/SimpleSAML/Store/Redis.php has been renamed to lib/SimpleSAML/Store/RedisStore.php
+
+- Configuration options removed:
+  - languages[priorities]

--- a/lib/SimpleSAML/IdP.php
+++ b/lib/SimpleSAML/IdP.php
@@ -169,6 +169,8 @@ class IdP
 
     /**
      * Get SP name.
+     * Only usefd in IFrameLogout it seems.
+     * TODO: probably replace with template Template::getEntityDisplayName()
      *
      * @param string $assocId The association identifier.
      *

--- a/lib/SimpleSAML/IdP.php
+++ b/lib/SimpleSAML/IdP.php
@@ -169,7 +169,7 @@ class IdP
 
     /**
      * Get SP name.
-     * Only usefd in IFrameLogout it seems.
+     * Only used in IFrameLogout it seems.
      * TODO: probably replace with template Template::getEntityDisplayName()
      *
      * @param string $assocId The association identifier.

--- a/lib/SimpleSAML/Locale/Translate.php
+++ b/lib/SimpleSAML/Locale/Translate.php
@@ -393,20 +393,6 @@ class Translate
             return $translations[$context['currentLanguage']];
         }
 
-        // we don't have a translation for the current language, load alternative priorities
-        $sspcfg = Configuration::getInstance();
-        /** @psalm-var \SimpleSAML\Configuration $langcfg */
-        $langcfg = $sspcfg->getConfigItem('language');
-        $priorities = $langcfg->getArray('priorities', []);
-
-        if (!empty($priorities[$context['currentLanguage']])) {
-            foreach ($priorities[$context['currentLanguage']] as $lang) {
-                if (isset($translations[$lang])) {
-                    return $translations[$lang];
-                }
-            }
-        }
-
         // nothing we can use, return null so that we can set a default
         return null;
     }

--- a/lib/SimpleSAML/XHTML/IdPDisco.php
+++ b/lib/SimpleSAML/XHTML/IdPDisco.php
@@ -589,30 +589,12 @@ class IdPDisco
 
         $t = new Template($this->config, $templateFile, 'disco');
 
-        $fallbackLanguage = 'en';
-        $defaultLanguage = $this->config->getString('language.default', $fallbackLanguage);
-        $translator = $t->getTranslator();
-        $language = $translator->getLanguage()->getLanguage();
-        $tryLanguages = [0 => $language, 1 => $defaultLanguage, 2 => $fallbackLanguage];
-
         $newlist = [];
         foreach ($idpList as $entityid => $data) {
             $newlist[$entityid]['entityid'] = $entityid;
-            foreach ($tryLanguages as $lang) {
-                if ($name = $this->getEntityDisplayName($data, $lang)) {
-                    $newlist[$entityid]['name'] = $name;
-                    continue;
-                }
-            }
-            if (empty($newlist[$entityid]['name'])) {
-                $newlist[$entityid]['name'] = $entityid;
-            }
-            foreach ($tryLanguages as $lang) {
-                if (!empty($data['description'][$lang])) {
-                    $newlist[$entityid]['description'] = $data['description'][$lang];
-                    continue;
-                }
-            }
+            $newlist[$entityid]['name'] = $t->getEntityDisplayName($data);
+
+            $newlist[$entityid]['description'] = $t->getEntityPropertyTranslation('description', $data);
             if (!empty($data['icon'])) {
                 $newlist[$entityid]['icon'] = $data['icon'];
                 $newlist[$entityid]['iconurl'] = $httpUtils->resolveURL($data['icon']);
@@ -639,23 +621,5 @@ class IdPDisco
         $t->data['rememberenabled'] = $this->config->getBoolean('idpdisco.enableremember', false);
         $t->data['rememberchecked'] = $this->config->getBoolean('idpdisco.rememberchecked', false);
         $t->send();
-    }
-
-
-    /**
-     * @param array $idpData
-     * @param string $language
-     * @return string|null
-     */
-    private function getEntityDisplayName(array $idpData, string $language): ?string
-    {
-        if (isset($idpData['UIInfo']['DisplayName'][$language])) {
-            return $idpData['UIInfo']['DisplayName'][$language];
-        } elseif (isset($idpData['name'][$language])) {
-            return $idpData['name'][$language];
-        } elseif (isset($idpData['OrganizationDisplayName'][$language])) {
-            return $idpData['OrganizationDisplayName'][$language];
-        }
-        return null;
     }
 }

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -583,4 +583,47 @@ class Template extends Response
     {
         return $this->translator->getLanguage()->isLanguageRTL();
     }
+
+    /**
+     * Search through entity metadata to find the best display name for this
+     * entity. It will search in order for the current language, default
+     * language and fallback language for the DisplayName, name, OrganizationDisplayName
+     * and OrganizationName; the first one found is considered the best match.
+     * If nothing found, will return the entityId.
+     */
+    public function getEntityDisplayName(array $data): string
+    {
+        $tryLanguages = $this->translator->getLanguage()->getPreferredLanguages();
+
+        foreach($tryLanguages as $language) {
+            if (isset($data['UIInfo']['DisplayName'][$language])) {
+                return $data['UIInfo']['DisplayName'][$language];
+            } elseif (isset($data['name'][$language])) {
+                return $data['name'][$language];
+            } elseif (isset($data['OrganizationDisplayName'][$language])) {
+                return $data['OrganizationDisplayName'][$language];
+            } elseif (isset($data['OrganizationName'][$language])) {
+                return $data['OrganizationName'][$language];
+            }
+        }
+        return $data['entityid'];
+    }
+
+    /**
+     * Search through entity metadata to find the best value for a
+     * specific property. It will search in order for the current language, default
+     * language and fallback language; if not found it returns null.
+     */
+    public function getEntityPropertyTranslation(string $property, array $data): ?string
+    {
+        $tryLanguages = $this->translator->getLanguage()->getPreferredLanguages();
+
+        foreach($tryLanguages as $language) {
+            if (isset($data[$property][$language])) {
+                return $data[$property][$language];
+            }
+        }
+
+        return null;
+    }
 }

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -325,6 +325,13 @@ class Template extends Response
                 ['needs_context' => true]
             )
         );
+        // add a filter for preferred entity name
+        $twig->addFilter(
+            new TwigFilter(
+                'entityDisplayName',
+                [$this, 'getEntityDisplayName'],
+            )
+        );
 
         // add an asset() function
         $twig->addFunction(new TwigFunction('asset', [$this, 'asset']));

--- a/tests/lib/SimpleSAML/Locale/LanguageTest.php
+++ b/tests/lib/SimpleSAML/Locale/LanguageTest.php
@@ -173,4 +173,27 @@ class LanguageTest extends TestCase
         $l = new Language($c);
         $this->assertEquals('en', $l->getLanguage());
     }
+
+    public function testGetPreferredLanguages(): void
+    {
+        // test defaults
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $l = new Language($c);
+        $l->setLanguage('en');
+        $this->assertEquals(['en'], $l->getPreferredLanguages());
+
+        // test order current, default, fallback
+        $c = Configuration::loadFromArray([
+            'language.available' => ['fr', 'nn', 'es'],
+            'language.default' => 'nn',
+        ], '', 'simplesaml');
+        $l = new Language($c);
+        $l->setLanguage('es');
+        $this->assertEquals(['es', 'nn', 'en'], $l->getPreferredLanguages());
+
+        // test duplicate values (curlang is default lang) removed
+        $l->setLanguage('nn');
+        $this->assertEquals([0 => 'nn', 2 => 'en'], $l->getPreferredLanguages());
+    }
+
 }

--- a/tests/lib/SimpleSAML/XHTML/TemplateTest.php
+++ b/tests/lib/SimpleSAML/XHTML/TemplateTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\XHTML;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
+use SimpleSAML\XHTML\Template;
+
+/**
+ * @covers \SimpleSAML\XHTML\Template
+ */
+class TemplateTest extends TestCase
+{
+    private const TEMPLATE = 'sandbox.twig';
+
+    function testSetup(): void
+    {
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $t = new Template($c, self::TEMPLATE);
+        $this->assertEquals(self::TEMPLATE, $t->getTemplateName());
+    }
+
+    function testNormalizeName(): void
+    {
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $t = new Template($c, 'sandbox');
+        $this->assertEquals(self::TEMPLATE, $t->getTemplateName());
+    }
+
+    function testTemplateModuleNamespace(): void
+    {
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $t = new Template($c, 'core:login');
+        $this->assertEquals('core:login.twig', $t->getTemplateName());
+    }
+
+    function testGetEntityDisplayNameBasic(): void
+    {
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $t = new Template($c, self::TEMPLATE);
+
+        $data = [
+            'entityid' => 'urn:example.org',
+            'name' => ['nl' => 'Something', 'en' => 'Other lang'],
+        ];
+        $name = $t->getEntityDisplayName($data);
+        $this->assertEquals('Other lang', $name);
+
+        $c = Configuration::loadFromArray(['language.default' => 'nl'], '', 'simplesaml');
+        $t = new Template($c, self::TEMPLATE);
+        $name = $t->getEntityDisplayName($data);
+        $this->assertEquals('Something', $name);
+    }
+
+    function testGetEntityDisplayNamePriorities(): void
+    {
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $t = new Template($c, self::TEMPLATE);
+
+        $data = [
+            'entityid' => 'urn:example.org',
+        ];
+        $name = $t->getEntityDisplayName($data);
+        $this->assertEquals('urn:example.org', $name);
+
+        $data['OrganizationName'] = ['fr' => 'Example Org', 'nl' => 'Anything Org'];
+        $data['OrganizationDisplayName'] = ['fr' => 'DisplayExample', 'nl' => 'DisplayAnything'];
+
+        $name = $t->getEntityDisplayName($data);
+        $this->assertEquals('urn:example.org', $name);
+
+        $data['OrganizationName']['en'] = 'Example Org EN';
+        
+        $name = $t->getEntityDisplayName($data);
+        $this->assertEquals('Example Org EN', $name);
+
+        $c = Configuration::loadFromArray(['language.default' => 'nl'], '', 'simplesaml');
+        $t = new Template($c, self::TEMPLATE);
+
+        $data['UIInfo']['DisplayName'] = ['de' => 'UIname', 'nl' => 'UIname NL'];
+        $name = $t->getEntityDisplayName($data);
+        $this->assertEquals('UIname NL', $name);
+    }
+
+    function testGetEntityPropertyTranslation(): void
+    {
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $t = new Template($c, self::TEMPLATE);
+
+	$prop = 'description';
+        $data = [
+            'entityid' => 'urn:example.org',
+            $prop => ['nl' => 'Something', 'en' => 'Other lang', 'fr' => 'Another desc'],
+        ];
+        $name = $t->getEntityPropertyTranslation($prop, $data);
+        $this->assertEquals('Other lang', $name);
+
+        $c = Configuration::loadFromArray(['language.default' => 'nl'], '', 'simplesaml');
+        $t = new Template($c, self::TEMPLATE);
+        $name = $t->getEntityPropertyTranslation($prop, $data);
+        $this->assertEquals('Something', $name);
+
+	unset($data[$prop]['nl']);
+        $name = $t->getEntityPropertyTranslation($prop, $data);
+        $this->assertEquals('Other lang', $name);
+
+	unset($data[$prop]['en']);
+        $name = $t->getEntityPropertyTranslation($prop, $data);
+        $this->assertNull($name);
+    }
+}

--- a/tests/lib/SimpleSAML/XHTML/TemplateTest.php
+++ b/tests/lib/SimpleSAML/XHTML/TemplateTest.php
@@ -80,6 +80,9 @@ class TemplateTest extends TestCase
         $c = Configuration::loadFromArray(['language.default' => 'nl'], '', 'simplesaml');
         $t = new Template($c, self::TEMPLATE);
 
+        $name = $t->getEntityDisplayName($data);
+        $this->assertEquals('DisplayAnything', $name);
+
         $data['UIInfo']['DisplayName'] = ['de' => 'UIname', 'nl' => 'UIname NL'];
         $name = $t->getEntityDisplayName($data);
         $this->assertEquals('UIname NL', $name);

--- a/tests/lib/SimpleSAML/XHTML/TemplateTest.php
+++ b/tests/lib/SimpleSAML/XHTML/TemplateTest.php
@@ -90,7 +90,7 @@ class TemplateTest extends TestCase
         $c = Configuration::loadFromArray([], '', 'simplesaml');
         $t = new Template($c, self::TEMPLATE);
 
-	$prop = 'description';
+        $prop = 'description';
         $data = [
             'entityid' => 'urn:example.org',
             $prop => ['nl' => 'Something', 'en' => 'Other lang', 'fr' => 'Another desc'],
@@ -103,11 +103,11 @@ class TemplateTest extends TestCase
         $name = $t->getEntityPropertyTranslation($prop, $data);
         $this->assertEquals('Something', $name);
 
-	unset($data[$prop]['nl']);
+        unset($data[$prop]['nl']);
         $name = $t->getEntityPropertyTranslation($prop, $data);
         $this->assertEquals('Other lang', $name);
 
-	unset($data[$prop]['en']);
+        unset($data[$prop]['en']);
         $name = $t->getEntityPropertyTranslation($prop, $data);
         $this->assertNull($name);
     }


### PR DESCRIPTION
Reimplement getPreferredTranslation outside of IdPDisco so it's reusable and much more complete. The new method will search the current, default and fallback language for a displayable string in various metadata fields. This should be much more complete and robust than previous approches. Make it a Twig filter so it can also be used there.

For clarity:
- translateFromArray method/filter will give a single entry for an array with multiple language options. Most useful with e.g. config file options that have this format.
- getEntityPropertyTranslation method/filter will walk the three languages in priority order to find a named metadata key (useful for localized metadata fields where no other fields need to be searched)
- getEntityDisplayName (method only fornow) for the specific case for displaying the name, where besides different languages we also search different metadata fields.

If the approach is deemed OK there are some other places in the code where we can use this so we have a consistent algorithm across the code to find the name of some entity to display.