### PR TITLE
Remove selectize

### DIFF
--- a/modules/core/templates/loginuserpass.twig
+++ b/modules/core/templates/loginuserpass.twig
@@ -76,7 +76,7 @@
                 <div class="pure-control-group">
                     <label for="organization">{{ 'Organization'|trans }}</label>
                     <div class="pure-select right pure-input-1-2 pure-input-sm-1-1">
-                        <select name="organization" class="" id="organization" tabindex="3">
+                        <select name="organization" id="organization" tabindex="3">
                             {{ selectedOrg ?: null }}
                             {%- for id, orgDesc in organizations -%}
                                 {% if id == selectedOrg -%}

--- a/modules/core/templates/loginuserpass.twig
+++ b/modules/core/templates/loginuserpass.twig
@@ -76,7 +76,7 @@
                 <div class="pure-control-group">
                     <label for="organization">{{ 'Organization'|trans }}</label>
                     <div class="pure-select right pure-input-1-2 pure-input-sm-1-1">
-                        <select name="organization" class="selectize" id="organization" tabindex="3">
+                        <select name="organization" class="" id="organization" tabindex="3">
                             {{ selectedOrg ?: null }}
                             {%- for id, orgDesc in organizations -%}
                                 {% if id == selectedOrg -%}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "jquery": "^3.6.0",
         "minimum-node-version": "^3.0.0",
         "purecss": "^2.0.6",
-        "reset-css": "^5.0.1",
-        "selectize": "^0.12.6"
+        "reset-css": "^5.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.16.7",
@@ -678,11 +677,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
-    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -703,14 +697,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/babel-loader": {
@@ -806,18 +792,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
-      }
-    },
-    "node_modules/cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dependencies": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~1.0.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
       }
     },
     "node_modules/chalk": {
@@ -1096,11 +1070,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
-    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1267,18 +1236,6 @@
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
-      "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/esrecurse": {
@@ -1602,14 +1559,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
-      "integrity": "sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/hyperquest": {
@@ -1949,11 +1898,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2006,14 +1950,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/microplugin": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/microplugin/-/microplugin-0.0.3.tgz",
-      "integrity": "sha1-H8Lhu3yeGegr2Eu6kTe75xJQ2M0=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/mime-db": {
@@ -2213,20 +2149,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -2514,14 +2436,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "dependencies": {
-        "esprima": "~3.0.0"
-      }
-    },
     "node_modules/reset-css": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/reset-css/-/reset-css-5.0.1.tgz",
@@ -2678,21 +2592,6 @@
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
-    "node_modules/selectize": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/selectize/-/selectize-0.12.6.tgz",
-      "integrity": "sha512-bWO5A7G+I8+QXyjLfQUgh31VI4WKYagUZQxAXlDyUmDDNrFxrASV0W9hxCOl0XJ/XQ1dZEu3G9HjXV4Wj0yb6w==",
-      "dependencies": {
-        "microplugin": "0.0.3",
-        "sifter": "^0.5.1"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "peerDependencies": {
-        "jquery": "^1.7.0, ^2, ^3"
-      }
-    },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2741,21 +2640,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sifter": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/sifter/-/sifter-0.5.4.tgz",
-      "integrity": "sha512-t2yxTi/MM/ESup7XH5oMu8PUcttlekt269RqxARgnvS+7D/oP6RyA1x3M/5w8dG9OgkOyQ8hNRWelQ8Rj4TAQQ==",
-      "dependencies": {
-        "async": "^2.6.0",
-        "cardinal": "^1.0.0",
-        "csv-parse": "^4.6.5",
-        "humanize": "^0.0.9",
-        "optimist": "^0.6.1"
-      },
-      "bin": {
-        "sifter": "bin/sifter.js"
       }
     },
     "node_modules/signal-exit": {
@@ -3295,14 +3179,6 @@
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -3841,11 +3717,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
-    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -3861,14 +3732,6 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "babel-loader": {
       "version": "8.2.3",
@@ -3934,15 +3797,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
       "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
       "dev": true
-    },
-    "cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~1.0.0"
-      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -4151,11 +4005,6 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
-    "csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
-    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -4285,11 +4134,6 @@
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
-    "esprima": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
-      "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -4529,11 +4373,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
-    },
-    "humanize": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
-      "integrity": "sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ="
     },
     "hyperquest": {
       "version": "2.1.3",
@@ -4787,11 +4626,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4830,11 +4664,6 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
-    },
-    "microplugin": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/microplugin/-/microplugin-0.0.3.tgz",
-      "integrity": "sha1-H8Lhu3yeGegr2Eu6kTe75xJQ2M0="
     },
     "mime-db": {
       "version": "1.51.0",
@@ -4977,22 +4806,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        }
       }
     },
     "p-limit": {
@@ -5186,14 +4999,6 @@
         "resolve": "^1.9.0"
       }
     },
-    "redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "requires": {
-        "esprima": "~3.0.0"
-      }
-    },
     "reset-css": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/reset-css/-/reset-css-5.0.1.tgz",
