### PR TITLE
2.0:  PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "gettext/gettext": "^4.6",
         "phpmailer/phpmailer": "^6.5",
         "simplesamlphp/assert": "^0.2.11",
-        "simplesamlphp/saml2": "^4.4",
+        "simplesamlphp/saml2": "^4.5",
         "symfony/cache": "^5.4",
         "symfony/config": "^5.4",
         "symfony/console": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ext-pcre": "*",
         "ext-SPL": "*",
         "ext-zlib": "*",
-        "gettext/gettext": "^4.6",
+        "gettext/gettext": "v4.x-dev#3e7460f8d9c90174824e3f39240bd578bb3d376a",
         "phpmailer/phpmailer": "^6.5",
         "simplesamlphp/assert": "^0.2.11",
         "simplesamlphp/saml2": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "gettext/gettext",
-            "version": "v4.8.6",
+            "version": "4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Gettext.git",
-                "reference": "bbeb8f4d3077663739aecb4551b22e720c0e9efe"
+                "reference": "3e7460f8d9c90174824e3f39240bd578bb3d376a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/bbeb8f4d3077663739aecb4551b22e720c0e9efe",
-                "reference": "bbeb8f4d3077663739aecb4551b22e720c0e9efe",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/3e7460f8d9c90174824e3f39240bd578bb3d376a",
+                "reference": "3e7460f8d9c90174824e3f39240bd578bb3d376a",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
             "support": {
                 "email": "oom@oscarotero.com",
                 "issues": "https://github.com/oscarotero/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.6"
+                "source": "https://github.com/php-gettext/Gettext/tree/4.x"
             },
             "funding": [
                 {
@@ -85,7 +85,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-10-19T10:44:53+00:00"
+            "time": "2022-02-17T10:14:02+00:00"
         },
         {
             "name": "gettext/languages",
@@ -6628,6 +6628,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "gettext/gettext": 20,
         "simplesamlphp/simplesamlphp-module-adfs": 5
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88613b7122ef0ac8c71e58873a683965",
+    "content-hash": "499ed983a7e8abed35ed5ab324abc681",
     "packages": [
         {
             "name": "gettext/gettext",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2176427956e72c623e660394ffd6404",
+    "content-hash": "88613b7122ef0ac8c71e58873a683965",
     "packages": [
         {
             "name": "gettext/gettext",

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -200,11 +200,11 @@ class Session implements Utils\ClearableState
 
 
     /**
-     * Serialize this XML chunk.
+     * Serialize this Session.
      *
      * This method will be invoked by any calls to serialize().
      *
-     * @return array The serialized representation of this XML object.
+     * @return array The serialized representation of this Session.
      */
     public function __serialize(): array
     {

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -28,7 +28,7 @@ use SimpleSAML\Utils;
  * @package SimpleSAMLphp
  */
 
-class Session implements Serializable, Utils\ClearableState
+class Session implements Utils\ClearableState
 {
     /**
      * This is a timeout value for setData, which indicates that the data
@@ -200,15 +200,15 @@ class Session implements Serializable, Utils\ClearableState
 
 
     /**
-     * Serialize this session object.
+     * Serialize this XML chunk.
      *
      * This method will be invoked by any calls to serialize().
      *
-     * @return string The serialized representation of this session object.
+     * @return array The serialized representation of this XML object.
      */
-    public function serialize(): string
+    public function __serialize(): array
     {
-        return serialize(get_object_vars($this));
+        return get_object_vars($this);
     }
 
 
@@ -218,17 +218,12 @@ class Session implements Serializable, Utils\ClearableState
      * This method will be invoked by any calls to unserialize(), allowing us to restore any data that might not
      * be serializable in its original form (e.g.: DOM objects).
      *
-     * @param string $serialized The serialized representation of a session that we want to restore.
-     *
-     * Cannot typehint param as string due to upstream restrictions
+     * @param array $serialized The serialized representation of a session that we want to restore.
      */
-    public function unserialize($serialized): void
+    public function __unserialize($serialized): void
     {
-        $session = unserialize($serialized);
-        if (is_array($session)) {
-            foreach ($session as $k => $v) {
-                $this->$k = $v;
-            }
+        foreach ($serialized as $k => $v) {
+            $this->$k = $v;
         }
         self::$config = Configuration::getInstance();
 


### PR DESCRIPTION
This PR takes care of all deprecation issues.
This is necessary because PHP 8.1 will treat deprecations as exceptions instead of warnings.