### PR TITLE
Memcache server always seen as down when using moxi

### DIFF
--- a/lib/SimpleSAML/Memcache.php
+++ b/lib/SimpleSAML/Memcache.php
@@ -55,7 +55,7 @@ class Memcache
             if ($serializedInfo === false) {
                 // either the server is down, or we don't have the value stored on that server
                 $mustUpdate = true;
-                $up = $server->getStats();
+                $up = $server->getVersion();
                 if ($up !== false) {
                     $allDown = false;
                 }


### PR DESCRIPTION
We're using a Couchbase cluster for our back-end, then using moxi to provide a memcache interface to it in order to make use of memcookie authentication. Unfortunately, the SimpleSAML\Memcache class is checking server status with getStats, which always seem to return false from moxi. I've locally modified our installation to use getVersion instead, and it has been working as intended for some time. I don't believe this will cause unintended consequences, as the server has to be responding for getVersion to return.