@@ -5283,15 +5088,6 @@
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
-    "selectize": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/selectize/-/selectize-0.12.6.tgz",
-      "integrity": "sha512-bWO5A7G+I8+QXyjLfQUgh31VI4WKYagUZQxAXlDyUmDDNrFxrASV0W9hxCOl0XJ/XQ1dZEu3G9HjXV4Wj0yb6w==",
-      "requires": {
-        "microplugin": "0.0.3",
-        "sifter": "^0.5.1"
-      }
-    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -5329,18 +5125,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "sifter": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/sifter/-/sifter-0.5.4.tgz",
-      "integrity": "sha512-t2yxTi/MM/ESup7XH5oMu8PUcttlekt269RqxARgnvS+7D/oP6RyA1x3M/5w8dG9OgkOyQ8hNRWelQ8Rj4TAQQ==",
-      "requires": {
-        "async": "^2.6.0",
-        "cardinal": "^1.0.0",
-        "csv-parse": "^4.6.5",
-        "humanize": "^0.0.9",
-        "optimist": "^0.6.1"
-      }
     },
     "signal-exit": {
       "version": "3.0.6",
@@ -5715,11 +5499,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "jquery": "^3.6.0",
     "minimum-node-version": "^3.0.0",
     "purecss": "^2.0.6",
-    "reset-css": "^5.0.1",
-    "selectize": "^0.12.6"
+    "reset-css": "^5.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",

--- a/src/css/default-rtl.css
+++ b/src/css/default-rtl.css
@@ -93,15 +93,8 @@ fieldset.fancyfieldset legend {
     margin-right: auto;
 }
 
-/*selectize elements*/
 div .item{
     float: right;
-}
-.selectize-input{
-    padding-right:8px;
-}
-.selectize-input:after{
-    transform: translate(-8px, 0);
 }
 
 /*purecss elements*/

--- a/src/css/default.scss
+++ b/src/css/default.scss
@@ -3,7 +3,6 @@
 $fa-font-path: '../fonts/';
 @import "../../node_modules/\@fortawesome/fontawesome-free/scss/fontawesome";
 @import "../../node_modules/\@fortawesome/fontawesome-free/scss/solid";
-@import "../../node_modules/selectize/dist/css/selectize.css";
 @import "../../node_modules/highlight.js/styles/zenburn.css";
 
 /*************
@@ -616,51 +615,8 @@ input[type="file"] {
   float: right;
 }
 
-/* SELECTIZE */
-.selectize-input,
-.selectize-dropdown,
-.selectize-input.dropdown-active {
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
-  border-radius: 0;
-}
-
-.selectize-input:after {
-  transform: translate(8px, 0);
-}
-
 div .item {
   float: left;
-}
-
-.selectize-dropdown {
-  text-align: left;
-}
-
-.selectize-control.single .selectize-input, .selectize-dropdown.single {
-  background-color: white;
-  background-image: none;
-  border: 1px solid #ccc;
-  box-shadow: inset 0 1px 3px #ddd;
-  box-sizing: border-box;
-  font-size: inherit;
-  padding: 0.5em 0.6em;
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.selectize-dropdown-content {
-  cursor: pointer;
-  .option {
-    &:hover, &:focus, &.active {
-      color: white;
-      background-color: #444444;
-    }
-    span.highlight {
-      color: black;
-      background-color: #fffbd5;
-    }
-  }
 }
 
 /* ***********************************************************

--- a/src/js/bundle.js
+++ b/src/js/bundle.js
@@ -1,26 +1,11 @@
 import "es6-shim";
 import ClipboardJS from "clipboard/dist/clipboard";
-import "selectize/dist/js/selectize";
 import hljs from  "highlight.js/lib/core";
 import xml from "highlight.js/lib/languages/xml";
 import php from "highlight.js/lib/languages/php";
 import json from "highlight.js/lib/languages/json";
 
 $(document).ready(function () {
-    // get available languages
-    let languages = $.map($('#language-selector option'), function (option) {
-        return option.text.toLowerCase();
-    });
-
-    // initialize selectize
-    $('#language-selector').selectize({
-        onChange: function () {
-            if (-1 !== $.inArray($('#language-selector-selectized').prev().text().toLowerCase(), languages)) {
-                $('#language-form').submit();
-            }
-        },
-    });
-
     // side menu
     $('#menuLink').click(function (e) {
         e.preventDefault();

--- a/src/js/bundle.js
+++ b/src/js/bundle.js
@@ -6,6 +6,10 @@ import php from "highlight.js/lib/languages/php";
 import json from "highlight.js/lib/languages/json";
 
 $(document).ready(function () {
+    $('#language-selector').on('change', function () {
+        $("#language-form").submit();
+    });
+
     // side menu
     $('#menuLink').click(function (e) {
         e.preventDefault();

--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -55,7 +55,7 @@
             <input type="hidden" name="{{ name }}">
               {% endif %}
             {% endfor %}
-            <select  class="pure-input-1-4 language-menu selectize" name="language" id="language-selector">
+            <select  class="pure-input-1-4 language-menu" name="language" id="language-selector">
             {% for key, lang in languageBar %}
               {% if key == currentLanguage %}
               <option value="{{ key }}" selected="selected">&#xf0ac;  {{ lang.name }}</option>

--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -55,7 +55,7 @@
             <input type="hidden" name="{{ name }}">
               {% endif %}
             {% endfor %}
-            <select  class="pure-input-1-4 language-menu" name="language" id="language-selector">
+            <select aria-label="{% trans %}Language{% endtrans %}" class="pure-input-1-4 language-menu" name="language" id="language-selector">
             {% for key, lang in languageBar %}
               {% if key == currentLanguage %}
               <option value="{{ key }}" selected="selected">&#xf0ac;  {{ lang.name }}</option>


### PR DESCRIPTION
This is an arguably opinionated implementation of #1566: just remove Selectize and replace it with nothing.

The available alternatives come with loads of features while we essentially use none. So even "only 23 kB gzipped" is 23 kB mostly unneeded. We use it in two places, for languages in the header and organizations on the login form. The standard dropdowns work just fine there in my opinion.

We can add more complex comboboxes when we have something that actually needs them.