### PR TITLE
Fix: Predis\Client class name

### DIFF
--- a/modules/admin/lib/Controller/Config.php
+++ b/modules/admin/lib/Controller/Config.php
@@ -308,7 +308,7 @@ class Config
         // check object-oriented external libraries and extensions
         $libs = [
             [
-                'classes' => ['\Predis\Predis'],
+                'classes' => ['\Predis\Client'],
                 'required' => $store === 'redis' ? 'required' : 'optional',
                 'descr' => [
                     'optional' => Translate::noop('predis/predis (required if the redis data store is used)'),


### PR DESCRIPTION
Fixes #1570

This matches what is used in `modules/core/www/frontpage_config.php` for the classic UI.