### PR TITLE
Use $state saml:RelayState in startSSO2

### DIFF
--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -524,6 +524,10 @@ class SP extends \SimpleSAML\Auth\Source
         if (isset($state['\SimpleSAML\Auth\Source.ReturnURL'])) {
             $ar->setRelayState($state['\SimpleSAML\Auth\Source.ReturnURL']);
         }
+        
+        if (isset($state['saml:RelayState'])) {
+            $ar->setRelayState($state['saml:RelayState']);
+        }
 
         $accr = null;
         if ($idpMetadata->getString('AuthnContextClassRef', false)) {


### PR DESCRIPTION
Hello, I had to implement this little patch because the upstream idp doesn't work without a relayState parameter.
I'm using phpsamlphp as a "proxy", when invoked by an sp no relay state is passed to the upstream idp (it does when you test the authentication).
This patch uses the saml:RelayState value already present in $state (the one from the sp request) and forwards it to the upstream idp.
I don't know if this is a violation of the SAML protocol or if this is something very bad to do, in that case please apologize me and ignore this request :)
