### PR TITLE
Initial version of tool to extract translatable strings from templates.

### DIFF
--- a/bin/get-translatable-strings
+++ b/bin/get-translatable-strings
@@ -1,0 +1,29 @@
+#!/usr/bin/php -q
+<?php
+use SimpleSAML\Module;
+use SimpleSAML\Utils;
+
+// This is the base directory of the SimpleSAMLphp installation
+$baseDir = dirname(dirname(__FILE__));
+
+// Add library autoloader
+require_once($baseDir . '/lib/_autoload.php');
+
+$transUtils = new Utils\Translate();
+$sysUtils = new Utils\System();
+$tempDirBase = $sysUtils->getTempDir() . "/temptemplatestemp";
+$outputSuffix = '/locales/en/LC_MESSAGES';
+
+$modules = ['', 'core', 'admin', 'cron', 'exampleauth', 'multiauth', 'saml'];
+
+foreach($modules as $module) {
+    $tempDir = $tempDirBase . "/" . $module;
+    $transUtils->compileAllTemplates($module, $tempDir);
+    $domain = $module ?: 'messages';
+
+    $outputDir = $baseDir . ($module === '' ? '' : '/modules/' . $module) . $outputSuffix;
+    print `xgettext --default-domain=$domain -p $outputDir --from-code=UTF-8 -j --no-location -ktrans -L PHP $tempDir/*/*.php`;
+}
+
+// TODO: clean up workdir before/after run
+// TODO: merge new strings into translated languages catalogs

--- a/bin/get-translatable-strings
+++ b/bin/get-translatable-strings
@@ -1,7 +1,11 @@
 #!/usr/bin/php -q
 <?php
+
+declare(strict_types=1);
+
 use SimpleSAML\Module;
 use SimpleSAML\Utils;
+use Symfony\Component\Filesystem\Filesystem;
 
 // This is the base directory of the SimpleSAMLphp installation
 $baseDir = dirname(dirname(__FILE__));
@@ -11,7 +15,12 @@ require_once($baseDir . '/lib/_autoload.php');
 
 $transUtils = new Utils\Translate();
 $sysUtils = new Utils\System();
+$filesystem = new Filesystem();
+
 $tempDirBase = $sysUtils->getTempDir() . "/temptemplatestemp";
+// Ensure no leftover from any previous invocation
+$filesystem->remove($tempDirBase);
+
 $outputSuffix = '/locales/en/LC_MESSAGES';
 
 $modules = ['', 'core', 'admin', 'cron', 'exampleauth', 'multiauth', 'saml'];
@@ -25,5 +34,5 @@ foreach($modules as $module) {
     print `xgettext --default-domain=$domain -p $outputDir --from-code=UTF-8 -j --no-location -ktrans -L PHP $tempDir/*/*.php`;
 }
 
-// TODO: clean up workdir before/after run
+$filesystem->remove($tempDirBase);
 // TODO: merge new strings into translated languages catalogs

--- a/bin/get-translatable-strings
+++ b/bin/get-translatable-strings
@@ -1,6 +1,17 @@
 #!/usr/bin/php -q
 <?php
-
+/**
+ * Find translatable strings in Twig templates and the PHP library
+ * and merge them into the English PO file.
+ *
+ * It should be invoked from the root of a SimpleSAMLphp installation
+ * and can work on:
+ * - A specific module name given on the command line
+ * - The main product and the standard modules, when invoked with '--main'.
+ *
+ * It will search all Twig templates for occurences of the trans()
+ * function, and all PHP code under lib/ for the noop() function.
+ */
 declare(strict_types=1);
 
 use SimpleSAML\Module;
@@ -13,6 +24,17 @@ $baseDir = dirname(dirname(__FILE__));
 // Add library autoloader
 require_once($baseDir . '/lib/_autoload.php');
 
+if($argc != 2) {
+    echo "Usage: $argv[0] (<module>|--main)\n";
+    exit(1);
+}
+
+if($argv[1] === '--main') {
+    $modules = ['', 'core', 'admin', 'cron', 'exampleauth', 'multiauth', 'saml'];
+} else {
+    $modules = [$argv[1]];
+}
+
 $transUtils = new Utils\Translate();
 $sysUtils = new Utils\System();
 $filesystem = new Filesystem();
@@ -23,7 +45,6 @@ $filesystem->remove($tempDirBase);
 
 $outputSuffix = '/locales/en/LC_MESSAGES';
 
-$modules = ['', 'core', 'admin', 'cron', 'exampleauth', 'multiauth', 'saml'];
 
 foreach($modules as $module) {
     $tempDir = $tempDirBase . "/" . $module;

--- a/bin/get-translatable-strings
+++ b/bin/get-translatable-strings
@@ -30,8 +30,10 @@ foreach($modules as $module) {
     $transUtils->compileAllTemplates($module, $tempDir);
     $domain = $module ?: 'messages';
 
-    $outputDir = $baseDir . ($module === '' ? '' : '/modules/' . $module) . $outputSuffix;
-    print `xgettext --default-domain=$domain -p $outputDir --from-code=UTF-8 -j --no-location -ktrans -L PHP $tempDir/*/*.php`;
+    $moduleDir = $baseDir . ($module === '' ? '' : '/modules/' . $module);
+    $moduleLibDir = $moduleDir . '/lib/';
+    $outputDir = $moduleDir . $outputSuffix;
+    print `find $tempDir $moduleLibDir -name \*.php | xargs xgettext --default-domain=$domain -p $outputDir --from-code=UTF-8 -j --omit-header --no-location -ktrans -knoop -L PHP`;
 }
 
 $filesystem->remove($tempDirBase);

--- a/lib/SimpleSAML/Utils/Translate.php
+++ b/lib/SimpleSAML/Utils/Translate.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Utils;
+
+use SimpleSAML\Configuration;
+use SimpleSAML\XHTML\Template;
+
+/**
+ * @package SimpleSAMLphp
+ */
+class Translate
+{
+    /**
+     * Compile all Twig templates for the given $module into the given $outputDir.
+     * This is used by the translation extraction tool to find the translatable
+     * strings for this module in the compiled templates.
+     * $module can be '' for the main SimpleSAMLphp templates.
+     */
+    public function compileAllTemplates(string $module, string $outputDir): void
+    {
+        $config = Configuration::loadFromArray(['template.cache' => $outputDir, 'module.enable' => [$module => true]]);
+        $baseDir = $config->getBaseDir();
+        $tplSuffix = '/templates/';
+
+        $tplDir = $baseDir . ($module === '' ? '' : 'modules/' . $module) . $tplSuffix;
+        $templateprefix = ($module === '' ? '' : $module . ":");
+
+        foreach (
+            new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($tplDir),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            ) as $file
+        ) {
+            if ($file->isFile()) {
+                $p = new Template($config, $templateprefix . str_replace($tplDir, '', $file->getPathname()));
+                $p->compile();
+            }
+        }
+    }
+}

