### PR TITLE
Change logging date formatting string from strftime() to date().

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -302,7 +302,7 @@ $config = [
      * are:
      *
      * - %date{<format>}: the date and time, with its format specified inside the brackets. See the PHP documentation
-     *   of the strftime() function for more information on the format. If the brackets are omitted, the standard
+     *   of the date() function for more information on the format. If the brackets are omitted, the standard
      *   format is applied. This can be useful if you just want to control the placement of the date, but don't care
      *   about the format.
      *
@@ -322,7 +322,7 @@ $config = [
      * - %msg: the message to be logged.
      *
      */
-    //'logging.format' => '%date{%b %d %H:%M:%S} %process %level %stat[%trackid] %msg',
+    //'logging.format' => '%date{M j H:i:s} %process %level %stat[%trackid] %msg',
 
     /*
      * Choose which facility should be used when logging with syslog.

--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -34,7 +34,10 @@ Configuration changes
 ---------------------
 Quite some options have been changed or removed. We recommend to start with a fresh
 template from `config-templates/` and migrate the settings you require to the new
-config file= manualy.
+config file manualy.
+
+The date formatting when specifying a custom logging string has been changed from PHP's
+deprecated `strftime()` format to PHP's `date()` format.
 
 Configuration options that have been removed:
  - languages[priorities]

--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -91,7 +91,7 @@ class Logger
      * general the options are:
      *
      * - %date{<format>}: the date and time, with its format specified inside the brackets. See the PHP documentation
-     *   of the strftime() function for more information on the format. If the brackets are omitted, the standard
+     *   of the date() function for more information on the format. If the brackets are omitted, the standard
      *   format is applied. This can be useful if you just want to control the placement of the date, but don't care
      *   about the format.
      *
@@ -113,7 +113,7 @@ class Logger
      *
      * @var string The format of the log line.
      */
-    private static string $format = '%date{%b %d %H:%M:%S} %process %level %stat[%trackid] %msg';
+    private static string $format = '%date{M j H:i:s} %process %level %stat[%trackid] %msg';
 
     /**
      * This variable tells if we have a shutdown function registered or not.

--- a/lib/SimpleSAML/Logger/FileLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/FileLoggingHandler.php
@@ -112,13 +112,13 @@ class FileLoggingHandler implements LoggingHandlerInterface
 
             $matches = [];
             if (preg_match('/%date(?:\{([^\}]+)\})?/', $this->format, $matches)) {
-                $format = "%b %d %H:%M:%S";
+                $format = "M j H:i:s";
                 if (isset($matches[1])) {
                     $format = $matches[1];
                 }
 
                 array_push($formats, $matches[0]);
-                array_push($replacements, strftime($format));
+                array_push($replacements, date($format));
             }
 
             $string = str_replace($formats, $replacements, $string);


### PR DESCRIPTION
strftime is deprecated and will be removed in PHP 9. SSP 2.0 is our chance to change this format as it's exposed to installers of SSP.

The approch is to keep it simple and just change the format to PHP's built in date() function which remains supported, in one go. As this is SSP 2.0 we're already breaking some config options, and if we make the jump now we can keep the code simple after instead of painstakingly trying to keep compatble also with the old format.

Also we do not try to localize the logging date/timestamps anymore. This matches the syslog approach that this format tried to mimic. We are using the day without leading zeroes now also to be a bit closer to how syslog does it. All just keeping things simple, which is what logging should be.

Likely not many installs are even using custom logging formats at all.