### PR TITLE
Refactor Configuration getters

### DIFF
--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -710,29 +710,26 @@ class Configuration implements Utils\ClearableState
      *
      * @return mixed The option with the given name, or $default if the option isn't found and $default is given.
      *
-     * @throws \Exception If the option does not have any of the allowed values.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option does not have any of the allowed values.
      */
-    public function getValueValidate(string $name, array $allowedValues, $default = self::REQUIRED_OPTION)
+    public function getValueValidate(string $name, array $allowedValues, $default = null)
     {
-        $ret = $this->getValue($name, $default);
+        $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
+
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
             return $ret;
         }
 
-        if (!in_array($ret, $allowedValues, true)) {
-            $strValues = [];
-            foreach ($allowedValues as $av) {
-                $strValues[] = var_export($av, true);
-            }
-            $strValues = implode(', ', $strValues);
-
-            throw new \Exception(
-                $this->location . ': Invalid value given for the option ' .
-                var_export($name, true) . '. It should have one of the following values: ' .
-                $strValues . '; but it had the following value: ' . var_export($ret, true)
-            );
-        }
+        Assert::inArray(
+            $ret,
+            $allowedValues,
+            sprintf(
+                '%s: Invalid value given for option %s. It should have one of: %2$s; but got: %%s.',
+                $this->location,
+                var_export($name, true),
+            ),
+        );
 
         return $ret;
     }

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -355,18 +355,17 @@ class Configuration implements Utils\ClearableState
      *
      * @return mixed The configuration option with name $name, or $default if the option was not found.
      *