--- a/lib/SimpleSAML/Utils/Translate.php
+++ b/lib/SimpleSAML/Utils/Translate.php
@@ -22,9 +22,9 @@ class Translate
     {
         $config = Configuration::loadFromArray(['template.cache' => $outputDir, 'module.enable' => [$module => true]]);
         $baseDir = $config->getBaseDir();
-        $tplSuffix = '/templates/';
+        $tplSuffix = DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR;
 
-        $tplDir = $baseDir . ($module === '' ? '' : 'modules/' . $module) . $tplSuffix;
+        $tplDir = $baseDir . ($module === '' ? '' : 'modules' . DIRECTORY_SEPARATOR . $module) . $tplSuffix;
         $templateprefix = ($module === '' ? '' : $module . ":");
 
         foreach (

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -491,6 +491,15 @@ class Template extends Response
         $this->data['header'] = $this->configuration->getValue('theme.header', 'SimpleSAMLphp');
     }
 
+    /**
+     * Helper function for locale extraction: just compile but not display
+     * this template. This is not generally useful, getContents() will normally
+     * compile and display the template in one step.
+     */
+    public function compile(): void
+    {
+        $this->twig->load($this->twig_template);
+    }
 
     /**
      * Get the contents produced by this template.

--- a/tests/lib/SimpleSAML/Utils/SystemTest.php
+++ b/tests/lib/SimpleSAML/Utils/SystemTest.php
@@ -16,7 +16,7 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\System.
  *
- * @covers \SimpleSAML\Utils\Random
+ * @covers \SimpleSAML\Utils\System
  */
 class SystemTest extends TestCase
 {

--- a/tests/lib/SimpleSAML/Utils/TranslateTest.php
+++ b/tests/lib/SimpleSAML/Utils/TranslateTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\Utils;
+
+use InvalidArgumentException;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error;
+use SimpleSAML\Utils;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Tests for SimpleSAML\Utils\Translate.
+ *
+ * @covers \SimpleSAML\Utils\Translate
+ */
+class TranslateTest extends TestCase
+{
+    protected Utils\System $sysUtils;
+
+    protected Utils\Translate $translate;
+
+    protected Filesystem $filesystem;
+
+    protected string $tempdir;
+
+    public function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->sysUtils = new Utils\System();
+
+        do {
+            $tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . mt_rand();
+        } while (!@mkdir($tmp, 0700));
+        $this->tempdir = $tmp;
+
+        $this->translate = new Utils\Translate();
+    }
+
+    /**
+     * @test
+     */
+    public function testCompileAllTemplatesMain(): void
+    {
+        $workdir = $this->tempdir . DIRECTORY_SEPARATOR . "testall";
+        $this->translate->compileAllTemplates('', $workdir);
+        $this->checkAllFilesAreCompiledTemplates($workdir);
+    }
+
+    /**
+     * @test
+     */
+    public function testCompileAllTemplatesModule(): void
+    {
+        $workdir = $this->tempdir . DIRECTORY_SEPARATOR . "testadmin";
+        $this->translate->compileAllTemplates('admin', $workdir);
+        $this->checkAllFilesAreCompiledTemplates($workdir);
+    }
+
+    public function tearDown(): void
+    {
+        $this->filesystem->remove($this->tempdir);
+    }
+
+    protected function checkAllFilesAreCompiledTemplates(string $dir)
+    {
+        $finder = new Finder();
+        $finder->files()->in($dir);
+
+        $this->assertTrue($finder->hasResults());
+
+        foreach ($finder as $file) {
+            $this->assertEquals('php', $file->getExtension());
+            $this->assertStringContainsString('class __TwigTemplate', $file->getContents());
+        }
+    }
+}


### PR DESCRIPTION
This is likely not yet perfect or complete but it's a start to have something to extract translatable strings into PO files.

What it can do:
- For a module or the 'base' (= main code + the standard modules), walk all Twig templates for strings in the trans() function plus the PHP code under lib for the (Translate::)noop() function.
- Update the `en` po file for the module/for the global messages if not already present.

Since we currently have nothing of the sort I think this is a good step towards fixing #493.

Some things that could be improved upon (later):
- It does not yet merge the new EN strings into the language POs. This can be done but could also be done by the translator, so not sure if it's in scope. If it should be, is there a global list of what the supported languages are?
- It does not clean up strings from the PO that it not find to be present in the sources. This is probably good to add later if we're reasonably certain that what it finds is complete.