### PR TITLE
Show overview of modules in the admin plugin

### DIFF
--- a/modules/admin/lib/Controller/Config.php
+++ b/modules/admin/lib/Controller/Config.php
@@ -137,6 +137,7 @@ class Config
             ],
             'funcmatrix' => $this->getPrerequisiteChecks(),
             'logouturl' => $this->authUtils->getAdminLogoutURL(),
+            'modulelist' => $this->getModuleList(),
         ];
 
         Module::callHooks('configpage', $t);
@@ -144,6 +145,15 @@ class Config
         return $this->menu->insert($t);
     }
 
+    protected function getModuleList(): array
+    {
+        $modules = Module::getModules();
+        $modulestates = [];
+        foreach ($modules as $module) {
+            $modulestates[$module] = Module::isModuleEnabled($module);
+        }
+        return $modulestates;
+    }
 
     /**
      * Display the output of phpinfo().

--- a/modules/admin/templates/config.twig
+++ b/modules/admin/templates/config.twig
@@ -24,11 +24,20 @@
     </div>
     <h2>{% trans %}Configuration{% endtrans %}</h2>
     <div class="enablebox mini">
-      <table>
+      <table class="pure-table">
+        <thead><tr><th>{% trans %}Module/function{% endtrans %}</th><th>{% trans %}Enabled?{% endtrans %}</th></tr></thead>
+        <tbody>
         <tr class="{%- if enablematrix.saml20idp %}enabled{% else %}disabled{% endif -%}">
           <td>SAML 2.0 IdP</td>
-          <td><i class="fa fa-{%- if enablematrix.saml20idp %}check{% else %}ban{% endif %}"></i></td>
+          <td><i class="fa fa-{%- if enablematrix.saml20idp %}check" title="{% trans %}enabled{% endtrans %}"{% else %}ban" title="{% trans %}disabled{% endtrans %}"{% endif %}></i></td>
         </tr>
+        {% for module, enabled in modulelist %}
+        <tr class="{%- if enabled %}enabled{% else %}disabled{% endif -%}">
+          <td>{{ module }}</td>
+          <td><i class="fa fa-{%- if enabled %}check" title="{% trans %}enabled{% endtrans %}"{% else %}ban" title="{% trans %}disabled{% endtrans %}"{% endif %}></i></td>
+        </tr>
+        {% endfor %}
+        </tbody>
       </table>
     </div>
     <ul>


### PR DESCRIPTION
Previously, the admin module did not provide any information about which modules you have installed or wheter they are enabled. This seems a logical thing to show there.

This is now combined with the "SAML 2.0 IdP" enabled/disabled flag
which was a bit lonely before, as it's the only flag of its type.

![Screenshot showing a table of modules with enabled or disabled icons behind them in the admin module's configuration page](https://user-images.githubusercontent.com/3808792/149969551-9c2e4a22-8efa-4867-869d-cfc16c7fe9dc.png)