-     * @throws \Exception If the required option cannot be retrieved.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the required option cannot be retrieved.
      */
     public function getValue(string $name, $default = null)
     {
         // return the default value if the option is unset
         if (!array_key_exists($name, $this->configuration)) {
-            if ($default === self::REQUIRED_OPTION) {
-                throw new \Exception(
-                    $this->location . ': Could not retrieve the required option ' .
-                    var_export($name, true)
-                );
-            }
+            Assert::false(
+                (func_num_args() === 1),
+                sprintf('%s: Could not retrieve the required option %s.', $this->location, var_export($name, true)),
+            );
+
             return $default;
         }
 
@@ -562,7 +561,7 @@ class Configuration implements Utils\ClearableState
      */
     public function getBoolean(string $name, $default = self::REQUIRED_OPTION)
     {
-        $ret = $this->getValue($name, $default);
+        $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
@@ -598,7 +597,7 @@ class Configuration implements Utils\ClearableState
      */
     public function getString(string $name, $default = self::REQUIRED_OPTION)
     {
-        $ret = $this->getValue($name, $default);
+        $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
@@ -634,7 +633,7 @@ class Configuration implements Utils\ClearableState
      */
     public function getInteger(string $name, $default = self::REQUIRED_OPTION)
     {
-        $ret = $this->getValue($name, $default);
+        $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -585,17 +585,16 @@ class Configuration implements Utils\ClearableState
      * An exception will be thrown if this option isn't a string, or if this option isn't found, and no default value
      * is given.
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                  required if this parameter isn't given. The default value can be any value, including
-     *                  null.
+     * @param string       $name The name of the option.
+     * @param string|null  $default A default value which will be returned if the option isn't found.
+     *                       The default value can be null or a string.
+     * @psalm-return       ($default is set ? ($default is string ? string : null) : string)
+     *                     The option with the given name, or $default if the option isn't found
+     *                       and $default is specified.
      *
-     * @return string|mixed The option with the given name, or $default if the option isn't found and $default is
-     *     specified.
-     *
-     * @throws \Exception If the option is not a string.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not a string.
      */
-    public function getString(string $name, $default = self::REQUIRED_OPTION)
+    public function getString(string $name, ?string $default = null): ?string
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
@@ -604,12 +603,10 @@ class Configuration implements Utils\ClearableState
             return $ret;
         }
 
-        if (!is_string($ret)) {
-            throw new \Exception(
-                $this->location . ': The option ' . var_export($name, true) .
-                ' is not a valid string value.'
-            );
-        }
+        Assert::string(
+            $ret,
+            sprintf('%s: The option %s is not a valid string value.', $this->location, var_export($name, true)),
+        );
 
         return $ret;
     }
@@ -623,8 +620,7 @@ class Configuration implements Utils\ClearableState
      *
      * @param string $name The name of the option.
      * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                  required if this parameter isn't given. The default value can be any value, including
-     *                  null.
+     *                  required if this parameter isn't given. The default value can be any value, including null.
      *
      * @return int|mixed The option with the given name, or $default if the option isn't found and $default is
      * specified.

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -665,11 +665,7 @@ class Configuration implements Utils\ClearableState
      */
     public function getIntegerRange(string $name, int $minimum, int $maximum, ?int $default = null): ?int
     {
-        if (func_num_args() === 3) {
-            $ret = $this->getInteger($name, $minimum, $maximum);
-        } else {
-            $ret = $this->getInteger($name, $minimum, $maximum, $default);
-        }
+        $ret = (func_num_args() === 3) ? $this->getInteger($name) : $this->getInteger($name, $default);
 
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -741,28 +741,29 @@ class Configuration implements Utils\ClearableState
      * An exception will be thrown if this option isn't an array, or if this option isn't found, and no
      * default value is given.
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                       required if this parameter isn't given. The default value can be any value, including
-     *                       null.
+     * @param string      $name The name of the option.
+     * @param array|null  $default A default value which will be returned if the option isn't found. The option will be
+     *                      required if this parameter isn't given. The default value can be null or an array.
      *
-     * @return array|mixed The option with the given name, or $default if the option isn't found and $default is
-     * specified.
+     * @psalm-return      ($default is set ? ($default is array ? array : null) : array)
+     *                    The option with the given name, or $default if the option isn't found and $default
+     *                      is specified.
      *
-     * @throws \Exception If the option is not an array.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not an array.
      */
-    public function getArray(string $name, $default = self::REQUIRED_OPTION)
+    public function getArray(string $name, ?array $default = null): ?array
     {
-        $ret = $this->getValue($name, $default);
+        $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
             return $ret;
         }
 
-        if (!is_array($ret)) {
-            throw new \Exception($this->location . ': The option ' . var_export($name, true) . ' is not an array.');
-        }
+        Assert::isArray(
+            $ret,
+            sprintf('%s: The option %s is not an array.', $this->location, var_export($name, true)),
+        );
 
         return $ret;
     }
@@ -773,16 +774,17 @@ class Configuration implements Utils\ClearableState
      *
      * If the configuration option isn't an array, it will be converted to an array.
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                       required if this parameter isn't given. The default value can be any value, including
-     *                       null.
+     * @param string      $name The name of the option.
+     * @param array|null  $default A default value which will be returned if the option isn't found. The option will be
+     *                       required if this parameter isn't given. The default value can be null or an array.
      *
-     * @return mixed The option with the given name, or $default if the option isn't found and $default is specified.
+     * @psalm-return      ($default is set ? ($default is array ? array : null) : array)
+     *                    The option with the given name, or $default if the option isn't found and $default
+     *                      is specified.
      */
-    public function getArrayize(string $name, $default = self::REQUIRED_OPTION)
+    public function getArrayize(string $name, ?array $default = null): ?array
     {
-        $ret = $this->getValue($name, $default);
+        $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
@@ -802,31 +804,32 @@ class Configuration implements Utils\ClearableState
      *
      * If the configuration option is a string, it will be converted to an array with a single string
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                       required if this parameter isn't given. The default value can be any value, including
-     *                       null.
+     * @param string      $name The name of the option.
+     * @param array|null  $default A default value which will be returned if the option isn't found. The option will be
+     *                       required if this parameter isn't given. The default value can be null or an array.
      *
-     * @return mixed The option with the given name, or $default if the option isn't found and $default is specified.
+     * @psalm-return      ($default is set ? ($default is array ? array : null) : array)
+     *                    The option with the given name, or $default if the option isn't found and $default
+     *                      is specified.
      *
-     * @throws \Exception If the option is not a string or an array of strings.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not a string or an array of strings.
      */
-    public function getArrayizeString(string $name, $default = self::REQUIRED_OPTION)
+    public function getArrayizeString(string $name, ?array $default = null): ?array
     {
-        $ret = $this->getArrayize($name, $default);
+        $ret = (func_num_args() === 1) ? $this->getArrayize($name) : $this->getArrayize($name, $default);
+
+        Assert::nullOrAllString(
+            $ret,
+            sprintf(
+                '%s: The option %s must be a string or an array of strings.',
+                $this->location,
+                var_export($name, true),
+            ),
+        );
 
         if ($ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
             return $ret;
-        }
-
-        foreach ($ret as $value) {
-            if (!is_string($value)) {
-                throw new \Exception(
-                    $this->location . ': The option ' . var_export($name, true) .
-                    ' must be a string or an array of strings.'
-                );
-            }
         }
 
         return $ret;

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -854,9 +854,9 @@ class Configuration implements Utils\ClearableState
      * @return \SimpleSAML\Configuration|null The option with the given name,
      *   or $default if the option isn't found and $default is specified.
      *
-     * @throws \Exception If the option is not an array.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not an array.
      */
-    public function getConfigItem(string $name, $default = []): ?Configuration
+    public function getConfigItem(string $name, ?array $default = []): ?Configuration
     {
         $ret = $this->getValue($name, $default);
 
@@ -866,12 +866,10 @@ class Configuration implements Utils\ClearableState
             return null;
         }
 
-        if (!is_array($ret)) {
-            throw new \Exception(
-                $this->location . ': The option ' . var_export($name, true) .
-                ' is not an array.'
-            );
-        }
+        Assert::isArray(
+            $ret,
+            sprintf('%s: The option %s is not an array.', $this->location, var_export($name, true)),
+        );
 
         return self::loadFromArray($ret, $this->location . '[' . var_export($name, true) . ']');
     }

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -563,9 +563,9 @@ class Configuration implements Utils\ClearableState
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         Assert::boolean(
@@ -596,9 +596,9 @@ class Configuration implements Utils\ClearableState
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         Assert::string(
@@ -630,9 +630,9 @@ class Configuration implements Utils\ClearableState
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         Assert::integer(
@@ -667,9 +667,9 @@ class Configuration implements Utils\ClearableState
     {
         $ret = (func_num_args() === 3) ? $this->getInteger($name) : $this->getInteger($name, $default);
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         Assert::range(
@@ -712,9 +712,9 @@ class Configuration implements Utils\ClearableState
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         Assert::inArray(
@@ -751,9 +751,9 @@ class Configuration implements Utils\ClearableState
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         Assert::isArray(
@@ -782,9 +782,9 @@ class Configuration implements Utils\ClearableState
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         if (!is_array($ret)) {
@@ -823,9 +823,9 @@ class Configuration implements Utils\ClearableState
             ),
         );
 
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         return $ret;
@@ -1086,9 +1086,9 @@ class Configuration implements Utils\ClearableState
     public function getLocalizedString(string $name, ?array $default = []): ?array
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
-        if ($ret === $default) {
+        if ($ret === null || $ret === $default) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
         $loc = $this->location . '[' . var_export($name, true) . ']';

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -549,17 +549,17 @@ class Configuration implements Utils\ClearableState
      * An exception will be thrown if this option isn't a boolean, or if this option isn't found, and no default value
      * is given.
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                  required if this parameter isn't given. The default value can be any value, including
-     *                  null.
+     * @param string     $name The name of the option.
+     * @param bool|null  $default A default value which will be returned if the option isn't found. The option will be
+     *                     required if this parameter isn't given. The default value can be null or a boolean.
      *
-     * @return boolean|mixed The option with the given name, or $default if the option isn't found and $default is
-     *     specified.
+     * @psalm-return     ($default is set ? ($default is bool ? bool : null) : bool)
+     *                   The option with the given name, or $default if the option isn't found and $default is
+     *                     specified.
      *
-     * @throws \Exception If the option is not boolean.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not boolean.
      */
-    public function getBoolean(string $name, $default = self::REQUIRED_OPTION)
+    public function getBoolean(string $name, ?bool $default = null): ?bool
     {
         $ret = (func_num_args() === 1) ? $this->getValue($name) : $this->getValue($name, $default);
 
@@ -568,12 +568,10 @@ class Configuration implements Utils\ClearableState
             return $ret;
         }
 
-        if (!is_bool($ret)) {
-            throw new \Exception(
-                $this->location . ': The option ' . var_export($name, true) .
-                ' is not a valid boolean value.'
-            );
-        }
+        Assert::boolean(
+            $ret,
+            sprintf('%s: The option %s is not a valid boolean value.', $this->location, var_export($name, true)),
+        );
 
         return $ret;
     }

--- a/lib/SimpleSAML/Utils/Config/Metadata.php
+++ b/lib/SimpleSAML/Utils/Config/Metadata.php
@@ -280,8 +280,9 @@ class Metadata
                 'Format'      => $nameIdPolicy_cf->getString('Format', Constants::NAMEID_TRANSIENT),
                 'AllowCreate' => $nameIdPolicy_cf->getBoolean('AllowCreate', true),
             ];
-            $spNameQualifier = $nameIdPolicy_cf->getString('SPNameQualifier', false);
-            if ($spNameQualifier !== false) {
+
+            $spNameQualifier = $nameIdPolicy_cf->getString('SPNameQualifier', null);
+            if ($spNameQualifier !== null) {
                 $policy['SPNameQualifier'] = $spNameQualifier;
             }
         } elseif ($nameIdPolicy === null) {

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -821,7 +821,7 @@ class HTTP
              */
 
             /** @var \SimpleSAML\Configuration $appcfg */
-            $appcfg = $cfg->getConfigItem('application');
+            $appcfg = $cfg->getConfigItem('application', []);
             $appurl = $appcfg->getString('baseURL', '');
             if (!empty($appurl)) {
                 $protocol = parse_url($appurl, PHP_URL_SCHEME);

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -460,8 +460,8 @@ class HTTP
             if (!isset($context['http']['proxy'])) {
                 $context['http']['proxy'] = $proxy;
             }
-            $proxy_auth = $config->getString('proxy.auth', false);
-            if ($proxy_auth !== false) {
+            $proxy_auth = $config->getString('proxy.auth', null);
+            if ($proxy_auth !== null) {
                 $context['http']['header'] = "Proxy-Authorization: Basic " . base64_encode($proxy_auth);
             }
             if (!isset($context['http']['request_fulluri'])) {

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -137,9 +137,9 @@ class Template extends Response
         $this->localization = new Localization($configuration);
 
         // check if we need to attach a theme controller
-        $controller = $this->configuration->getString('theme.controller', false);
+        $controller = $this->configuration->getString('theme.controller', null);
         if (
-            $controller
+            $controller !== null
             && class_exists($controller)
             && in_array(TemplateControllerInterface::class, class_implements($controller))
         ) {
@@ -266,7 +266,7 @@ class Template extends Response
     private function setupTwig(): Environment
     {
         $auto_reload = $this->configuration->getBoolean('template.auto_reload', true);
-        $cache = $this->configuration->getString('template.cache', false);
+        $cache = $this->configuration->getString('template.cache', null);
 
         // set up template paths
         $loader = $this->setupTwigTemplatepaths();
@@ -287,7 +287,7 @@ class Template extends Response
         // set up translation
         $options = [
             'auto_reload' => $auto_reload,
-            'cache' => $cache,
+            'cache' => $cache ?? false,
             'strict_variables' => true,
         ];
 

--- a/modules/admin/lib/Controller/Federation.php
+++ b/modules/admin/lib/Controller/Federation.php
@@ -331,7 +331,7 @@ class Federation
             // get the name
             $name = $source->getMetadata()->getLocalizedString(
                 'name',
-                $source->getMetadata()->getLocalizedString('OrganizationDisplayName', $source->getAuthId())
+                $source->getMetadata()->getLocalizedString('OrganizationDisplayName', ['en' => $source->getAuthId()])
             );
 
             $builder = new SAMLBuilder($source->getEntityId());

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -441,7 +441,7 @@ class SP extends \SimpleSAML\Auth\Source
         $arrayUtils = new Utils\Arrays();
 
         $accr = null;
-        if ($idpMetadata->getString('AuthnContextClassRef', false)) {
+        if ($idpMetadata->getString('AuthnContextClassRef', null) !== null) {
             $accr = $arrayUtils->arrayize($idpMetadata->getString('AuthnContextClassRef'));
         } elseif (isset($state['saml:AuthnContextClassRef'])) {
             $accr = $arrayUtils->arrayize($state['saml:AuthnContextClassRef']);
@@ -449,7 +449,7 @@ class SP extends \SimpleSAML\Auth\Source
 
         if ($accr !== null) {
             $comp = Constants::COMPARISON_EXACT;
-            if ($idpMetadata->getString('AuthnContextComparison', false)) {
+            if ($idpMetadata->getString('AuthnContextComparison', null) !== null) {
                 $comp = $idpMetadata->getString('AuthnContextComparison');
             } elseif (
                 isset($state['saml:AuthnContextComparison'])

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -937,8 +937,8 @@ class SAML2
         }
 
         $globalConfig = Configuration::getInstance();
-        $email = $globalConfig->getString('technicalcontact_email', false);
-        if ($email && $email !== 'na@example.org') {
+        $email = $globalConfig->getString('technicalcontact_email', 'na@example.org');
+        if ($email !== 'na@example.org') {
             $contact = [
                 'emailAddress' => $email,
                 'givenName' => $globalConfig->getString('technicalcontact_name', null),

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -68,25 +68,26 @@ class ConfigurationTest extends ClearStateTestCase
             'exists_true' => true,
             'exists_null' => null,
         ]);
-        $this->assertEquals($c->getValue('missing'), null);
-        $this->assertEquals($c->getValue('missing', true), true);
-        $this->assertEquals($c->getValue('missing', true), true);
-
         $this->assertEquals($c->getValue('exists_true'), true);
 
         $this->assertEquals($c->getValue('exists_null'), null);
         $this->assertEquals($c->getValue('exists_null', false), null);
+
+        $this->assertEquals($c->getValue('missing', true), true);
+
+        $this->expectException(AssertionFailedException::class);
+        $c->getValue('missing');
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getValue(), REQUIRED_OPTION flag.
+     * Test \SimpleSAML\Configuration::getValue(), required option.
      */
     public function testGetValueRequired(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(AssertionFailedException::class);
         $c = Configuration::loadFromArray([]);
-        $c->getValue('missing', Configuration::REQUIRED_OPTION);
+        $c->getValue('missing');
     }
 
 
@@ -261,7 +262,7 @@ class ConfigurationTest extends ClearStateTestCase
      */
     public function testGetBooleanMissing(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(AssertionFailedException::class);
         $c = Configuration::loadFromArray([]);
         $c->getBoolean('missing_opt');
     }
@@ -298,7 +299,7 @@ class ConfigurationTest extends ClearStateTestCase
      */
     public function testGetStringMissing(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(AssertionFailedException::class);
         $c = Configuration::loadFromArray([]);
         $c->getString('missing_opt');
     }
@@ -335,7 +336,7 @@ class ConfigurationTest extends ClearStateTestCase
      */
     public function testGetIntegerMissing(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(AssertionFailedException::class);
         $c = Configuration::loadFromArray([]);
         $c->getInteger('missing_opt');
     }

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -327,8 +327,8 @@ class ConfigurationTest extends ClearStateTestCase
         $c = Configuration::loadFromArray([
             'int_opt' => 42,
         ]);
-        $this->assertEquals($c->getInteger('missing_opt', '--missing--'), '--missing--');
-        $this->assertEquals($c->getInteger('int_opt', '--missing--'), 42);
+        $this->assertEquals($c->getInteger('missing_opt', 10), 10);
+        $this->assertEquals($c->getInteger('int_opt'), 42);
     }
 
 
@@ -364,7 +364,7 @@ class ConfigurationTest extends ClearStateTestCase
         $c = Configuration::loadFromArray([
             'int_opt' => 42,
         ]);
-        $this->assertEquals($c->getIntegerRange('missing_opt', 0, 100, '--missing--'), '--missing--');
+        $this->assertEquals($c->getIntegerRange('missing_opt', 0, 100, null), null);
         $this->assertEquals($c->getIntegerRange('int_opt', 0, 100), 42);
     }
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -429,7 +429,7 @@ class ConfigurationTest extends ClearStateTestCase
         $c = Configuration::loadFromArray([
             'opt' => ['a', 'b', 'c'],
         ]);
-        $this->assertEquals($c->getArray('missing_opt', '--missing--'), '--missing--');
+        $this->assertEquals($c->getArray('missing_opt', null), null);
         $this->assertEquals($c->getArray('opt'), ['a', 'b', 'c']);
     }
 
@@ -457,7 +457,7 @@ class ConfigurationTest extends ClearStateTestCase
             'opt_int' => 42,
             'opt_str' => 'string',
         ]);
-        $this->assertEquals($c->getArrayize('missing_opt', '--missing--'), '--missing--');
+        $this->assertEquals($c->getArrayize('missing_opt', null), null);
         $this->assertEquals($c->getArrayize('opt'), ['a', 'b', 'c']);
         $this->assertEquals($c->getArrayize('opt_int'), [42]);
         $this->assertEquals($c->getArrayize('opt_str'), ['string']);
@@ -473,7 +473,7 @@ class ConfigurationTest extends ClearStateTestCase
             'opt' => ['a', 'b', 'c'],
             'opt_str' => 'string',
         ]);
-        $this->assertEquals($c->getArrayizeString('missing_opt', '--missing--'), '--missing--');
+        $this->assertEquals($c->getArrayizeString('missing_opt', null), null);
         $this->assertEquals($c->getArrayizeString('opt'), ['a', 'b', 'c']);
         $this->assertEquals($c->getArrayizeString('opt_str'), ['string']);
     }

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -860,7 +860,7 @@ class ConfigurationTest extends ClearStateTestCase
                 'no' => 'Hei Verden!',
             ],
         ]);
-        $this->assertEquals($c->getLocalizedString('missing_opt', '--missing--'), '--missing--');
+        $this->assertEquals($c->getLocalizedString('missing_opt', null), null);
         $this->assertEquals($c->getLocalizedString('str_opt'), ['en' => 'Hello World!']);
         $this->assertEquals($c->getLocalizedString('str_array'), ['en' => 'Hello World!', 'no' => 'Hei Verden!']);
     }

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Test;
 
 use Exception;
 use SAML2\Constants;
+use SimpleSAML\Assert\AssertionFailedException;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error;
 use SimpleSAML\TestUtils\ClearStateTestCase;
@@ -310,7 +311,7 @@ class ConfigurationTest extends ClearStateTestCase
      */
     public function testGetStringWrong(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(AssertionFailedException::class);
         $c = Configuration::loadFromArray([
             'wrong' => false,
         ]);

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -252,9 +252,9 @@ class ConfigurationTest extends ClearStateTestCase
             'true_opt' => true,
             'false_opt' => false,
         ]);
-        $this->assertEquals($c->getBoolean('missing_opt', '--missing--'), '--missing--');
-        $this->assertEquals($c->getBoolean('true_opt', '--missing--'), true);
-        $this->assertEquals($c->getBoolean('false_opt', '--missing--'), false);
+        $this->assertEquals($c->getBoolean('true_opt', null), true);
+        $this->assertEquals($c->getBoolean('false_opt', null), false);
+        $this->assertNull($c->getBoolean('--missing--', null));
     }
 
 
@@ -265,7 +265,7 @@ class ConfigurationTest extends ClearStateTestCase
     {
         $this->expectException(AssertionFailedException::class);
         $c = Configuration::loadFromArray([]);
-        $c->getBoolean('missing_opt');
+        $x = $c->getBoolean('missing_opt');
     }
 
 

--- a/tests/modules/saml/lib/IdP/SAML2Test.php
+++ b/tests/modules/saml/lib/IdP/SAML2Test.php
@@ -270,7 +270,6 @@ EOT;
         $md = [];
         $hostedMd = $this->idpMetadataHandlerHelper($md);
 
-        $this->assertIsArray($hostedMd);
         $this->assertArrayHasKey('metadata-set', $hostedMd);
         $this->assertEquals('saml20-idp-hosted', $hostedMd['metadata-set']);
         $this->assertArrayHasKey('entityid', $hostedMd);


### PR DESCRIPTION
This slightly changes the behaviour of the getters.  If no default is passed at all, the option will be considered 'required' and an exception will be thrown if it doesn't exist. It also adds typehints to the default value, instead of accepting literally _anything_..
This means that when you're calling `getString()` you can be certain that the returned value is either `null` or a string, and not something completely different.. This also improves static analysis.