### PR TITLE
Refactor Configuration getters

### DIFF
--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -96,3 +96,17 @@ processing filters or interface with the SimpleSAMLphp development API.
     - lib/SimpleSAML/Store/Memcache.php has been renamed to lib/SimpleSAML/Store/MemcacheStore.php
     - lib/SimpleSAML/Store/Redis.php has been renamed to lib/SimpleSAML/Store/RedisStore.php
 
+- The following methods have had their signature changed:
+  - Configuration::getValue
+  - Configuration::getBoolean
+  - Configuration::getString
+  - Configuration::getInteger
+  - Configuration::getIntegerRange
+  - Configuration::getValueValidate
+  - Configuration::getArray
+  - Configuration::getArrayize
+  - Configuration::getArrayizeString
+  - Configuration::getConfigItem
+  - Configuration::getLocalizedString
+
+  All of these methods no longer accept a default as their last parameter. Use their getOptional* counterparts instead.

--- a/lib/SimpleSAML/Auth/ProcessingChain.php
+++ b/lib/SimpleSAML/Auth/ProcessingChain.php
@@ -61,7 +61,7 @@ class ProcessingChain
     public function __construct(array $idpMetadata, array $spMetadata, string $mode = 'idp')
     {
         $config = Configuration::getInstance();
-        $configauthproc = $config->getArray('authproc.' . $mode, null);
+        $configauthproc = $config->getOptionalArray('authproc.' . $mode, null);
 
         if (!empty($configauthproc)) {
             $configfilters = self::parseFilterList($configauthproc);

--- a/lib/SimpleSAML/Auth/Simple.php
+++ b/lib/SimpleSAML/Auth/Simple.php
@@ -26,8 +26,8 @@ class Simple
      */
     protected string $authSource;
 
-    /** @var \SimpleSAML\Configuration */
-    protected Configuration $app_config;
+    /** @var \SimpleSAML\Configuration|null */
+    protected ?Configuration $app_config;
 
     /** @var \SimpleSAML\Session */
     protected Session $session;
@@ -46,8 +46,7 @@ class Simple
             $config = Configuration::getInstance();
         }
         $this->authSource = $authSource;
-        /** @psalm-var \SimpleSAML\Configuration $this->app_config */
-        $this->app_config = $config->getConfigItem('application');
+        $this->app_config = $config->getOptionalConfigItem('application', null);
 
         if ($session === null) {
             $session = Session::getSessionFromRequest();

--- a/lib/SimpleSAML/Auth/Simple.php
+++ b/lib/SimpleSAML/Auth/Simple.php
@@ -385,7 +385,7 @@ class Simple
             $port = '';
         }
 
-        $base = trim($this->app_config->getString(
+        $base = trim($this->app_config->getOptionalString(
             'baseURL',
             $scheme . '://' . $host . $port
         ), '/');

--- a/lib/SimpleSAML/Auth/Simple.php
+++ b/lib/SimpleSAML/Auth/Simple.php
@@ -26,8 +26,8 @@ class Simple
      */
     protected string $authSource;
 
-    /** @var \SimpleSAML\Configuration|null */
-    protected ?Configuration $app_config;
+    /** @var \SimpleSAML\Configuration */
+    protected Configuration $app_config;
 
     /** @var \SimpleSAML\Session */
     protected Session $session;
@@ -46,7 +46,7 @@ class Simple
             $config = Configuration::getInstance();
         }
         $this->authSource = $authSource;
-        $this->app_config = $config->getOptionalConfigItem('application', null);
+        $this->app_config = $config->getOptionalConfigItem('application', []);
 
         if ($session === null) {
             $session = Session::getSessionFromRequest();

--- a/lib/SimpleSAML/Auth/Source.php
+++ b/lib/SimpleSAML/Auth/Source.php
@@ -344,7 +344,7 @@ abstract class Source
         // for now - load and parse config file
         $config = Configuration::getConfig('authsources.php');
 
-        $authConfig = $config->getArray($authId, null);
+        $authConfig = $config->getOptionalArray($authId, null);
         if ($authConfig === null) {
             if ($type !== null) {
                 throw new Error\Exception(

--- a/lib/SimpleSAML/Auth/State.php
+++ b/lib/SimpleSAML/Auth/State.php
@@ -181,7 +181,7 @@ class State
     {
         if (self::$stateTimeout === null) {
             $globalConfig = Configuration::getInstance();
-            self::$stateTimeout = $globalConfig->getInteger('session.state.timeout', 60 * 60);
+            self::$stateTimeout = $globalConfig->getOptionalInteger('session.state.timeout', 60 * 60);
         }
 
         return self::$stateTimeout;

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -876,21 +876,40 @@ class Configuration implements Utils\ClearableState
      * If the configuration option isn't an array, it will be converted to an array.
      *
      * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                       required if this parameter isn't given. The default value can be any value, including
-     *                       null.
+     *
+     * @return mixed The option with the given name.
+     */
+    public function getArrayize(string $name): array
+    {
+        $ret = $this->getValue($name);
+
+        if (!is_array($ret)) {
+            $ret = [$ret];
+        }
+
+        return $ret;
+    }
+
+
+    /**
+     * This function retrieves an array configuration option.
+     *
+     * If the configuration option isn't an array, it will be converted to an array.
+     *
+     * @param string $name The name of the option.
+     * @param mixed  $default A default value which will be returned if the option isn't found.
+     *                       The default value can be null or an array.
      *
      * @return mixed The option with the given name, or $default if the option isn't found and $default is specified.
      */
-    public function getArrayize(string $name, $default = self::REQUIRED_OPTION)
+    public function getOptionalArrayize(string $name, $default): ?array
     {
-        $ret = $this->getValue($name, $default);
-
-        if ($ret === $default) {
+        if (!$this->hasValue($name)) {
             // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
+            return $default;
         }
 
+        $ret = $this->getValue($name);
         if (!is_array($ret)) {
             $ret = [$ret];
         }

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -559,36 +559,47 @@ class Configuration implements Utils\ClearableState
     /**
      * This function retrieves a boolean configuration option.
      *
-     * An exception will be thrown if this option isn't a boolean, or if this option isn't found, and no default value
-     * is given.
+     * An exception will be thrown if this option isn't a boolean, or if this option isn't found.
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                  required if this parameter isn't given. The default value can be any value, including
-     *                  null.
+     * @param string   $name The name of the option.
+     * @return boolean       The option with the given name.
      *
-     * @return boolean|mixed The option with the given name, or $default if the option isn't found and $default is
-     *     specified.
-     *
-     * @throws \Exception If the option is not boolean.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not boolean.
      */
-    public function getBoolean(string $name, $default = self::REQUIRED_OPTION)
+    public function getBoolean(string $name): bool
     {
-        $ret = $this->getValue($name, $default);
+        $ret = $this->getValue($name);
 
-        if ($ret === $default) {
-            // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
-        }
-
-        if (!is_bool($ret)) {
-            throw new \Exception(
-                $this->location . ': The option ' . var_export($name, true) .
-                ' is not a valid boolean value.'
-            );
-        }
+        Assert::boolean(
+            $ret,
+            sprintf('%s: The option %s is not a valid boolean value.', $this->location, var_export($name, true)),
+        );
 
         return $ret;
+    }
+
+
+    /**
+     * This function retrieves a boolean configuration option.
+     *
+     * An exception will be thrown if this option isn't a boolean.
+     *
+     * @param string    $name     The name of the option.
+     * @param bool|null $default  A default value which will be returned if the option isn't found.
+     *                            The default value can be null or a boolean.
+     *
+     * @return bool|null          The option with the given name, or $default.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not boolean.
+     */
+    public function getOptionalBoolean(string $name, ?bool $default): ?bool
+    {
+        if (!$this->hasValue($name)) {
+            // the option wasn't found, or it matches the default value. In any case, return this value
+            return $default;
+        }
+
+        return $this->getBoolean($name);
     }
 
 

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -877,7 +877,7 @@ class Configuration implements Utils\ClearableState
      *
      * @param string $name The name of the option.
      *
-     * @return mixed The option with the given name.
+     * @return array The option with the given name.
      */
     public function getArrayize(string $name): array
     {
@@ -896,11 +896,11 @@ class Configuration implements Utils\ClearableState
      *
      * If the configuration option isn't an array, it will be converted to an array.
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found.
+     * @param string      $name The name of the option.
+     * @param array|null  $default A default value which will be returned if the option isn't found.
      *                       The default value can be null or an array.
      *
-     * @return mixed The option with the given name, or $default if the option isn't found and $default is specified.
+     * @return array|null The option with the given name.
      */
     public function getOptionalArrayize(string $name, $default): ?array
     {
@@ -924,33 +924,48 @@ class Configuration implements Utils\ClearableState
      * If the configuration option is a string, it will be converted to an array with a single string
      *
      * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                       required if this parameter isn't given. The default value can be any value, including
-     *                       null.
+     * @return string[] The option with the given name.
      *
-     * @return mixed The option with the given name, or $default if the option isn't found and $default is specified.
-     *
-     * @throws \Exception If the option is not a string or an array of strings.
+     * @throws \SimpleSAML\Assert\AssertFailedException If the option is not a string or an array of strings.
      */
-    public function getArrayizeString(string $name, $default = self::REQUIRED_OPTION)
+    public function getArrayizeString(string $name): array
     {
-        $ret = $this->getArrayize($name, $default);
+        $ret = $this->getArrayize($name);
 
-        if ($ret === $default) {
-            // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
-        }
-
-        foreach ($ret as $value) {
-            if (!is_string($value)) {
-                throw new \Exception(
-                    $this->location . ': The option ' . var_export($name, true) .
-                    ' must be a string or an array of strings.'
-                );
-            }
-        }
+        Assert::allString(
+            $ret,
+            sprintf(
+                '%s: The option %s must be a string or an array of strings.',
+                $this->location,
+                var_export($name, true),
+            ),
+        );
 
         return $ret;
+    }
+
+
+    /**
+     * This function retrieves an optional configuration option with a string or an array of strings.
+     *
+     * If the configuration option is a string, it will be converted to an array with a single string
+     *
+     * @param string         $name The name of the option.
+     * @param string[]|null  $default A default value which will be returned if the option isn't found.
+     *                         The default value can be null or an array of strings.
+     *
+     * @return string[]|null The option with the given name, or $default if the option isn't found and $default is specified.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not a string or an array of strings.
+     */
+    public function getOptionalArrayizeString(string $name, ?array $default): ?array
+    {
+        if (!$this->hasValue($name)) {
+            // the option wasn't found, or it matches the default value. In any case, return this value
+            return $default;
+        }
+
+        return $this->getArrayizeString($name, $allowedValues);
     }
 
 

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -972,41 +972,51 @@ class Configuration implements Utils\ClearableState
     /**
      * Retrieve an array as a \SimpleSAML\Configuration object.
      *
-     * This function will load the value of an option into a \SimpleSAML\Configuration object. The option must contain
-     * an array.
+     * This function will load the value of an option into a \SimpleSAML\Configuration object.
+     *   The option must contain an array.
      *
-     * An exception will be thrown if this option isn't an array, or if this option isn't found, and no default value
-     * is given.
+     * An exception will be thrown if this option isn't an array, or if this option isn't found.
      *
      * @param string $name The name of the option.
-     * @param array|null $default A default value which will be used if the option isn't found. An empty Configuration
-     *                        object will be returned if this parameter isn't given and the option doesn't exist.
-     *                        This function will only return null if $default is set to null and the option
-     *                        doesn't exist.
+     * @return \SimpleSAML\Configuration The option with the given name,
      *
-     * @return \SimpleSAML\Configuration|null The option with the given name,
-     *   or $default if the option isn't found and $default is specified.
-     *
-     * @throws \Exception If the option is not an array.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not an array.
      */
-    public function getConfigItem(string $name, $default = []): ?Configuration
+    public function getConfigItem(string $name): Configuration
     {
-        $ret = $this->getValue($name, $default);
-
-        if ($ret === null) {
-            // the option wasn't found, or it is explicitly null
-            // do not instantiate a new Configuration instance, but just return null
-            return null;
-        }
-
-        if (!is_array($ret)) {
-            throw new \Exception(
-                $this->location . ': The option ' . var_export($name, true) .
-                ' is not an array.'
-            );
-        }
+        $ret = $this->getArray($name);
 
         return self::loadFromArray($ret, $this->location . '[' . var_export($name, true) . ']');
+    }
+
+
+
+    /**
+     * Retrieve an optional array as a \SimpleSAML\Configuration object.
+     *
+     * This function will load the optional value of an option into a \SimpleSAML\Configuration object.
+     *   The option must contain an array.
+     *
+     * An exception will be thrown if this option isn't an array, or if this option isn't found.
+     *
+     * @param string     $name The name of the option.
+     * @param array|null $default A default value which will be used if the option isn't found. An empty Configuration
+     *                     object will be returned if this parameter isn't given and the option doesn't exist.
+     *                     This function will only return null if $default is set to null and the option doesn't exist.
+     *
+     * @return \SimpleSAML\Configuration|null The option with the given name,
+     *   or $default, converted into a Configuration object.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailed\Exception If the option is not an array.
+     */
+    public function getOptionalConfigItem(string $name, ?array $default): ?Configuration
+    {
+        if (!$this->hasValue($name)) {
+            // the option wasn't found, or it matches the default value. In any case, return this value
+            return $default;
+        }
+
+        return $this->getConfigItem($name);
     }
 
 

--- a/lib/SimpleSAML/Configuration.php
+++ b/lib/SimpleSAML/Configuration.php
@@ -653,36 +653,47 @@ class Configuration implements Utils\ClearableState
     /**
      * This function retrieves an integer configuration option.
      *
-     * An exception will be thrown if this option isn't an integer, or if this option isn't found, and no default value
-     * is given.
+     * An exception will be thrown if this option isn't an integer, or if this option isn't found.
      *
-     * @param string $name The name of the option.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                  required if this parameter isn't given. The default value can be any value, including
-     *                  null.
+     * @param string $name  The name of the option.
+     * @return int          The option with the given name.
      *
-     * @return int|mixed The option with the given name, or $default if the option isn't found and $default is
-     * specified.
-     *
-     * @throws \Exception If the option is not an integer.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not an integer.
      */
-    public function getInteger(string $name, $default = self::REQUIRED_OPTION)
+    public function getInteger(string $name): int
     {
-        $ret = $this->getValue($name, $default);
+        $ret = $this->getValue($name);
 
-        if ($ret === $default) {
-            // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
-        }
-
-        if (!is_int($ret)) {
-            throw new \Exception(
-                $this->location . ': The option ' . var_export($name, true) .
-                ' is not a valid integer value.'
-            );
-        }
+        Assert::integer(
+            $ret,
+            sprintf('%s: The option %s is not a valid integer value.', $this->location, var_export($name, true)),
+        );
 
         return $ret;
+    }
+
+
+    /**
+     * This function retrieves an optional integer configuration option.
+     *
+     * An exception will be thrown if this option isn't an integer.
+     *
+     * @param string $name     The name of the option.
+     * @param mixed  $default  A default value which will be returned if the option isn't found.
+     *                         The default value can be null or an integer.
+     *
+     * @return int|null The option with the given name, or $default if the option isn't found.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not an integer.
+     */
+    public function getOptionalInteger(string $name, ?int $default): ?int
+    {
+        if (!$this->hasValue($name)) {
+            // the option wasn't found, or it matches the default value. In any case, return this value
+            return $default;
+        }
+
+        return $this->getInteger($name);
     }
 
 
@@ -697,33 +708,56 @@ class Configuration implements Utils\ClearableState
      * @param string $name The name of the option.
      * @param int    $minimum The smallest value which is allowed.
      * @param int    $maximum The largest value which is allowed.
-     * @param mixed  $default A default value which will be returned if the option isn't found. The option will be
-     *                  required if this parameter isn't given. The default value can be any value, including
-     *                  null.
      *
-     * @return int|mixed The option with the given name, or $default if the option isn't found and $default is
-     *     specified.
+     * @return int The option with the given name.
      *
-     * @throws \Exception If the option is not in the range specified.
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not in the range specified.
      */
-    public function getIntegerRange(string $name, int $minimum, int $maximum, $default = self::REQUIRED_OPTION)
+    public function getIntegerRange(string $name, int $minimum, int $maximum): int
     {
-        $ret = $this->getInteger($name, $default);
+        $ret = $this->getInteger($name);
 
-        if ($ret === $default) {
-            // the option wasn't found, or it matches the default value. In any case, return this value
-            return $ret;
-        }
-
-        if ($ret < $minimum || $ret > $maximum) {
-            throw new \Exception(
-                $this->location . ': Value of option ' . var_export($name, true) .
-                ' is out of range. Value is ' . $ret . ', allowed range is ['
-                . $minimum . ' - ' . $maximum . ']'
-            );
-        }
+        Assert::range(
+            $ret,
+            $minimum,
+            $maximum,
+            sprintf(
+                '%s: Value of option %s is out of range. Value is %%s, allowed range is [%%2$s - %%3$s]',
+                $this->location,
+                var_export($name, true),
+            ),
+        );
 
         return $ret;
+    }
+
+
+    /**
+     * This function retrieves an optional integer configuration option where the value must be in the specified range.
+     *
+     * An exception will be thrown if:
+     * - the option isn't an integer
+     * - the value is outside of the allowed range
+     *
+     * @param string    $name    The name of the option.
+     * @param int       $minimum The smallest value which is allowed.
+     * @param int       $maximum The largest value which is allowed.
+     * @param int|null  $default A default value which will be returned if the option isn't found.
+     *                             The default value can be null or an integer.
+     *
+     * @return int|null The option with the given name, or $default if the option isn't found and $default is
+     *     specified.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException If the option is not in the range specified.
+     */
+    public function getOptionalIntegerRange(string $name, int $minimum, int $maximum, ?int $default): ?int
+    {
+        if (!$this->hasValue($name)) {
+            // the option wasn't found, or it matches the default value. In any case, return this value
+            return $default;
+        }
+
+        return $this->getInteger($name, $minimum, $maximum);
     }
 
 

--- a/lib/SimpleSAML/Database.php
+++ b/lib/SimpleSAML/Database.php
@@ -136,7 +136,7 @@ class Database
                 'database.username'   => $config->getString('database.username', null),
                 'database.password'   => $config->getString('database.password', null),
                 'database.prefix'     => $config->getString('database.prefix', ''),
-                'database.persistent' => $config->getBoolean('database.persistent', true),
+                'database.persistent' => $config->getOptionalBoolean('database.persistent', true),
             ],
 
             // TODO: deprecated: the "database.slave" terminology is preserved here for backwards compatibility.

--- a/lib/SimpleSAML/Database.php
+++ b/lib/SimpleSAML/Database.php
@@ -92,8 +92,8 @@ class Database
         // connect to the primary
         $this->dbPrimary = $this->connect(
             $config->getString('database.dsn'),
-            $config->getString('database.username', null),
-            $config->getString('database.password', null),
+            $config->getOptionalString('database.username', null),
+            $config->getOptionalString('database.password', null),
             $driverOptions
         );
 
@@ -117,7 +117,7 @@ class Database
                 )
             );
         }
-        $this->tablePrefix = $config->getString('database.prefix', '');
+        $this->tablePrefix = $config->getOptionalString('database.prefix', '');
     }
 
 
@@ -133,9 +133,9 @@ class Database
         $assembledConfig = [
             'primary' => [
                 'database.dsn'        => $config->getString('database.dsn'),
-                'database.username'   => $config->getString('database.username', null),
-                'database.password'   => $config->getString('database.password', null),
-                'database.prefix'     => $config->getString('database.prefix', ''),
+                'database.username'   => $config->getOptionalString('database.username', null),
+                'database.password'   => $config->getOptionalString('database.password', null),
+                'database.prefix'     => $config->getOptionalString('database.prefix', ''),
                 'database.persistent' => $config->getOptionalBoolean('database.persistent', true),
             ],
 

--- a/lib/SimpleSAML/Database.php
+++ b/lib/SimpleSAML/Database.php
@@ -84,8 +84,8 @@ class Database
      */
     private function __construct(Configuration $config)
     {
-        $driverOptions = $config->getArray('database.driver_options', []);
-        if ($config->getBoolean('database.persistent', true)) {
+        $driverOptions = $config->getOptionalArray('database.driver_options', []);
+        if ($config->getOptionalBoolean('database.persistent', true)) {
             $driverOptions[PDO::ATTR_PERSISTENT] = true;
         }
 
@@ -98,14 +98,14 @@ class Database
         );
 
         // TODO: deprecated: the "database.slave" terminology is preserved here for backwards compatibility.
-        if ($config->getArray('database.slaves', null) !== null) {
+        if ($config->getOptionalArray('database.slaves', null) !== null) {
             Logger::warning(
                 'The "database.slaves" config option is deprecated. ' .
                 'Please update your configuration to use "database.secondaries".'
             );
         }
         // connect to any configured secondaries, preserving legacy config option
-        $secondaries = $config->getArray('database.secondaries', $config->getArray('database.slaves', []));
+        $secondaries = $config->getOptionalArray('database.secondaries', $config->getOptionalArray('database.slaves', []));
         foreach ($secondaries as $secondary) {
             array_push(
                 $this->dbSecondaries,
@@ -138,8 +138,9 @@ class Database
                 'database.prefix'     => $config->getString('database.prefix', ''),
                 'database.persistent' => $config->getBoolean('database.persistent', true),
             ],
+
             // TODO: deprecated: the "database.slave" terminology is preserved here for backwards compatibility.
-            'secondaries' => $config->getArray('database.secondaries', $config->getArray('database.slaves', [])),
+            'secondaries' => $config->getOptionalArray('database.secondaries', $config->getOptionalArray('database.slaves', [])),
         ];
 
         return sha1(serialize($assembledConfig));

--- a/lib/SimpleSAML/Error/Error.php
+++ b/lib/SimpleSAML/Error/Error.php
@@ -243,7 +243,7 @@ class Error extends Exception
         // check if there is a valid technical contact email address
         if (
             $config->getOptionalBoolean('errorreporting', true)
-            && $config->getString('technicalcontact_email', 'na@example.org') !== 'na@example.org'
+            && $config->getOptionalString('technicalcontact_email', 'na@example.org') !== 'na@example.org'
         ) {
             // enable error reporting
             $httpUtils = new Utils\HTTP();

--- a/lib/SimpleSAML/Error/Error.php
+++ b/lib/SimpleSAML/Error/Error.php
@@ -230,7 +230,7 @@ class Error extends Exception
         $config = Configuration::getInstance();
 
         $data = [];
-        $data['showerrors'] = $config->getBoolean('showerrors', true);
+        $data['showerrors'] = $config->getOptionalBoolean('showerrors', true);
         $data['error'] = $errorData;
         $data['errorCode'] = $this->errorCode;
         $data['parameters'] = $this->parameters;
@@ -242,7 +242,7 @@ class Error extends Exception
 
         // check if there is a valid technical contact email address
         if (
-            $config->getBoolean('errorreporting', true)
+            $config->getOptionalBoolean('errorreporting', true)
             && $config->getString('technicalcontact_email', 'na@example.org') !== 'na@example.org'
         ) {
             // enable error reporting

--- a/lib/SimpleSAML/Error/Error.php
+++ b/lib/SimpleSAML/Error/Error.php
@@ -262,7 +262,7 @@ class Error extends Exception
             }
         }
 
-        $show_function = $config->getArray('errors.show_function', null);
+        $show_function = $config->getOptionalArray('errors.show_function', null);
         if (isset($show_function)) {
             Assert::isCallable($show_function);
             $this->setHTTPCode();

--- a/lib/SimpleSAML/Error/Exception.php
+++ b/lib/SimpleSAML/Error/Exception.php
@@ -200,7 +200,7 @@ class Exception extends \Exception
     protected function logBacktrace(int $level = Logger::DEBUG): void
     {
         // Do nothing if backtraces have been disabled in config.
-        $debug = Configuration::getInstance()->getArray('debug', ['backtraces' => true]);
+        $debug = Configuration::getInstance()->getOptionalArray('debug', ['backtraces' => true]);
         if (array_key_exists('backtraces', $debug) && $debug['backtraces'] === false) {
             return;
         }

--- a/lib/SimpleSAML/IdP.php
+++ b/lib/SimpleSAML/IdP.php
@@ -81,12 +81,12 @@ class IdP
         $globalConfig = Configuration::getInstance();
 
         if (substr($id, 0, 6) === 'saml2:') {
-            if (!$globalConfig->getBoolean('enable.saml20-idp', false)) {
+            if (!$globalConfig->getOptionalBoolean('enable.saml20-idp', false)) {
                 throw new Error\Exception('enable.saml20-idp disabled in config.php.');
             }
             $this->config = $metadata->getMetaDataConfig(substr($id, 6), 'saml20-idp-hosted');
         } elseif (substr($id, 0, 5) === 'adfs:') {
-            if (!$globalConfig->getBoolean('enable.adfs-idp', false)) {
+            if (!$globalConfig->getOptionalBoolean('enable.adfs-idp', false)) {
                 throw new Error\Exception('enable.adfs-idp disabled in config.php.');
             }
             $this->config = $metadata->getMetaDataConfig(substr($id, 5), 'adfs-idp-hosted');

--- a/lib/SimpleSAML/IdP.php
+++ b/lib/SimpleSAML/IdP.php
@@ -423,7 +423,7 @@ class IdP
     public function getLogoutHandler(): LogoutHandlerInterface
     {
         // find the logout handler
-        $logouttype = $this->getConfig()->getString('logouttype', 'traditional');
+        $logouttype = $this->getConfig()->getOptionalString('logouttype', 'traditional');
         switch ($logouttype) {
             case 'traditional':
                 $handler = TraditionalLogoutHandler::class;

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -155,8 +155,8 @@ class Language
         $this->availableLanguages = $this->getInstalledLanguages();
         $this->defaultLanguage = $this->configuration->getOptionalString('language.default', self::FALLBACKLANGUAGE);
         $this->languageParameterName = $this->configuration->getOptionalString('language.parameter.name', 'language');
-        $this->customFunction = $this->configuration->getArray('language.get_language_function', null);
-        $this->rtlLanguages = $this->configuration->getArray('language.rtl', []);
+        $this->customFunction = $this->configuration->getOptionalArray('language.get_language_function', null);
+        $this->rtlLanguages = $this->configuration->getOptionalArray('language.rtl', []);
         if (isset($_GET[$this->languageParameterName])) {
             $this->setLanguage(
                 $_GET[$this->languageParameterName],
@@ -173,7 +173,10 @@ class Language
      */
     private function getInstalledLanguages(): array
     {
-        $configuredAvailableLanguages = $this->configuration->getArray('language.available', [self::FALLBACKLANGUAGE]);
+        $configuredAvailableLanguages = $this->configuration->getOptionalArray(
+            'language.available',
+            [self::FALLBACKLANGUAGE]
+        );
         $availableLanguages = [];
         foreach ($configuredAvailableLanguages as $code) {
             if (array_key_exists($code, self::$language_names) && isset(self::$language_names[$code])) {
@@ -403,7 +406,7 @@ class Language
     public static function getLanguageCookie(): ?string
     {
         $config = Configuration::getInstance();
-        $availableLanguages = $config->getArray('language.available', [self::FALLBACKLANGUAGE]);
+        $availableLanguages = $config->getOptionalArray('language.available', [self::FALLBACKLANGUAGE]);
         $name = $config->getOptionalString('language.cookie.name', 'language');
 
         if (isset($_COOKIE[$name])) {
@@ -426,7 +429,7 @@ class Language
     {
         $language = strtolower($language);
         $config = Configuration::getInstance();
-        $availableLanguages = $config->getArray('language.available', [self::FALLBACKLANGUAGE]);
+        $availableLanguages = $config->getOptionalArray('language.available', [self::FALLBACKLANGUAGE]);
 
         if (!in_array($language, $availableLanguages, true) || headers_sent()) {
             return;

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -160,7 +160,7 @@ class Language
         if (isset($_GET[$this->languageParameterName])) {
             $this->setLanguage(
                 $_GET[$this->languageParameterName],
-                $this->configuration->getBoolean('language.parameter.setcookie', true)
+                $this->configuration->getOptionalBoolean('language.parameter.setcookie', true)
             );
         }
     }
@@ -437,8 +437,8 @@ class Language
             'lifetime' => ($config->getInteger('language.cookie.lifetime', 60 * 60 * 24 * 900)),
             'domain'   => ($config->getString('language.cookie.domain', '')),
             'path'     => ($config->getString('language.cookie.path', '/')),
-            'secure'   => ($config->getBoolean('language.cookie.secure', false)),
-            'httponly' => ($config->getBoolean('language.cookie.httponly', false)),
+            'secure'   => ($config->getOptionalBoolean('language.cookie.secure', false)),
+            'httponly' => ($config->getOptionalBoolean('language.cookie.httponly', false)),
             'samesite' => ($config->getString('language.cookie.samesite', null)),
         ];
 

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -434,7 +434,7 @@ class Language
 
         $name = $config->getOptionalString('language.cookie.name', 'language');
         $params = [
-            'lifetime' => ($config->getInteger('language.cookie.lifetime', 60 * 60 * 24 * 900)),
+            'lifetime' => ($config->getOptionalInteger('language.cookie.lifetime', 60 * 60 * 24 * 900)),
             'domain'   => ($config->getOptionalString('language.cookie.domain', '')),
             'path'     => ($config->getOptionalString('language.cookie.path', '/')),
             'secure'   => ($config->getOptionalBoolean('language.cookie.secure', false)),

--- a/lib/SimpleSAML/Locale/Language.php
+++ b/lib/SimpleSAML/Locale/Language.php
@@ -153,8 +153,8 @@ class Language
     {
         $this->configuration = $configuration;
         $this->availableLanguages = $this->getInstalledLanguages();
-        $this->defaultLanguage = $this->configuration->getString('language.default', self::FALLBACKLANGUAGE);
-        $this->languageParameterName = $this->configuration->getString('language.parameter.name', 'language');
+        $this->defaultLanguage = $this->configuration->getOptionalString('language.default', self::FALLBACKLANGUAGE);
+        $this->languageParameterName = $this->configuration->getOptionalString('language.parameter.name', 'language');
         $this->customFunction = $this->configuration->getArray('language.get_language_function', null);
         $this->rtlLanguages = $this->configuration->getArray('language.rtl', []);
         if (isset($_GET[$this->languageParameterName])) {
@@ -404,7 +404,7 @@ class Language
     {
         $config = Configuration::getInstance();
         $availableLanguages = $config->getArray('language.available', [self::FALLBACKLANGUAGE]);
-        $name = $config->getString('language.cookie.name', 'language');
+        $name = $config->getOptionalString('language.cookie.name', 'language');
 
         if (isset($_COOKIE[$name])) {
             $language = strtolower((string) $_COOKIE[$name]);
@@ -432,14 +432,14 @@ class Language
             return;
         }
 
-        $name = $config->getString('language.cookie.name', 'language');
+        $name = $config->getOptionalString('language.cookie.name', 'language');
         $params = [
             'lifetime' => ($config->getInteger('language.cookie.lifetime', 60 * 60 * 24 * 900)),
-            'domain'   => ($config->getString('language.cookie.domain', '')),
-            'path'     => ($config->getString('language.cookie.path', '/')),
+            'domain'   => ($config->getOptionalString('language.cookie.domain', '')),
+            'path'     => ($config->getOptionalString('language.cookie.path', '/')),
             'secure'   => ($config->getOptionalBoolean('language.cookie.secure', false)),
             'httponly' => ($config->getOptionalBoolean('language.cookie.httponly', false)),
-            'samesite' => ($config->getString('language.cookie.samesite', null)),
+            'samesite' => ($config->getOptionalString('language.cookie.samesite', null)),
         ];
 
         $httpUtils = new Utils\HTTP();

--- a/lib/SimpleSAML/Locale/Localization.php
+++ b/lib/SimpleSAML/Locale/Localization.php
@@ -268,7 +268,7 @@ class Localization
     {
         $this->addDomain($this->localeDir, 'attributes');
 
-        list($theme,) = explode(':', $this->configuration->getString('theme.use', 'default'));
+        list($theme,) = explode(':', $this->configuration->getOptionalString('theme.use', 'default'));
         if ($theme !== 'default') {
             $this->addModuleDomain($theme, null, 'attributes');
         }

--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -453,7 +453,7 @@ class Logger
 
         // get the metadata handler option from the configuration
         if (is_null($handler)) {
-            $handler = $config->getString(
+            $handler = $config->getOptionalString(
                 'logging.handler',
                 php_sapi_name() === 'cli' || defined('STDIN') ? 'stderr' : 'syslog'
             );
@@ -473,7 +473,7 @@ class Logger
             $handler = $known_handlers[$handler];
         }
 
-        self::$format = $config->getString('logging.format', self::$format);
+        self::$format = $config->getOptionalString('logging.format', self::$format);
 
         try {
             /** @var \SimpleSAML\Logger\LoggingHandlerInterface */

--- a/lib/SimpleSAML/Logger.php
+++ b/lib/SimpleSAML/Logger.php
@@ -449,7 +449,7 @@ class Logger
         $config = Configuration::getInstance();
 
         // setting minimum log_level
-        self::$logLevel = $config->getInteger('logging.level', self::INFO);
+        self::$logLevel = $config->getOptionalInteger('logging.level', self::INFO);
 
         // get the metadata handler option from the configuration
         if (is_null($handler)) {

--- a/lib/SimpleSAML/Logger/ErrorLogLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/ErrorLogLoggingHandler.php
@@ -49,7 +49,7 @@ class ErrorLogLoggingHandler implements LoggingHandlerInterface
         $this->processname = preg_replace(
             '/[\x00-\x1F\x7F\xA0]/u',
             '',
-            $config->getString('logging.processname', 'SimpleSAMLphp')
+            $config->getOptionalString('logging.processname', 'SimpleSAMLphp')
         );
     }
 

--- a/lib/SimpleSAML/Logger/FileLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/FileLoggingHandler.php
@@ -54,13 +54,13 @@ class FileLoggingHandler implements LoggingHandlerInterface
     {
         // get the metadata handler option from the configuration
         $this->logFile = $config->getPathValue('loggingdir', 'log/') .
-            $config->getString('logging.logfile', 'simplesamlphp.log');
+            $config->getOptionalString('logging.logfile', 'simplesamlphp.log');
 
         // Remove any non-printable characters before storing
         $this->processname = preg_replace(
             '/[\x00-\x1F\x7F\xA0]/u',
             '',
-            $config->getString('logging.processname', 'SimpleSAMLphp')
+            $config->getOptionalString('logging.processname', 'SimpleSAMLphp')
         );
 
         if (@file_exists($this->logFile)) {

--- a/lib/SimpleSAML/Logger/StandardErrorLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/StandardErrorLoggingHandler.php
@@ -26,7 +26,7 @@ class StandardErrorLoggingHandler extends FileLoggingHandler
         $this->processname = preg_replace(
             '/[\x00-\x1F\x7F\xA0]/u',
             '',
-            $config->getString('logging.processname', 'SimpleSAMLphp')
+            $config->getOptionalString('logging.processname', 'SimpleSAMLphp')
         );
         $this->logFile = 'php://stderr';
     }

--- a/lib/SimpleSAML/Logger/SyslogLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/SyslogLoggingHandler.php
@@ -33,7 +33,7 @@ class SyslogLoggingHandler implements LoggingHandlerInterface
         $processname = preg_replace(
             '/[\x00-\x1F\x7F\xA0]/u',
             '',
-            $config->getString('logging.processname', 'SimpleSAMLphp')
+            $config->getOptionalString('logging.processname', 'SimpleSAMLphp')
         );
 
         // Setting facility to LOG_USER (only valid in Windows), enable log level rewrite on windows systems

--- a/lib/SimpleSAML/Logger/SyslogLoggingHandler.php
+++ b/lib/SimpleSAML/Logger/SyslogLoggingHandler.php
@@ -27,7 +27,7 @@ class SyslogLoggingHandler implements LoggingHandlerInterface
      */
     public function __construct(Configuration $config)
     {
-        $facility = $config->getInteger('logging.facility', defined('LOG_LOCAL5') ? constant('LOG_LOCAL5') : LOG_USER);
+        $facility = $config->getOptionalInteger('logging.facility', defined('LOG_LOCAL5') ? constant('LOG_LOCAL5') : LOG_USER);
 
         // Remove any non-printable characters before storing
         $processname = preg_replace(

--- a/lib/SimpleSAML/Memcache.php
+++ b/lib/SimpleSAML/Memcache.php
@@ -375,7 +375,7 @@ class Memcache
         $config = Configuration::getInstance();
 
         // get the expire-value from the configuration
-        $expire = $config->getInteger('memcache_store.expires', 0);
+        $expire = $config->getOptionalInteger('memcache_store.expires', 0);
 
         // it must be a positive integer
         if ($expire < 0) {

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandler.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandler.php
@@ -66,7 +66,7 @@ class MetaDataStorageHandler implements ClearableState
     {
         $config = Configuration::getInstance();
 
-        $sourcesConfig = $config->getArray('metadata.sources', null);
+        $sourcesConfig = $config->getOptionalArray('metadata.sources', null);
 
         // for backwards compatibility, and to provide a default configuration
         if ($sourcesConfig === null) {

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandler.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandler.php
@@ -70,7 +70,7 @@ class MetaDataStorageHandler implements ClearableState
 
         // for backwards compatibility, and to provide a default configuration
         if ($sourcesConfig === null) {
-            $type = $config->getString('metadata.handler', 'flatfile');
+            $type = $config->getOptionalString('metadata.handler', 'flatfile');
             $sourcesConfig = [['type' => $type]];
         }
 

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
@@ -52,7 +52,7 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
         if (array_key_exists('directory', $config)) {
             $this->directory = $config['directory'] ?: 'metadata/';
         } else {
-            $this->directory = $globalConfig->getString('metadatadir', 'metadata/');
+            $this->directory = $globalConfig->getOptionalString('metadatadir', 'metadata/');
         }
 
         /* Resolve this directory relative to the SimpleSAMLphp directory (unless it is

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
@@ -45,7 +45,6 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
         $globalConfig = Configuration::getInstance();
 
         $cfgHelp = Configuration::loadFromArray($config, 'serialize metadata source');
-var_dump($config);
         $this->directory = $cfgHelp->getString('directory');
 
         /* Resolve this directory relative to the SimpleSAMLphp directory (unless it is

--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
@@ -45,7 +45,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
         $globalConfig = Configuration::getInstance();
 
         $cfgHelp = Configuration::loadFromArray($config, 'serialize metadata source');
-
+var_dump($config);
         $this->directory = $cfgHelp->getString('directory');
 
         /* Resolve this directory relative to the SimpleSAMLphp directory (unless it is

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -432,12 +432,8 @@ class SAMLBuilder
          */
         $attributeconsumer = new AttributeConsumingService();
 
-        $attributeconsumer->setIndex($metadata->getInteger('attributes.index', 0));
-
-        if ($metadata->hasValue('attributes.isDefault')) {
-            $attributeconsumer->setIsDefault($metadata->getBoolean('attributes.isDefault', false));
-        }
-
+        $attributeconsumer->setIndex($metadata->getOptionalInteger('attributes.index', 0));
+        $attributeconsumer->setIsDefault($metadata->getOptionalBoolean('attributes.isDefault', false));
         $attributeconsumer->setServiceName($name);
         $attributeconsumer->setServiceDescription($metadata->getLocalizedString('description', []));
 

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -437,7 +437,7 @@ class SAMLBuilder
         $attributeconsumer->setServiceName($name);
         $attributeconsumer->setServiceDescription($metadata->getLocalizedString('description', []));
 
-        $nameFormat = $metadata->getString('attributes.NameFormat', Constants::NAMEFORMAT_URI);
+        $nameFormat = $metadata->getOptionalString('attributes.NameFormat', Constants::NAMEFORMAT_URI);
         foreach ($attributes as $friendlyName => $attribute) {
             $t = new RequestedAttribute();
             $t->setName($attribute);

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -518,10 +518,10 @@ class SAMLBuilder
 
         $e->setSingleLogoutService(self::createEndpoints($metadata->getEndpoints('SingleLogoutService'), false));
 
-        $e->setNameIDFormat($metadata->getArrayizeString('NameIDFormat', []));
+        $e->setNameIDFormat($metadata->getOptionalArrayizeString('NameIDFormat', []));
 
         $endpoints = $metadata->getEndpoints('AssertionConsumerService');
-        foreach ($metadata->getArrayizeString('AssertionConsumerService.artifact', []) as $acs) {
+        foreach ($metadata->getOptionalArrayizeString('AssertionConsumerService.artifact', []) as $acs) {
             $endpoints[] = [
                 'Binding'  => Constants::BINDING_HTTP_ARTIFACT,
                 'Location' => $acs,
@@ -575,7 +575,7 @@ class SAMLBuilder
 
         $e->setSingleLogoutService(self::createEndpoints($metadata->getEndpoints('SingleLogoutService'), false));
 
-        $e->setNameIDFormat($metadata->getArrayizeString('NameIDFormat', []));
+        $e->setNameIDFormat($metadata->getOptionalArrayizeString('NameIDFormat', []));
 
         $e->setSingleSignOnService(self::createEndpoints($metadata->getEndpoints('SingleSignOnService'), false));
 
@@ -614,7 +614,7 @@ class SAMLBuilder
             false
         ));
 
-        $e->setNameIDFormat($metadata->getArrayizeString('NameIDFormat', []));
+        $e->setNameIDFormat($metadata->getOptionalArrayizeString('NameIDFormat', []));
 
         $this->entityDescriptor->addRoleDescriptor($e);
     }

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -431,9 +431,12 @@ class SAMLBuilder
          * of requested attributes
          */
         $attributeconsumer = new AttributeConsumingService();
-
         $attributeconsumer->setIndex($metadata->getOptionalInteger('attributes.index', 0));
-        $attributeconsumer->setIsDefault($metadata->getOptionalBoolean('attributes.isDefault', false));
+
+        if ($metadata->hasValue('attributes.isDefault')) {
+            $attributeconsumer->setIsDefault($metadata->getBoolean('attributes.isDefault', false));
+        }
+
         $attributeconsumer->setServiceName($name);
         $attributeconsumer->setServiceDescription($metadata->getLocalizedString('description', []));
 

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -417,7 +417,7 @@ class SAMLBuilder
         Configuration $metadata
     ): void {
         $attributes = $metadata->getOptionalArray('attributes', []);
-        $name = $metadata->getLocalizedString('name', null);
+        $name = $metadata->getOptionalLocalizedString('name', null);
 
         if ($name === null || count($attributes) == 0) {
             // we cannot add an AttributeConsumingService without name and attributes
@@ -434,11 +434,11 @@ class SAMLBuilder
         $attributeconsumer->setIndex($metadata->getOptionalInteger('attributes.index', 0));
 
         if ($metadata->hasValue('attributes.isDefault')) {
-            $attributeconsumer->setIsDefault($metadata->getBoolean('attributes.isDefault', false));
+            $attributeconsumer->setIsDefault($metadata->getOptionalBoolean('attributes.isDefault', false));
         }
 
         $attributeconsumer->setServiceName($name);
-        $attributeconsumer->setServiceDescription($metadata->getLocalizedString('description', []));
+        $attributeconsumer->setServiceDescription($metadata->getOptionalLocalizedString('description', []));
 
         $nameFormat = $metadata->getOptionalString('attributes.NameFormat', Constants::NAMEFORMAT_URI);
         foreach ($attributes as $friendlyName => $attribute) {

--- a/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -416,7 +416,7 @@ class SAMLBuilder
         SPSSODescriptor $spDesc,
         Configuration $metadata
     ): void {
-        $attributes = $metadata->getArray('attributes', []);
+        $attributes = $metadata->getOptionalArray('attributes', []);
         $name = $metadata->getLocalizedString('name', null);
 
         if ($name === null || count($attributes) == 0) {
@@ -424,7 +424,7 @@ class SAMLBuilder
             return;
         }
 
-        $attributesrequired = $metadata->getArray('attributes.required', []);
+        $attributesrequired = $metadata->getOptionalArray('attributes.required', []);
 
         /*
          * Add an AttributeConsumingService element with information as name and description and list
@@ -534,7 +534,7 @@ class SAMLBuilder
 
         $this->entityDescriptor->addRoleDescriptor($e);
 
-        foreach ($metadata->getArray('contacts', []) as $contact) {
+        foreach ($metadata->getOptionalArray('contacts', []) as $contact) {
             if (array_key_exists('contactType', $contact) && array_key_exists('emailAddress', $contact)) {
                 $this->addContact(Utils\Config\Metadata::getContact($contact));
             }
@@ -582,7 +582,7 @@ class SAMLBuilder
 
         $this->entityDescriptor->addRoleDescriptor($e);
 
-        foreach ($metadata->getArray('contacts', []) as $contact) {
+        foreach ($metadata->getOptionalArray('contacts', []) as $contact) {
             if (array_key_exists('contactType', $contact) && array_key_exists('emailAddress', $contact)) {
                 $this->addContact(Utils\Config\Metadata::getContact($contact));
             }
@@ -604,7 +604,7 @@ class SAMLBuilder
         $metadata = Configuration::loadFromArray($metadata, $metadata['entityid']);
 
         $e = new AttributeAuthorityDescriptor();
-        $e->setProtocolSupportEnumeration($metadata->getArray('protocols', [Constants::NS_SAMLP]));
+        $e->setProtocolSupportEnumeration($metadata->getOptionalArray('protocols', [Constants::NS_SAMLP]));
 
         $this->addExtensions($metadata, $e);
         $this->addCertificate($e, $metadata);

--- a/lib/SimpleSAML/Metadata/Signer.php
+++ b/lib/SimpleSAML/Metadata/Signer.php
@@ -144,7 +144,7 @@ class Signer
             return $entityMetadata['metadata.sign.enable'];
         }
 
-        return $config->getBoolean('metadata.sign.enable', false);
+        return $config->getOptionalBoolean('metadata.sign.enable', false);
     }
 
 

--- a/lib/SimpleSAML/Metadata/Signer.php
+++ b/lib/SimpleSAML/Metadata/Signer.php
@@ -62,8 +62,8 @@ class Signer
         }
 
         // then we look for default values in the global configuration
-        $privatekey = $config->getString('metadata.sign.privatekey', null);
-        $certificate = $config->getString('metadata.sign.certificate', null);
+        $privatekey = $config->getOptionalString('metadata.sign.privatekey', null);
+        $certificate = $config->getOptionalString('metadata.sign.certificate', null);
         if ($privatekey !== null || $certificate !== null) {
             if ($privatekey === null || $certificate === null) {
                 throw new \Exception(
@@ -75,7 +75,7 @@ class Signer
             }
             $ret = ['privatekey' => $privatekey, 'certificate' => $certificate];
 
-            $privatekey_pass = $config->getString('metadata.sign.privatekey_pass', null);
+            $privatekey_pass = $config->getOptionalString('metadata.sign.privatekey_pass', null);
             if ($privatekey_pass !== null) {
                 $ret['privatekey_pass'] = $privatekey_pass;
             }
@@ -178,7 +178,7 @@ class Signer
             }
             $alg = $entityMetadata['metadata.sign.algorithm'];
         } else {
-            $alg = $config->getString('metadata.sign.algorithm', XMLSecurityKey::RSA_SHA256);
+            $alg = $config->getOptionalString('metadata.sign.algorithm', XMLSecurityKey::RSA_SHA256);
         }
 
         $supported_algs = [

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -301,7 +301,7 @@ class Module
         /** @psalm-var \SimpleSAML\Configuration $assetConfig */
         $assetConfig = $config->getOptionalConfigItem('assets', null);
         /** @psalm-var \SimpleSAML\Configuration $cacheConfig */
-        $cacheConfig = $assetConfig ?: $assetOptionalConfig->getConfigItem('caching', null);
+        $cacheConfig = $assetConfig ?: $assetConfig->getOptionalConfigItem('caching', null);
         $response = new BinaryFileResponse($path);
         $response->setCache([
             // "public" allows response caching even if the request was authenticated,

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -310,7 +310,7 @@ class Module
             'max_age' => strval($cacheConfig->getInteger('max_age', 86400))
         ]);
         $response->setAutoLastModified();
-        if ($cacheConfig->getBoolean('etag', false)) {
+        if ($cacheConfig->getOptionalBoolean('etag', false)) {
             $response->setAutoEtag();
         }
         $response->isNotModified($request);

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -307,7 +307,7 @@ class Module
             // "public" allows response caching even if the request was authenticated,
             // which is exactly what we want for static resources
             'public' => true,
-            'max_age' => strval($cacheConfig->getInteger('max_age', 86400))
+            'max_age' => strval($cacheConfig->getOptionalInteger('max_age', 86400))
         ]);
         $response->setAutoLastModified();
         if ($cacheConfig->getOptionalBoolean('etag', false)) {

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -117,7 +117,7 @@ class Module
     public static function isModuleEnabled(string $module): bool
     {
         $config = Configuration::getOptionalConfig();
-        return self::isModuleEnabledWithConf($module, $config->getArray('module.enable', self::$core_modules));
+        return self::isModuleEnabledWithConf($module, $config->getOptionalArray('module.enable', self::$core_modules));
     }
 
 
@@ -522,7 +522,7 @@ class Module
     public static function callHooks(string $hook, &$data = null): void
     {
         $modules = self::getModules();
-        $config = Configuration::getOptionalConfig()->getArray('module.enable', []);
+        $config = Configuration::getOptionalConfig()->getOptionalArray('module.enable', []);
         sort($modules);
         foreach ($modules as $module) {
             if (!self::isModuleEnabledWithConf($module, $config)) {

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -299,9 +299,9 @@ class Module
         }
 
         /** @psalm-var \SimpleSAML\Configuration $assetConfig */
-        $assetConfig = $config->getConfigItem('assets');
+        $assetConfig = $config->getOptionalConfigItem('assets', null);
         /** @psalm-var \SimpleSAML\Configuration $cacheConfig */
-        $cacheConfig = $assetConfig->getConfigItem('caching');
+        $cacheConfig = $assetConfig ?: $assetOptionalConfig->getConfigItem('caching', null);
         $response = new BinaryFileResponse($path);
         $response->setCache([
             // "public" allows response caching even if the request was authenticated,

--- a/lib/SimpleSAML/Module.php
+++ b/lib/SimpleSAML/Module.php
@@ -298,10 +298,9 @@ class Module
             }
         }
 
-        /** @psalm-var \SimpleSAML\Configuration $assetConfig */
-        $assetConfig = $config->getOptionalConfigItem('assets', null);
-        /** @psalm-var \SimpleSAML\Configuration $cacheConfig */
-        $cacheConfig = $assetConfig ?: $assetConfig->getOptionalConfigItem('caching', null);
+
+        $assetConfig = $config->getConfigItem('assets');
+        $cacheConfig = $assetConfig->getConfigItem('caching');
         $response = new BinaryFileResponse($path);
         $response->setCache([
             // "public" allows response caching even if the request was authenticated,

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -575,7 +575,7 @@ class Session implements Utils\ClearableState
     public function setRememberMeExpire(int $lifetime = null): void
     {
         if ($lifetime === null) {
-            $lifetime = self::$config->getInteger('session.rememberme.lifetime', 14 * 86400);
+            $lifetime = self::$config->getOptionalInteger('session.rememberme.lifetime', 14 * 86400);
         }
         $this->rememberMeExpire = time() + $lifetime;
 
@@ -611,7 +611,7 @@ class Session implements Utils\ClearableState
             $data['AuthnInstant'] = time();
         }
 
-        $maxSessionExpire = time() + self::$config->getInteger('session.duration', 8 * 60 * 60);
+        $maxSessionExpire = time() + self::$config->getOptionalInteger('session.duration', 8 * 60 * 60);
         if (!isset($data['Expire']) || $data['Expire'] > $maxSessionExpire) {
             // unset, or beyond our session lifetime. Clamp it to our maximum session lifetime
             $data['Expire'] = $maxSessionExpire;
@@ -809,7 +809,7 @@ class Session implements Utils\ClearableState
         $this->markDirty();
 
         if ($expire === null) {
-            $expire = time() + self::$config->getInteger('session.duration', 8 * 60 * 60);
+            $expire = time() + self::$config->getOptionalInteger('session.duration', 8 * 60 * 60);
         }
 
         $this->authData[$authority]['Expire'] = $expire;
@@ -884,7 +884,7 @@ class Session implements Utils\ClearableState
 
         if ($timeout === null) {
             // use the default timeout
-            $timeout = self::$config->getInteger('session.datastore.timeout', null);
+            $timeout = self::$config->getOptionalInteger('session.datastore.timeout', null);
             if ($timeout !== null) {
                 if ($timeout <= 0) {
                     throw new \Exception(

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -355,7 +355,7 @@ class Session implements Utils\ClearableState
             $globalConfig = Configuration::getInstance();
 
             if ($session->authToken !== null) {
-                $authTokenCookieName = $globalConfig->getString(
+                $authTokenCookieName = $globalConfig->getOptionalString(
                     'session.authtoken.cookiename',
                     'SimpleSAMLAuthToken'
                 );
@@ -660,7 +660,7 @@ class Session implements Utils\ClearableState
             $httpUtils = new Utils\HTTP();
             try {
                 $httpUtils->setCookie(
-                    self::$config->getString('session.authtoken.cookiename', 'SimpleSAMLAuthToken'),
+                    self::$config->getOptionalString('session.authtoken.cookiename', 'SimpleSAMLAuthToken'),
                     $this->authToken,
                     $sessionHandler->getCookieParams()
                 );
@@ -790,7 +790,7 @@ class Session implements Utils\ClearableState
         if ($this->authToken !== null) {
             $httpUtils = new Utils\HTTP();
             $httpUtils->setCookie(
-                self::$config->getString('session.authtoken.cookiename', 'SimpleSAMLAuthToken'),
+                self::$config->getOptionalString('session.authtoken.cookiename', 'SimpleSAMLAuthToken'),
                 $this->authToken,
                 $params
             );

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -653,7 +653,7 @@ class Session implements Utils\ClearableState
             !$this->transient
             && (!empty($data['RememberMe'])
             || $this->rememberMeExpire !== null)
-            && self::$config->getBoolean('session.rememberme.enable', false)
+            && self::$config->getOptionalBoolean('session.rememberme.enable', false)
         ) {
             $this->setRememberMeExpire();
         } else {

--- a/lib/SimpleSAML/Session.php
+++ b/lib/SimpleSAML/Session.php
@@ -180,7 +180,7 @@ class Session implements Utils\ClearableState
             $this->markDirty();
 
             // initialize data for session check function if defined
-            $checkFunction = self::$config->getValue('session.check_function', null);
+            $checkFunction = self::$config->getOptionalValue('session.check_function', null);
             if (is_callable($checkFunction)) {
                 call_user_func($checkFunction, $this, true);
             }
@@ -371,7 +371,7 @@ class Session implements Utils\ClearableState
             }
 
             // run session check function if defined
-            $checkFunction = $globalConfig->getValue('session.check_function', null);
+            $checkFunction = $globalConfig->getOptionalValue('session.check_function', null);
             if (is_callable($checkFunction)) {
                 $check = call_user_func($checkFunction, $session);
                 if ($check !== true) {

--- a/lib/SimpleSAML/SessionHandler.php
+++ b/lib/SimpleSAML/SessionHandler.php
@@ -136,7 +136,7 @@ abstract class SessionHandler
     private static function createSessionHandler(): void
     {
         $config = Configuration::getInstance();
-        $storeType = $config->getString('store.type', 'phpsession');
+        $storeType = $config->getOptionalString('store.type', 'phpsession');
 
         $store = StoreFactory::getInstance($storeType);
         if ($store === false) {
@@ -159,10 +159,10 @@ abstract class SessionHandler
 
         return [
             'lifetime' => $config->getInteger('session.cookie.lifetime', 0),
-            'path'     => $config->getString('session.cookie.path', '/'),
-            'domain'   => $config->getString('session.cookie.domain', null),
+            'path'     => $config->getOptionalString('session.cookie.path', '/'),
+            'domain'   => $config->getOptionalString('session.cookie.domain', null),
             'secure'   => $config->getOptionalBoolean('session.cookie.secure', false),
-            'samesite' => $config->getString('session.cookie.samesite', null),
+            'samesite' => $config->getOptionalString('session.cookie.samesite', null),
             'httponly' => true,
         ];
     }

--- a/lib/SimpleSAML/SessionHandler.php
+++ b/lib/SimpleSAML/SessionHandler.php
@@ -158,7 +158,7 @@ abstract class SessionHandler
         $config = Configuration::getInstance();
 
         return [
-            'lifetime' => $config->getInteger('session.cookie.lifetime', 0),
+            'lifetime' => $config->getOptionalInteger('session.cookie.lifetime', 0),
             'path'     => $config->getOptionalString('session.cookie.path', '/'),
             'domain'   => $config->getOptionalString('session.cookie.domain', null),
             'secure'   => $config->getOptionalBoolean('session.cookie.secure', false),

--- a/lib/SimpleSAML/SessionHandler.php
+++ b/lib/SimpleSAML/SessionHandler.php
@@ -161,7 +161,7 @@ abstract class SessionHandler
             'lifetime' => $config->getInteger('session.cookie.lifetime', 0),
             'path'     => $config->getString('session.cookie.path', '/'),
             'domain'   => $config->getString('session.cookie.domain', null),
-            'secure'   => $config->getBoolean('session.cookie.secure', false),
+            'secure'   => $config->getOptionalBoolean('session.cookie.secure', false),
             'samesite' => $config->getString('session.cookie.samesite', null),
             'httponly' => true,
         ];

--- a/lib/SimpleSAML/SessionHandlerCookie.php
+++ b/lib/SimpleSAML/SessionHandlerCookie.php
@@ -45,7 +45,7 @@ abstract class SessionHandlerCookie extends SessionHandler
         parent::__construct();
 
         $config = Configuration::getInstance();
-        $this->cookie_name = $config->getString('session.cookie.name', 'SimpleSAMLSessionID');
+        $this->cookie_name = $config->getOptionalString('session.cookie.name', 'SimpleSAMLSessionID');
     }
 
 

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -287,13 +287,13 @@ class SessionHandlerPHP extends SessionHandler
                 'You cannot set both the session.phpsession.limitedpath and session.cookie.path options.'
             );
         } elseif ($config->hasValue('session.phpsession.limitedpath')) {
-            $ret['path'] = $config->getBoolean(
+            $ret['path'] = $config->getOptionalBoolean(
                 'session.phpsession.limitedpath',
                 false
             ) ? $config->getBasePath() : '/';
         }
 
-        $ret['httponly'] = $config->getBoolean('session.phpsession.httponly', true);
+        $ret['httponly'] = $config->getOptionalBoolean('session.phpsession.httponly', true);
 
         return $ret;
     }

--- a/lib/SimpleSAML/SessionHandlerPHP.php
+++ b/lib/SimpleSAML/SessionHandlerPHP.php
@@ -48,7 +48,7 @@ class SessionHandlerPHP extends SessionHandler
         parent::__construct();
 
         $config = Configuration::getInstance();
-        $this->cookie_name = $config->getString(
+        $this->cookie_name = $config->getOptionalString(
             'session.phpsession.cookiename',
             ini_get('session.name') ?: 'PHPSESSID'
         );
@@ -92,7 +92,7 @@ class SessionHandlerPHP extends SessionHandler
             ]);
         }
 
-        $savepath = $config->getString('session.phpsession.savepath', null);
+        $savepath = $config->getOptionalString('session.phpsession.savepath', null);
         if (!empty($savepath)) {
             session_save_path($savepath);
         }

--- a/lib/SimpleSAML/SessionHandlerStore.php
+++ b/lib/SimpleSAML/SessionHandlerStore.php
@@ -79,7 +79,7 @@ class SessionHandlerStore extends SessionHandlerCookie
         $sessionId = $session->getSessionId();
 
         $config = Configuration::getInstance();
-        $sessionDuration = $config->getInteger('session.duration', 8 * 60 * 60);
+        $sessionDuration = $config->getOptionalInteger('session.duration', 8 * 60 * 60);
         $expire = time() + $sessionDuration;
 
         $this->store->set('session', $sessionId, $session, $expire);

--- a/lib/SimpleSAML/Stats.php
+++ b/lib/SimpleSAML/Stats.php
@@ -56,7 +56,7 @@ class Stats
     private static function initOutputs(): void
     {
         $config = Configuration::getInstance();
-        $outputCfgs = $config->getArray('statistics.out', []);
+        $outputCfgs = $config->getOptionalArray('statistics.out', []);
 
         self::$outputs = [];
         foreach ($outputCfgs as $cfg) {

--- a/lib/SimpleSAML/Store/MemcacheStore.php
+++ b/lib/SimpleSAML/Store/MemcacheStore.php
@@ -29,7 +29,7 @@ class MemcacheStore implements StoreInterface
     public function __construct()
     {
         $config = Configuration::getInstance();
-        $this->prefix = $config->getString('memcache_store.prefix', 'simpleSAMLphp');
+        $this->prefix = $config->getOptionalString('memcache_store.prefix', 'simpleSAMLphp');
     }
 
 

--- a/lib/SimpleSAML/Store/RedisStore.php
+++ b/lib/SimpleSAML/Store/RedisStore.php
@@ -35,10 +35,10 @@ class RedisStore implements StoreInterface
         if ($redis === null) {
             $config = Configuration::getInstance();
 
-            $host = $config->getString('store.redis.host', 'localhost');
+            $host = $config->getOptionalString('store.redis.host', 'localhost');
             $port = $config->getInteger('store.redis.port', 6379);
-            $prefix = $config->getString('store.redis.prefix', 'SimpleSAMLphp');
-            $password = $config->getString('store.redis.password', '');
+            $prefix = $config->getOptionalString('store.redis.prefix', 'SimpleSAMLphp');
+            $password = $config->getOptionalString('store.redis.password', null);
             $database = $config->getInteger('store.redis.database', 0);
 
             $redis = new Client(

--- a/lib/SimpleSAML/Store/RedisStore.php
+++ b/lib/SimpleSAML/Store/RedisStore.php
@@ -36,10 +36,10 @@ class RedisStore implements StoreInterface
             $config = Configuration::getInstance();
 
             $host = $config->getOptionalString('store.redis.host', 'localhost');
-            $port = $config->getInteger('store.redis.port', 6379);
+            $port = $config->getOptionalInteger('store.redis.port', 6379);
             $prefix = $config->getOptionalString('store.redis.prefix', 'SimpleSAMLphp');
             $password = $config->getOptionalString('store.redis.password', null);
-            $database = $config->getInteger('store.redis.database', 0);
+            $database = $config->getOptionalInteger('store.redis.database', 0);
 
             $redis = new Client(
                 [

--- a/lib/SimpleSAML/Store/SQLStore.php
+++ b/lib/SimpleSAML/Store/SQLStore.php
@@ -55,10 +55,10 @@ class SQLStore implements StoreInterface
         $config = Configuration::getInstance();
 
         $dsn = $config->getString('store.sql.dsn');
-        $username = $config->getString('store.sql.username', null);
-        $password = $config->getString('store.sql.password', null);
-        $options = $config->getArray('store.sql.options', null);
-        $this->prefix = $config->getString('store.sql.prefix', 'simpleSAMLphp');
+        $username = $config->getOptionalString('store.sql.username', null);
+        $password = $config->getOptionalString('store.sql.password', null);
+        $options = $config->getOptionalArray('store.sql.options', null);
+        $this->prefix = $config->getOptionalString('store.sql.prefix', 'simpleSAMLphp');
         try {
             $this->pdo = new PDO($dsn, $username, $password, $options);
         } catch (PDOException $e) {

--- a/lib/SimpleSAML/Utils/Config/Metadata.php
+++ b/lib/SimpleSAML/Utils/Config/Metadata.php
@@ -277,11 +277,11 @@ class Metadata
             // handle current configurations specifying an array in the NameIDPolicy config option
             $nameIdPolicy_cf = Configuration::loadFromArray($nameIdPolicy);
             $policy = [
-                'Format'      => $nameIdPolicy_cf->getString('Format', Constants::NAMEID_TRANSIENT),
+                'Format'      => $nameIdPolicy_cf->getOptionalString('Format', Constants::NAMEID_TRANSIENT),
                 'AllowCreate' => $nameIdPolicy_cf->getOptionalBoolean('AllowCreate', true),
             ];
-            $spNameQualifier = $nameIdPolicy_cf->getString('SPNameQualifier', false);
-            if ($spNameQualifier !== false) {
+            $spNameQualifier = $nameIdPolicy_cf->getOptionalString('SPNameQualifier', null);
+            if ($spNameQualifier !== null) {
                 $policy['SPNameQualifier'] = $spNameQualifier;
             }
         } elseif ($nameIdPolicy === null) {

--- a/lib/SimpleSAML/Utils/Config/Metadata.php
+++ b/lib/SimpleSAML/Utils/Config/Metadata.php
@@ -278,7 +278,7 @@ class Metadata
             $nameIdPolicy_cf = Configuration::loadFromArray($nameIdPolicy);
             $policy = [
                 'Format'      => $nameIdPolicy_cf->getString('Format', Constants::NAMEID_TRANSIENT),
-                'AllowCreate' => $nameIdPolicy_cf->getBoolean('AllowCreate', true),
+                'AllowCreate' => $nameIdPolicy_cf->getOptionalBoolean('AllowCreate', true),
             ];
             $spNameQualifier = $nameIdPolicy_cf->getString('SPNameQualifier', false);
             if ($spNameQualifier !== false) {

--- a/lib/SimpleSAML/Utils/Crypto.php
+++ b/lib/SimpleSAML/Utils/Crypto.php
@@ -203,7 +203,7 @@ class Crypto
         string $prefix = '',
         bool $full_path = false
     ): ?array {
-        $file = $metadata->getString($prefix . 'privatekey', null);
+        $file = $metadata->getOptionalString($prefix . 'privatekey', null);
         if ($file === null) {
             // no private key found
             if ($required) {
@@ -225,7 +225,7 @@ class Crypto
 
         $ret = [
             'PEM' => $data,
-            'password' => $metadata->getString($prefix . 'privatekey_pass', null),
+            'password' => $metadata->getOptionalString($prefix . 'privatekey_pass', null),
         ];
 
         return $ret;

--- a/lib/SimpleSAML/Utils/EMail.php
+++ b/lib/SimpleSAML/Utils/EMail.php
@@ -65,7 +65,7 @@ class EMail
     public function getDefaultMailAddress(): string
     {
         $config = Configuration::getInstance();
-        $address = $config->getString('technicalcontact_email', 'na@example.org');
+        $address = $config->getOptionalString('technicalcontact_email', 'na@example.org');
         $address = preg_replace('/^mailto:/i', '', $address);
         if ('na@example.org' === $address) {
             throw new \Exception('technicalcontact_email must be changed from the default value');
@@ -228,7 +228,7 @@ class EMail
     {
         $config = Configuration::getInstance();
         $EMail->setTransportMethod(
-            $config->getString('mail.transport.method', 'mail'),
+            $config->getOptionalString('mail.transport.method', 'mail'),
             $config->getArrayize('mail.transport.options', [])
         );
 

--- a/lib/SimpleSAML/Utils/EMail.php
+++ b/lib/SimpleSAML/Utils/EMail.php
@@ -229,7 +229,7 @@ class EMail
         $config = Configuration::getInstance();
         $EMail->setTransportMethod(
             $config->getOptionalString('mail.transport.method', 'mail'),
-            $config->getArrayize('mail.transport.options', [])
+            $config->getOptionalArrayize('mail.transport.options', [])
         );
 
         return $EMail;

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -375,7 +375,7 @@ class HTTP
 
         // get the white list of domains
         if ($trustedSites === null) {
-            $trustedSites = Configuration::getInstance()->getValue('trusted.url.domains', []);
+            $trustedSites = Configuration::getInstance()->getOptionalArray('trusted.url.domains', []);
         }
 
         // validates the URL's host is among those allowed

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -804,8 +804,8 @@ class HTTP
              */
 
             /** @var \SimpleSAML\Configuration $appcfg */
-            $appcfg = $cfg->getConfigItem('application');
-            $appurl = $appcfg->getOptionalString('baseURL', null);
+            $appcfg = $cfg->getOptionalConfigItem('application', null);
+            $appurl = $appcfg ?: $appcfg->getOptionalString('baseURL', null);
             if (!empty($appurl)) {
                 $protocol = parse_url($appurl, PHP_URL_SCHEME);
                 $hostname = parse_url($appurl, PHP_URL_HOST);

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -406,10 +406,10 @@ class HTTP
 
             $self_host = $this->getSelfHostWithNonStandardPort();
 
-            $trustedRegex = Configuration::getInstance()->getValue('trusted.url.regex', false);
+            $trustedRegex = Configuration::getInstance()->getOptionalString('trusted.url.regex', null);
 
             $trusted = false;
-            if ($trustedRegex) {
+            if ($trustedRegex !== null) {
                 // add self host to the white list
                 $trustedSites[] = preg_quote($self_host);
                 foreach ($trustedSites as $regex) {
@@ -455,13 +455,13 @@ class HTTP
     {
         $config = Configuration::getInstance();
 
-        $proxy = $config->getString('proxy', null);
+        $proxy = $config->getOptionalString('proxy', null);
         if ($proxy !== null) {
             if (!isset($context['http']['proxy'])) {
                 $context['http']['proxy'] = $proxy;
             }
-            $proxy_auth = $config->getString('proxy.auth', false);
-            if ($proxy_auth !== false) {
+            $proxy_auth = $config->getOptionalString('proxy.auth', null);
+            if ($proxy_auth !== null) {
                 $context['http']['header'] = "Proxy-Authorization: Basic " . base64_encode($proxy_auth);
             }
             if (!isset($context['http']['request_fulluri'])) {
@@ -638,7 +638,7 @@ class HTTP
     public function getBaseURL(): string
     {
         $globalConfig = Configuration::getInstance();
-        $baseURL = $globalConfig->getString('baseurlpath', 'simplesaml/');
+        $baseURL = $globalConfig->getOptionalString('baseurlpath', 'simplesaml/');
 
         if (preg_match('#^https?://.*/?$#D', $baseURL, $matches)) {
             // full URL in baseurlpath, override local server values
@@ -805,7 +805,7 @@ class HTTP
 
             /** @var \SimpleSAML\Configuration $appcfg */
             $appcfg = $cfg->getConfigItem('application');
-            $appurl = $appcfg->getString('baseURL', '');
+            $appurl = $appcfg->getOptionalString('baseURL', null);
             if (!empty($appurl)) {
                 $protocol = parse_url($appurl, PHP_URL_SCHEME);
                 $hostname = parse_url($appurl, PHP_URL_HOST);

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -688,7 +688,7 @@ class HTTP
     public function getPOSTRedirectURL(string $destination, array $data): string
     {
         $config = Configuration::getInstance();
-        $allowed = $config->getBoolean('enable.http_post', false);
+        $allowed = $config->getOptionalBoolean('enable.http_post', false);
 
         if ($allowed && preg_match("#^http:#", $destination) && $this->isHTTPS()) {
             // we need to post the data to HTTP
@@ -1181,7 +1181,7 @@ class HTTP
         }
 
         $config = Configuration::getInstance();
-        $allowed = $config->getBoolean('enable.http_post', false);
+        $allowed = $config->getOptionalBoolean('enable.http_post', false);
 
         if ($allowed && preg_match("#^http:#", $destination) && $this->isHTTPS()) {
             // we need to post the data to HTTP

--- a/lib/SimpleSAML/Utils/HTTP.php
+++ b/lib/SimpleSAML/Utils/HTTP.php
@@ -406,10 +406,10 @@ class HTTP
 
             $self_host = $this->getSelfHostWithNonStandardPort();
 
-            $trustedRegex = Configuration::getInstance()->getOptionalString('trusted.url.regex', null);
+            $trustedRegex = Configuration::getInstance()->getOptionalValue('trusted.url.regex', null);
 
             $trusted = false;
-            if ($trustedRegex !== null) {
+            if (!in_array($trustedRegex, [null, false])) {
                 // add self host to the white list
                 $trustedSites[] = preg_quote($self_host);
                 foreach ($trustedSites as $regex) {
@@ -802,10 +802,9 @@ class HTTP
              * current URI, so we need to build it back from the PHP environment, unless we have a base URL specified
              * for this case in the configuration. First, check if that's the case.
              */
-
-            /** @var \SimpleSAML\Configuration $appcfg */
             $appcfg = $cfg->getOptionalConfigItem('application', null);
-            $appurl = $appcfg ?: $appcfg->getOptionalString('baseURL', null);
+            $appurl = ($appcfg !== null) ? $appcfg->getOptionalString('baseURL', null) : null;
+
             if (!empty($appurl)) {
                 $protocol = parse_url($appurl, PHP_URL_SCHEME);
                 $hostname = parse_url($appurl, PHP_URL_HOST);

--- a/lib/SimpleSAML/Utils/System.php
+++ b/lib/SimpleSAML/Utils/System.php
@@ -75,7 +75,7 @@ class System
         $globalConfig = Configuration::getInstance();
 
         $tempDir = rtrim(
-            $globalConfig->getString(
+            $globalConfig->getOptionalString(
                 'tempdir',
                 sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'simplesaml'
             ),

--- a/lib/SimpleSAML/Utils/Time.php
+++ b/lib/SimpleSAML/Utils/Time.php
@@ -56,7 +56,7 @@ class Time
 
         $globalConfig = Configuration::getInstance();
 
-        $timezone = $globalConfig->getString('timezone', null);
+        $timezone = $globalConfig->getOptionalString('timezone', null);
         if ($timezone !== null) {
             if (!date_default_timezone_set($timezone)) {
                 throw new Error\Exception('Invalid timezone set in the "timezone" option in config.php.');

--- a/lib/SimpleSAML/Utils/XML.php
+++ b/lib/SimpleSAML/Utils/XML.php
@@ -52,7 +52,7 @@ class XML
         }
 
         // see if debugging is enabled for XML validation
-        $debug = Configuration::getInstance()->getArray('debug', ['validatexml' => false]);
+        $debug = Configuration::getInstance()->getOptionalArray('debug', ['validatexml' => false]);
 
         if (
             !(
@@ -100,7 +100,7 @@ class XML
         }
 
         // see if debugging is enabled for SAML messages
-        $debug = Configuration::getInstance()->getArray('debug', ['saml' => false]);
+        $debug = Configuration::getInstance()->getOptionalArray('debug', ['saml' => false]);
 
         if (
             !(

--- a/lib/SimpleSAML/XHTML/IdPDisco.php
+++ b/lib/SimpleSAML/XHTML/IdPDisco.php
@@ -513,7 +513,7 @@ class IdPDisco
         $httpUtils = new Utils\HTTP();
         $idp = $this->getTargetIdP();
         if ($idp !== null) {
-            $extDiscoveryStorage = $this->config->getString('idpdisco.extDiscoveryStorage', null);
+            $extDiscoveryStorage = $this->config->getOptionalString('idpdisco.extDiscoveryStorage', null);
             if ($extDiscoveryStorage !== null) {
                 $this->log('Choice made [' . $idp . '] (Forwarding to external discovery storage)');
                 $httpUtils->redirectTrustedURL($extDiscoveryStorage, [
@@ -576,7 +576,7 @@ class IdPDisco
          * Make use of an XHTML template to present the select IdP choice to the user. Currently the supported options
          * is either a drop down menu or a list view.
          */
-        switch ($this->config->getString('idpdisco.layout', 'links')) {
+        switch ($this->config->getOptionalString('idpdisco.layout', 'links')) {
             case 'dropdown':
                 $templateFile = 'selectidp-dropdown.twig';
                 break;

--- a/lib/SimpleSAML/XHTML/IdPDisco.php
+++ b/lib/SimpleSAML/XHTML/IdPDisco.php
@@ -243,7 +243,7 @@ class IdPDisco
             return null;
         }
 
-        if (!$this->config->getBoolean('idpdisco.validate', true)) {
+        if (!$this->config->getOptionalBoolean('idpdisco.validate', true)) {
             return $idp;
         }
 
@@ -308,7 +308,7 @@ class IdPDisco
      */
     protected function getSavedIdP(): ?string
     {
-        if (!$this->config->getBoolean('idpdisco.enableremember', false)) {
+        if (!$this->config->getOptionalBoolean('idpdisco.enableremember', false)) {
             // saving of IdP choices is disabled
             return null;
         }
@@ -402,7 +402,7 @@ class IdPDisco
      */
     protected function saveIdP(): bool
     {
-        if (!$this->config->getBoolean('idpdisco.enableremember', false)) {
+        if (!$this->config->getOptionalBoolean('idpdisco.enableremember', false)) {
             // saving of IdP choices is disabled
             return false;
         }
@@ -618,8 +618,8 @@ class IdPDisco
         $t->data['returnIDParam'] = $this->returnIdParam;
         $t->data['entityID'] = $this->spEntityId;
         $t->data['urlpattern'] = htmlspecialchars($httpUtils->getSelfURLNoQuery());
-        $t->data['rememberenabled'] = $this->config->getBoolean('idpdisco.enableremember', false);
-        $t->data['rememberchecked'] = $this->config->getBoolean('idpdisco.rememberchecked', false);
+        $t->data['rememberenabled'] = $this->config->getOptionalBoolean('idpdisco.enableremember', false);
+        $t->data['rememberchecked'] = $this->config->getOptionalBoolean('idpdisco.rememberchecked', false);
         $t->send();
     }
 }

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -129,7 +129,7 @@ class Template extends Response
 
         // parse config to find theme and module theme is in, if any
         list($this->theme['module'], $this->theme['name']) = $this->findModuleAndTemplateName(
-            $this->configuration->getString('theme.use', 'default')
+            $this->configuration->getOptionalString('theme.use', 'default')
         );
 
         // initialize internationalization system
@@ -137,9 +137,9 @@ class Template extends Response
         $this->localization = new Localization($configuration);
 
         // check if we need to attach a theme controller
-        $controller = $this->configuration->getString('theme.controller', false);
+        $controller = $this->configuration->getOptionalString('theme.controller', null);
         if (
-            $controller
+            $controller !== null
             && class_exists($controller)
             && in_array(TemplateControllerInterface::class, class_implements($controller))
         ) {
@@ -266,7 +266,7 @@ class Template extends Response
     private function setupTwig(): Environment
     {
         $auto_reload = $this->configuration->getOptionalBoolean('template.auto_reload', true);
-        $cache = $this->configuration->getString('template.cache', false);
+        $cache = $this->configuration->getOptionalString('template.cache', null);
 
         // set up template paths
         $loader = $this->setupTwigTemplatepaths();
@@ -287,7 +287,7 @@ class Template extends Response
         // set up translation
         $options = [
             'auto_reload' => $auto_reload,
-            'cache' => $cache,
+            'cache' => $cache ?? false,
             'strict_variables' => true,
         ];
 
@@ -299,7 +299,7 @@ class Template extends Response
         $twig->addFunction(new TwigFunction('moduleURL', [Module::class, 'getModuleURL']));
 
         // initialize some basic context
-        $langParam = $this->configuration->getString('language.parameter.name', 'language');
+        $langParam = $this->configuration->getOptionalString('language.parameter.name', 'language');
         $twig->addGlobal('languageParameterName', $langParam);
         $twig->addGlobal('currentLanguage', $this->translator->getLanguage()->getLanguage());
         $twig->addGlobal('isRTL', false); // language RTL configuration
@@ -488,7 +488,7 @@ class Template extends Response
 
         $this->data['year'] = date('Y');
 
-        $this->data['header'] = $this->configuration->getValue('theme.header', 'SimpleSAMLphp');
+        $this->data['header'] = $this->configuration->getOptionalString('theme.header', 'SimpleSAMLphp');
     }
 
     /**

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -265,7 +265,7 @@ class Template extends Response
      */
     private function setupTwig(): Environment
     {
-        $auto_reload = $this->configuration->getBoolean('template.auto_reload', true);
+        $auto_reload = $this->configuration->getOptionalBoolean('template.auto_reload', true);
         $cache = $this->configuration->getString('template.cache', false);
 
         // set up template paths
@@ -312,7 +312,7 @@ class Template extends Response
         }
         $twig->addGlobal('queryParams', $queryParams);
         $twig->addGlobal('templateId', str_replace('.twig', '', $this->normalizeTemplateName($this->template)));
-        $twig->addGlobal('isProduction', $this->configuration->getBoolean('production', true));
+        $twig->addGlobal('isProduction', $this->configuration->getOptionalBoolean('production', true));
         $twig->addGlobal('baseurlpath', ltrim($this->configuration->getBasePath(), '/'));
 
         // add a filter for translations out of arrays

--- a/modules/admin/lib/Controller/Config.php
+++ b/modules/admin/lib/Controller/Config.php
@@ -442,7 +442,7 @@ class Config
         }
 
         // make sure we have a secret salt set
-        if ($this->config->getValue('secretsalt') === 'defaultsecretsalt') {
+        if ($this->config->getString('secretsalt') === 'defaultsecretsalt') {
             $warnings[] = Translate::noop(
                 '<strong>The configuration uses the default secret salt</strong>. Make sure to modify the <code>' .
                 'secretsalt</code> option in the SimpleSAMLphp configuration in production environments. <a ' .
@@ -469,7 +469,7 @@ class Config
                     curl_setopt($ch, CURLOPT_USERAGENT, 'SimpleSAMLphp');
                     curl_setopt($ch, CURLOPT_TIMEOUT, 2);
                     curl_setopt($ch, CURLOPT_PROXY, $this->config->getOptionalString('proxy', null));
-                    curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->config->getValue('proxy.auth', null));
+                    curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->config->getOptionalValue('proxy.auth', null));
                     $response = curl_exec($ch);
 
                     if (curl_getinfo($ch, CURLINFO_RESPONSE_CODE) === 200) {

--- a/modules/admin/lib/Controller/Config.php
+++ b/modules/admin/lib/Controller/Config.php
@@ -132,7 +132,7 @@ class Config
                 ]
             ],
             'enablematrix' => [
-                'saml20idp' => $this->config->getBoolean('enable.saml20-idp', false),
+                'saml20idp' => $this->config->getOptionalBoolean('enable.saml20-idp', false),
             ],
             'funcmatrix' => $this->getPrerequisiteChecks(),
             'logouturl' => $this->authUtils->getAdminLogoutURL(),
@@ -267,7 +267,7 @@ class Config
                 ]
             ],
             'curl_init' => [
-                'required' => $this->config->getBoolean('admin.checkforupdates', true) ? 'required' : 'optional',
+                'required' => $this->config->getOptionalBoolean('admin.checkforupdates', true) ? 'required' : 'optional',
                 'descr' => [
                     'optional' => Translate::noop(
                         'cURL (might be required by some modules)'
@@ -366,7 +366,7 @@ class Config
         $cryptoUtils = new Utils\Crypto();
 
         // perform some sanity checks on the configured certificates
-        if ($this->config->getBoolean('enable.saml20-idp', false) !== false) {
+        if ($this->config->getOptionalBoolean('enable.saml20-idp', false) !== false) {
             $handler = MetaDataStorageHandler::getMetadataHandler();
             try {
                 $metadata = $handler->getMetaDataCurrent('saml20-idp-hosted');
@@ -401,7 +401,7 @@ class Config
             }
         }
 
-        if ($this->config->getBoolean('metadata.sign.enable', false) !== false) {
+        if ($this->config->getOptionalBoolean('metadata.sign.enable', false) !== false) {
             $private = $cryptoUtils->loadPrivateKey($this->config, false, 'metadata.sign.');
             $public = $cryptoUtils->loadPublicKey($this->config, false, 'metadata.sign.');
             $matrix[] = [
@@ -455,7 +455,7 @@ class Config
          * Check for updates. Store the remote result in the session so we don't need to fetch it on every access to
          * this page.
          */
-        if ($this->config->getBoolean('admin.checkforupdates', true) && $this->config->getVersion() !== 'master') {
+        if ($this->config->getOptionalBoolean('admin.checkforupdates', true) && $this->config->getVersion() !== 'master') {
             if (!function_exists('curl_init')) {
                 $warnings[] = Translate::noop(
                     'The cURL PHP extension is missing. Cannot check for SimpleSAMLphp updates.'

--- a/modules/admin/lib/Controller/Config.php
+++ b/modules/admin/lib/Controller/Config.php
@@ -202,7 +202,7 @@ class Config
                 'enabled' => version_compare(phpversion(), '7.4', '>=')
             ]
         ];
-        $store = $this->config->getString('store.type', '');
+        $store = $this->config->getOptionalString('store.type', null);
 
         // check dependencies used via normal functions
         $functions = [
@@ -354,13 +354,13 @@ class Config
         $matrix[] = [
             'required' => 'optional',
             'descr' => Translate::noop('The <code>technicalcontact_email</code> configuration option should be set'),
-            'enabled' => $this->config->getString('technicalcontact_email', 'na@example.org') !== 'na@example.org',
+            'enabled' => $this->config->getOptionalString('technicalcontact_email', 'na@example.org') !== 'na@example.org',
         ];
 
         $matrix[] = [
             'required' => 'required',
             'descr' => Translate::noop('The auth.adminpassword configuration option must be set'),
-            'enabled' => $this->config->getString('auth.adminpassword', '123') !== '123',
+            'enabled' => $this->config->getOptionalString('auth.adminpassword', '123') !== '123',
         ];
 
         $cryptoUtils = new Utils\Crypto();
@@ -468,7 +468,7 @@ class Config
                     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                     curl_setopt($ch, CURLOPT_USERAGENT, 'SimpleSAMLphp');
                     curl_setopt($ch, CURLOPT_TIMEOUT, 2);
-                    curl_setopt($ch, CURLOPT_PROXY, $this->config->getString('proxy', null));
+                    curl_setopt($ch, CURLOPT_PROXY, $this->config->getOptionalString('proxy', null));
                     curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->config->getValue('proxy.auth', null));
                     $response = curl_exec($ch);
 

--- a/modules/admin/lib/Controller/Federation.php
+++ b/modules/admin/lib/Controller/Federation.php
@@ -123,9 +123,9 @@ class Federation
             'remote' => [
                 'saml20-idp-remote' => !empty($hostedSPs)
                     ? $this->mdHandler->getList('saml20-idp-remote', true) : [],
-                'saml20-sp-remote' => $this->config->getBoolean('enable.saml20-idp', false) === true
+                'saml20-sp-remote' => $this->config->getOptionalBoolean('enable.saml20-idp', false) === true
                     ? $this->mdHandler->getList('saml20-sp-remote', true) : [],
-                'adfs-sp-remote' => ($this->config->getBoolean('enable.adfs-idp', false) === true) &&
+                'adfs-sp-remote' => ($this->config->getOptionalBoolean('enable.adfs-idp', false) === true) &&
                     Module::isModuleEnabled('adfs') ? $this->mdHandler->getList('adfs-sp-remote', true) : [],
             ],
         ];
@@ -190,7 +190,7 @@ class Federation
         $entities = [];
 
         // SAML 2
-        if ($this->config->getBoolean('enable.saml20-idp', false)) {
+        if ($this->config->getOptionalBoolean('enable.saml20-idp', false)) {
             try {
                 $idps = $this->mdHandler->getList('saml20-idp-hosted');
                 $saml2entities = [];
@@ -230,7 +230,7 @@ class Federation
         }
 
         // ADFS
-        if ($this->config->getBoolean('enable.adfs-idp', false) && Module::isModuleEnabled('adfs')) {
+        if ($this->config->getOptionalBoolean('enable.adfs-idp', false) && Module::isModuleEnabled('adfs')) {
             try {
                 $idps = $this->mdHandler->getList('adfs-idp-hosted');
                 $adfsentities = [];

--- a/modules/admin/lib/Controller/Federation.php
+++ b/modules/admin/lib/Controller/Federation.php
@@ -329,9 +329,9 @@ class Federation
             }
 
             // get the name
-            $name = $source->getMetadata()->getLocalizedString(
+            $name = $source->getMetadata()->getOptionalLocalizedString(
                 'name',
-                $source->getMetadata()->getLocalizedString('OrganizationDisplayName', $source->getAuthId())
+                $source->getMetadata()->getOptionalLocalizedString('OrganizationDisplayName', ['en' => $source->getAuthId()])
             );
 
             $builder = new SAMLBuilder($source->getEntityId());

--- a/modules/core/hooks/hook_sanitycheck.php
+++ b/modules/core/hooks/hook_sanitycheck.php
@@ -18,13 +18,13 @@ function core_hook_sanitycheck(array &$hookinfo): void
 
     $config = Configuration::getInstance();
 
-    if ($config->getString('auth.adminpassword', '123') === '123') {
+    if ($config->getOptionalString('auth.adminpassword', '123') === '123') {
         $hookinfo['errors'][] = '[core] Password in config.php is not set properly';
     } else {
         $hookinfo['info'][] = '[core] Password in config.php is set properly';
     }
 
-    if ($config->getString('technicalcontact_email', 'na@example.org') === 'na@example.org') {
+    if ($config->getOptionalString('technicalcontact_email', 'na@example.org') === 'na@example.org') {
         $hookinfo['errors'][] = '[core] In config.php technicalcontact_email is not set properly';
     } else {
         $hookinfo['info'][] = '[core] In config.php technicalcontact_email is set properly';

--- a/modules/core/lib/Auth/Process/ExtendIdPSession.php
+++ b/modules/core/lib/Auth/Process/ExtendIdPSession.php
@@ -46,7 +46,7 @@ class ExtendIdPSession extends Auth\ProcessingFilter
         if (
             !empty($state['RememberMe'])
             && $rememberMeExpire !== null
-            && $globalConfig->getBoolean('session.rememberme.enable', false)
+            && $globalConfig->getOptionalBoolean('session.rememberme.enable', false)
         ) {
             $session->setRememberMeExpire();
             return;

--- a/modules/core/lib/Auth/Process/ExtendIdPSession.php
+++ b/modules/core/lib/Auth/Process/ExtendIdPSession.php
@@ -28,7 +28,7 @@ class ExtendIdPSession extends Auth\ProcessingFilter
         $delta = $state['Expire'] - $now;
 
         $globalConfig = Configuration::getInstance();
-        $sessionDuration = $globalConfig->getInteger('session.duration', 28800); // 8*60*60
+        $sessionDuration = $globalConfig->getOptionalInteger('session.duration', 28800); // 8*60*60
 
         // Extend only if half of session duration already passed
         if ($delta >= ($sessionDuration * 0.5)) {

--- a/modules/core/lib/Auth/Process/ScopeAttribute.php
+++ b/modules/core/lib/Auth/Process/ScopeAttribute.php
@@ -60,7 +60,7 @@ class ScopeAttribute extends Auth\ProcessingFilter
         $this->scopeAttribute = $cfg->getString('scopeAttribute');
         $this->sourceAttribute = $cfg->getString('sourceAttribute');
         $this->targetAttribute = $cfg->getString('targetAttribute');
-        $this->onlyIfEmpty = $cfg->getBoolean('onlyIfEmpty', false);
+        $this->onlyIfEmpty = $cfg->getOptionalBoolean('onlyIfEmpty', false);
     }
 
 

--- a/modules/core/lib/Auth/Source/AdminPassword.php
+++ b/modules/core/lib/Auth/Source/AdminPassword.php
@@ -50,7 +50,7 @@ class AdminPassword extends UserPassBase
     protected function login(string $username, string $password): array
     {
         $config = Configuration::getInstance();
-        $adminPassword = $config->getString('auth.adminpassword', '123');
+        $adminPassword = $config->getOptionalString('auth.adminpassword', '123');
         if ($adminPassword === '123') {
             // We require that the user changes the password
             throw new Error\Error('NOTSET');

--- a/modules/core/lib/Auth/UserPassBase.php
+++ b/modules/core/lib/Auth/UserPassBase.php
@@ -120,8 +120,8 @@ abstract class UserPassBase extends Auth\Source
 
         // get the "remember me" config options
         $sspcnf = Configuration::getInstance();
-        $this->rememberMeEnabled = $sspcnf->getBoolean('session.rememberme.enable', false);
-        $this->rememberMeChecked = $sspcnf->getBoolean('session.rememberme.checked', false);
+        $this->rememberMeEnabled = $sspcnf->getOptionalBoolean('session.rememberme.enable', false);
+        $this->rememberMeChecked = $sspcnf->getOptionalBoolean('session.rememberme.checked', false);
     }
 
 

--- a/modules/core/lib/Stats/Output/Log.php
+++ b/modules/core/lib/Stats/Output/Log.php
@@ -29,7 +29,7 @@ class Log extends \SimpleSAML\Stats\Output
      */
     public function __construct(Configuration $config)
     {
-        $logLevel = $config->getString('level', 'notice');
+        $logLevel = $config->getOptionalString('level', 'notice');
         $this->logger = [Logger::class, $logLevel];
         if (!is_callable($this->logger)) {
             throw new \Exception('Invalid log level: ' . var_export($logLevel, true));

--- a/modules/core/www/idp/logout-iframe-post.php
+++ b/modules/core/www/idp/logout-iframe-post.php
@@ -36,9 +36,9 @@ if ($assertionLifetime === null) {
 }
 $lr->setNotOnOrAfter(time() + $assertionLifetime);
 
-$encryptNameId = $spMetadata->getBoolean('nameid.encryption', null);
+$encryptNameId = $spMetadata->getOptionalBoolean('nameid.encryption', null);
 if ($encryptNameId === null) {
-    $encryptNameId = $idpMetadata->getBoolean('nameid.encryption', false);
+    $encryptNameId = $idpMetadata->getOptionalBoolean('nameid.encryption', false);
 }
 if ($encryptNameId) {
     $lr->encryptNameId(\SimpleSAML\Module\saml\Message::getEncryptionKey($spMetadata));

--- a/modules/core/www/idp/logout-iframe-post.php
+++ b/modules/core/www/idp/logout-iframe-post.php
@@ -30,9 +30,9 @@ $lr = \SimpleSAML\Module\saml\Message::buildLogoutRequest($idpMetadata, $spMetad
 $lr->setSessionIndex($association['saml:SessionIndex']);
 $lr->setNameId($association['saml:NameID']);
 
-$assertionLifetime = $spMetadata->getInteger('assertion.lifetime', null);
+$assertionLifetime = $spMetadata->getOptionalInteger('assertion.lifetime', null);
 if ($assertionLifetime === null) {
-    $assertionLifetime = $idpMetadata->getInteger('assertion.lifetime', 300);
+    $assertionLifetime = $idpMetadata->getOptionalInteger('assertion.lifetime', 300);
 }
 $lr->setNotOnOrAfter(time() + $assertionLifetime);
 

--- a/modules/cron/hooks/hook_cron.php
+++ b/modules/cron/hooks/hook_cron.php
@@ -15,7 +15,7 @@ function cron_hook_cron(array &$croninfo): void
 
     $cronconfig = Configuration::getConfig('module_cron.php');
 
-    if ($cronconfig->getValue('debug_message', true)) {
+    if ($cronconfig->getOptionalBoolean('debug_message', true)) {
         $croninfo['summary'][] = 'Cron did run tag [' . $croninfo['tag'] . '] at ' . date(DATE_RFC822);
     }
 }

--- a/modules/cron/lib/Controller/Cron.php
+++ b/modules/cron/lib/Controller/Cron.php
@@ -85,8 +85,8 @@ class Cron
     {
         $this->authUtils->requireAdmin();
 
-        $key = $this->cronconfig->getValue('key', 'secret');
-        $tags = $this->cronconfig->getValue('allowed_tags', []);
+        $key = $this->cronconfig->getOptionalString('key', 'secret');
+        $tags = $this->cronconfig->getOptionalArray('allowed_tags', []);
 
         $def = [
             'weekly' => "22 0 * * 0",
@@ -127,7 +127,7 @@ class Cron
      */
     public function run(string $tag, string $key, string $output = 'xhtml'): Response
     {
-        $configKey = $this->cronconfig->getValue('key', 'secret');
+        $configKey = $this->cronconfig->getOptionalString('key', 'secret');
         if ($key !== $configKey) {
             Logger::error('Cron - Wrong key provided. Cron will not run.');
             exit;
@@ -146,7 +146,7 @@ class Cron
         $croninfo = $cron->runTag($tag);
         $summary = $croninfo['summary'];
 
-        if ($this->cronconfig->getValue('sendemail', true) && count($summary) > 0) {
+        if ($this->cronconfig->getOptionalBoolean('sendemail', true) && count($summary) > 0) {
             $mail = new Utils\EMail('SimpleSAMLphp cron report');
             $mail->setData(['url' => $url, 'tag' => $croninfo['tag'], 'summary' => $croninfo['summary']]);
             try {

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -80,7 +80,7 @@ class MultiAuth extends Auth\Source
         }
 
         $globalConfiguration = Configuration::getInstance();
-        $defaultLanguage = $globalConfiguration->getString('language.default', 'en');
+        $defaultLanguage = $globalConfiguration->getOptionalString('language.default', 'en');
         $authsources = Configuration::getConfig('authsources.php');
         $this->sources = [];
 

--- a/modules/multiauth/lib/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/lib/Auth/Source/MultiAuth.php
@@ -108,7 +108,7 @@ class MultiAuth extends Auth\Source
                 $css_class = $info['css-class'];
             } else {
                 // Use the authtype as the css class
-                $authconfig = $authsources->getArray($source, null);
+                $authconfig = $authsources->getOptionalArray($source, null);
                 if (!array_key_exists(0, $authconfig) || !is_string($authconfig[0])) {
                     $css_class = "";
                 } else {

--- a/modules/multiauth/lib/Controller/DiscoController.php
+++ b/modules/multiauth/lib/Controller/DiscoController.php
@@ -129,7 +129,7 @@ class DiscoController
 
         $t = new Template($this->config, 'multiauth:selectsource.twig');
 
-        $defaultLanguage = $this->config->getString('language.default', 'en');
+        $defaultLanguage = $this->config->getOptionalString('language.default', 'en');
         $language = $t->getTranslator()->getLanguage()->getLanguage();
 
         $sources = $state[MultiAuth::SOURCESID];

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -94,8 +94,8 @@ class SP extends \SimpleSAML\Auth\Source
             'authsources[' . var_export($this->authId, true) . ']'
         );
         $this->entityId = $this->metadata->getString('entityID');
-        $this->idp = $this->metadata->getString('idp', null);
-        $this->discoURL = $this->metadata->getString('discoURL', null);
+        $this->idp = $this->metadata->getOptionalString('idp', null);
+        $this->discoURL = $this->metadata->getOptionalString('discoURL', null);
         $this->disable_scoping = $this->metadata->getOptionalBoolean('disable_scoping', false);
     }
 
@@ -141,7 +141,7 @@ class SP extends \SimpleSAML\Auth\Source
         if ($this->metadata->hasValue('NameIDPolicy')) {
             $format = $this->metadata->getValue('NameIDPolicy');
             if (is_array($format)) {
-                $metadata['NameIDFormat'] = Configuration::loadFromArray($format)->getString(
+                $metadata['NameIDFormat'] = Configuration::loadFromArray($format)->getOptionalString(
                     'Format',
                     Constants::NAMEID_TRANSIENT
                 );
@@ -196,11 +196,11 @@ class SP extends \SimpleSAML\Auth\Source
 
         // add technical contact
         $globalConfig = Configuration::getInstance();
-        $email = $globalConfig->getString('technicalcontact_email', 'na@example.org');
-        if ($email && $email !== 'na@example.org') {
+        $email = $globalConfig->getOptionalString('technicalcontact_email', 'na@example.org');
+        if (!empty($email) && $email !== 'na@example.org') {
             $contact = [
                 'emailAddress' => $email,
-                'givenName' => $globalConfig->getString('technicalcontact_name', null),
+                'givenName' => $globalConfig->getOptionalString('technicalcontact_name', null),
                 'contactType' => 'technical',
             ];
             $metadata['contacts'][] = Utils\Config\Metadata::getContact($contact);
@@ -339,7 +339,7 @@ class SP extends \SimpleSAML\Auth\Source
             Constants::BINDING_HTTP_POST,
             Constants::BINDING_HTTP_ARTIFACT,
         ];
-        if ($this->metadata->getString('ProtocolBinding', '') === Constants::BINDING_HOK_SSO) {
+        if ($this->metadata->getOptionalString('ProtocolBinding', null) === Constants::BINDING_HOK_SSO) {
             $default[] = Constants::BINDING_HOK_SSO;
         }
 
@@ -387,7 +387,7 @@ class SP extends \SimpleSAML\Auth\Source
     private function getSLOEndpoints(): array
     {
         $config = Configuration::getInstance();
-        $storeType = $config->getString('store.type', 'phpsession');
+        $storeType = $config->getOptionalString('store.type', 'phpsession');
 
         $store = StoreFactory::getInstance($storeType);
         $bindings = $this->metadata->getOptionalArray(
@@ -398,7 +398,7 @@ class SP extends \SimpleSAML\Auth\Source
             ]
         );
         $defaultLocation = Module::getModuleURL('saml/sp/saml2-logout.php/' . $this->getAuthId());
-        $location = $this->metadata->getString('SingleLogoutServiceLocation', $defaultLocation);
+        $location = $this->metadata->getOptionalString('SingleLogoutServiceLocation', $defaultLocation);
 
         $endpoints = [];
         foreach ($bindings as $binding) {
@@ -441,7 +441,7 @@ class SP extends \SimpleSAML\Auth\Source
         $arrayUtils = new Utils\Arrays();
 
         $accr = null;
-        if ($idpMetadata->getString('AuthnContextClassRef', false)) {
+        if ($idpMetadata->getOptionalString('AuthnContextClassRef', null) !== null) {
             $accr = $arrayUtils->arrayize($idpMetadata->getString('AuthnContextClassRef'));
         } elseif (isset($state['saml:AuthnContextClassRef'])) {
             $accr = $arrayUtils->arrayize($state['saml:AuthnContextClassRef']);
@@ -449,7 +449,7 @@ class SP extends \SimpleSAML\Auth\Source
 
         if ($accr !== null) {
             $comp = Constants::COMPARISON_EXACT;
-            if ($idpMetadata->getString('AuthnContextComparison', false)) {
+            if ($idpMetadata->getOptionalString('AuthnContextComparison', null) !== null) {
                 $comp = $idpMetadata->getString('AuthnContextComparison');
             } elseif (
                 isset($state['saml:AuthnContextComparison'])
@@ -577,7 +577,7 @@ class SP extends \SimpleSAML\Auth\Source
             $ar->setExtensions($this->metadata->getArray('saml:Extensions'));
         }
 
-        $providerName = $this->metadata->getString("ProviderName", null);
+        $providerName = $this->metadata->getOptionalString("ProviderName", null);
         if ($providerName !== null) {
             $ar->setProviderName($providerName);
         }
@@ -1141,7 +1141,7 @@ class SP extends \SimpleSAML\Auth\Source
             if (!empty($state['saml:sp:RelayState'])) {
                 $redirectTo = $state['saml:sp:RelayState'];
             } else {
-                $redirectTo = $source->getMetadata()->getString('RelayState', '/');
+                $redirectTo = $source->getMetadata()->getOptionalString('RelayState', '/');
             }
 
             self::handleUnsolicitedAuth($sourceId, $state, $redirectTo);

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -96,7 +96,7 @@ class SP extends \SimpleSAML\Auth\Source
         $this->entityId = $this->metadata->getString('entityID');
         $this->idp = $this->metadata->getString('idp', null);
         $this->discoURL = $this->metadata->getString('discoURL', null);
-        $this->disable_scoping = $this->metadata->getBoolean('disable_scoping', false);
+        $this->disable_scoping = $this->metadata->getOptionalBoolean('disable_scoping', false);
     }
 
 
@@ -532,7 +532,7 @@ class SP extends \SimpleSAML\Auth\Source
         $requesterID = [];
 
         /* Only check for real info for Scoping element if we are going to send Scoping element */
-        if ($this->disable_scoping !== true && $idpMetadata->getBoolean('disable_scoping', false) !== true) {
+        if ($this->disable_scoping !== true && $idpMetadata->getOptionalBoolean('disable_scoping', false) !== true) {
             if (isset($state['saml:IDPList'])) {
                 $IDPList = $state['saml:IDPList'];
             }
@@ -994,9 +994,9 @@ class SP extends \SimpleSAML\Auth\Source
             $lr->setExtensions($this->metadata->getArray('saml:logout:Extensions'));
         }
 
-        $encryptNameId = $idpMetadata->getBoolean('nameid.encryption', null);
+        $encryptNameId = $idpMetadata->getOptionalBoolean('nameid.encryption', null);
         if ($encryptNameId === null) {
-            $encryptNameId = $this->metadata->getBoolean('nameid.encryption', false);
+            $encryptNameId = $this->metadata->getOptionalBoolean('nameid.encryption', false);
         }
         if ($encryptNameId) {
             $lr->encryptNameId(Module\saml\Message::getEncryptionKey($idpMetadata));

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -152,7 +152,7 @@ class SP extends \SimpleSAML\Auth\Source
 
         // add attributes
         $name = $this->metadata->getLocalizedString('name', null);
-        $attributes = $this->metadata->getArray('attributes', []);
+        $attributes = $this->metadata->getOptionalArray('attributes', []);
         if ($name !== null) {
             if (!empty($attributes)) {
                 $metadata['name'] = $name;
@@ -189,7 +189,7 @@ class SP extends \SimpleSAML\Auth\Source
         }
 
         // add contacts
-        $contacts = $this->metadata->getArray('contacts', []);
+        $contacts = $this->metadata->getOptionalArray('contacts', []);
         foreach ($contacts as $contact) {
             $metadata['contacts'][] = Utils\Config\Metadata::getContact($contact);
         }
@@ -343,7 +343,7 @@ class SP extends \SimpleSAML\Auth\Source
             $default[] = Constants::BINDING_HOK_SSO;
         }
 
-        $bindings = $this->metadata->getArray('acs.Bindings', $default);
+        $bindings = $this->metadata->getOptionalArray('acs.Bindings', $default);
         $index = 0;
         foreach ($bindings as $service) {
             switch ($service) {
@@ -390,7 +390,7 @@ class SP extends \SimpleSAML\Auth\Source
         $storeType = $config->getString('store.type', 'phpsession');
 
         $store = StoreFactory::getInstance($storeType);
-        $bindings = $this->metadata->getArray(
+        $bindings = $this->metadata->getOptionalArray(
             'SingleLogoutServiceBinding',
             [
                 Constants::BINDING_HTTP_REDIRECT,
@@ -560,8 +560,8 @@ class SP extends \SimpleSAML\Auth\Source
         $ar->setIDPList(
             array_unique(
                 array_merge(
-                    $this->metadata->getArray('IDPList', []),
-                    $idpMetadata->getArray('IDPList', []),
+                    $this->metadata->getOptionalArray('IDPList', []),
+                    $idpMetadata->getOptionalArray('IDPList', []),
                     (array) $IDPList
                 )
             )
@@ -573,7 +573,7 @@ class SP extends \SimpleSAML\Auth\Source
         // Otherwise use extensions that might be defined in the local SP (only makes sense in a proxy scenario)
         if (isset($state['saml:Extensions']) && count($state['saml:Extensions']) > 0) {
             $ar->setExtensions($state['saml:Extensions']);
-        } elseif ($this->metadata->getArray('saml:Extensions', null) !== null) {
+        } elseif ($this->metadata->getOptionalArray('saml:Extensions', null) !== null) {
             $ar->setExtensions($this->metadata->getArray('saml:Extensions'));
         }
 
@@ -990,7 +990,7 @@ class SP extends \SimpleSAML\Auth\Source
 
         if (isset($state['saml:logout:Extensions']) && count($state['saml:logout:Extensions']) > 0) {
             $lr->setExtensions($state['saml:logout:Extensions']);
-        } elseif ($this->metadata->getArray('saml:logout:Extensions', null) !== null) {
+        } elseif ($this->metadata->getOptionalArray('saml:logout:Extensions', null) !== null) {
             $lr->setExtensions($this->metadata->getArray('saml:logout:Extensions'));
         }
 

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -151,7 +151,7 @@ class SP extends \SimpleSAML\Auth\Source
         }
 
         // add attributes
-        $name = $this->metadata->getLocalizedString('name', null);
+        $name = $this->metadata->getOptionalLocalizedString('name', null);
         $attributes = $this->metadata->getOptionalArray('attributes', []);
         if ($name !== null) {
             if (!empty($attributes)) {
@@ -176,11 +176,11 @@ class SP extends \SimpleSAML\Auth\Source
         }
 
         // add organization info
-        $org = $this->metadata->getLocalizedString('OrganizationName', null);
+        $org = $this->metadata->getOptionalLocalizedString('OrganizationName', null);
         if ($org !== null) {
             $metadata['OrganizationName'] = $org;
-            $metadata['OrganizationDisplayName'] = $this->metadata->getLocalizedString('OrganizationDisplayName', $org);
-            $metadata['OrganizationURL'] = $this->metadata->getLocalizedString('OrganizationURL', null);
+            $metadata['OrganizationDisplayName'] = $this->metadata->getOptionalLocalizedString('OrganizationDisplayName', $org);
+            $metadata['OrganizationURL'] = $this->metadata->getOptionalLocalizedString('OrganizationURL', null);
             if ($metadata['OrganizationURL'] === null) {
                 throw new Error\Exception(
                     'If OrganizationName is set, OrganizationURL must also be set.'

--- a/modules/saml/lib/Auth/Source/SP.php
+++ b/modules/saml/lib/Auth/Source/SP.php
@@ -539,10 +539,10 @@ class SP extends \SimpleSAML\Auth\Source
 
             if (isset($state['saml:ProxyCount']) && $state['saml:ProxyCount'] !== null) {
                 $ar->setProxyCount($state['saml:ProxyCount']);
-            } elseif ($idpMetadata->getInteger('ProxyCount', null) !== null) {
-                $ar->setProxyCount($idpMetadata->getInteger('ProxyCount', null));
-            } elseif ($this->metadata->getInteger('ProxyCount', null) !== null) {
-                $ar->setProxyCount($this->metadata->getInteger('ProxyCount', null));
+            } elseif ($idpMetadata->hasValue('ProxyCount')) {
+                $ar->setProxyCount($idpMetadata->getInteger('ProxyCount'));
+            } elseif ($this->metadata->hasValue('ProxyCount')) {
+                $ar->setProxyCount($this->metadata->getInteger('ProxyCount'));
             }
 
             $requesterID = [];

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -456,7 +456,7 @@ class SAML2
             throw new Exception('Unable to use any of the ACS endpoints found for SP \'' . $spEntityId . '\'');
         }
 
-        $IDPList = array_unique(array_merge($IDPList, $spMetadata->getArrayizeString('IDPList', [])));
+        $IDPList = array_unique(array_merge($IDPList, $spMetadata->getOptionalArrayizeString('IDPList', [])));
         if ($ProxyCount === null) {
             $ProxyCount = $spMetadata->getOptionalInteger('ProxyCount', null);
         }
@@ -796,7 +796,7 @@ class SAML2
             'entityid' => $entityid,
             'SingleSignOnService' => $sso,
             'SingleLogoutService' => $slo,
-            'NameIDFormat' => $config->getArrayizeString('NameIDFormat', [Constants::NAMEID_TRANSIENT]),
+            'NameIDFormat' => $config->getOptionalArrayizeString('NameIDFormat', [Constants::NAMEID_TRANSIENT]),
         ];
 
         $cryptoUtils = new Utils\Crypto();
@@ -1254,9 +1254,11 @@ class SAML2
 
         if ($nameIdFormat === null || !isset($state['saml:NameID'][$nameIdFormat])) {
             // either not set in request, or not set to a format we supply. Fall back to old generation method
-            $nameIdFormat = current($spMetadata->getArrayizeString('NameIDFormat', []));
+            $nameIdFormat = current($spMetadata->getOptionalArrayizeString('NameIDFormat', []));
             if ($nameIdFormat === false) {
-                $nameIdFormat = current($idpMetadata->getArrayizeString('NameIDFormat', [Constants::NAMEID_TRANSIENT]));
+                $nameIdFormat = current(
+                    $idpMetadata->getOptionalArrayizeString('NameIDFormat', [Constants::NAMEID_TRANSIENT])
+                );
             }
         }
 

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -662,7 +662,7 @@ class SAML2
                 'idpEntityID' => $idpMetadata->getString('entityid'),
             ]);
 
-            $spStatsId = $spMetadata->getString('core:statistics-id', $spEntityId);
+            $spStatsId = $spMetadata->getOptionalString('core:statistics-id', $spEntityId);
             Logger::stats('saml20-idp-SLO spinit ' . $spStatsId . ' ' . $idpMetadata->getString('entityid'));
 
             $state = [
@@ -937,11 +937,11 @@ class SAML2
         }
 
         $globalConfig = Configuration::getInstance();
-        $email = $globalConfig->getString('technicalcontact_email', false);
-        if ($email && $email !== 'na@example.org') {
+        $email = $globalConfig->getOptionalString('technicalcontact_email', 'na@example.org');
+        if (!empty($email) && $email !== 'na@example.org') {
             $contact = [
                 'emailAddress' => $email,
-                'givenName' => $globalConfig->getString('technicalcontact_name', null),
+                'givenName' => $globalConfig->getOptionalString('technicalcontact_name', null),
                 'contactType' => 'technical',
             ];
             $metadata['contacts'][] = Utils\Config\Metadata::getContact($contact);
@@ -965,9 +965,9 @@ class SAML2
         Configuration $spMetadata,
         array &$state
     ): ?string {
-        $attribute = $spMetadata->getString('simplesaml.nameidattribute', null);
+        $attribute = $spMetadata->getOptionalString('simplesaml.nameidattribute', null);
         if ($attribute === null) {
-            $attribute = $idpMetadata->getString('simplesaml.nameidattribute', null);
+            $attribute = $idpMetadata->getOptionalString('simplesaml.nameidattribute', null);
             if ($attribute === null) {
                 Logger::error('Unable to generate NameID. Check the simplesaml.nameidattribute option.');
                 return null;
@@ -1083,21 +1083,21 @@ class SAML2
         Configuration $spMetadata
     ): string {
         // try SP metadata first
-        $attributeNameFormat = $spMetadata->getString('attributes.NameFormat', null);
+        $attributeNameFormat = $spMetadata->getOptionalString('attributes.NameFormat', null);
         if ($attributeNameFormat !== null) {
             return $attributeNameFormat;
         }
-        $attributeNameFormat = $spMetadata->getString('AttributeNameFormat', null);
+        $attributeNameFormat = $spMetadata->getOptionalString('AttributeNameFormat', null);
         if ($attributeNameFormat !== null) {
             return $attributeNameFormat;
         }
 
         // look in IdP metadata
-        $attributeNameFormat = $idpMetadata->getString('attributes.NameFormat', null);
+        $attributeNameFormat = $idpMetadata->getOptionalString('attributes.NameFormat', null);
         if ($attributeNameFormat !== null) {
             return $attributeNameFormat;
         }
-        $attributeNameFormat = $idpMetadata->getString('AttributeNameFormat', null);
+        $attributeNameFormat = $idpMetadata->getOptionalString('AttributeNameFormat', null);
         if ($attributeNameFormat !== null) {
             return $attributeNameFormat;
         }
@@ -1264,7 +1264,7 @@ class SAML2
             $nameId = $state['saml:NameID'][$nameIdFormat];
             $nameId->setFormat($nameIdFormat);
         } else {
-            $spNameQualifier = $spMetadata->getString('SPNameQualifier', null);
+            $spNameQualifier = $spMetadata->getOptionalString('SPNameQualifier', null);
             if ($spNameQualifier === null) {
                 $spNameQualifier = $spMetadata->getString('entityid');
             }
@@ -1334,12 +1334,12 @@ class SAML2
         }
 
 
-        $sharedKey = $spMetadata->getString('sharedkey', null);
+        $sharedKey = $spMetadata->getOptionalString('sharedkey', null);
         if ($sharedKey !== null) {
-            $algo = $spMetadata->getString('sharedkey_algorithm', null);
+            $algo = $spMetadata->getOptionalString('sharedkey_algorithm', null);
             if ($algo === null) {
                 // If no algorithm is configured, use a sane default
-                $algo = $idpMetadata->getString('sharedkey_algorithm', XMLSecurityKey::AES128_GCM);
+                $algo = $idpMetadata->getOptionalString('sharedkey_algorithm', XMLSecurityKey::AES128_GCM);
             }
 
             $key = new XMLSecurityKey($algo);

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -1012,8 +1012,8 @@ class SAML2
             $defaultEncoding = 'string';
         }
 
-        $srcEncodings = $idpMetadata->getArray('attributeencodings', []);
-        $dstEncodings = $spMetadata->getArray('attributeencodings', []);
+        $srcEncodings = $idpMetadata->getOptionalArray('attributeencodings', []);
+        $dstEncodings = $spMetadata->getOptionalArray('attributeencodings', []);
 
         /*
          * Merge the two encoding arrays. Encodings specified in the target metadata
@@ -1146,7 +1146,7 @@ class SAML2
         $issuer->setFormat(Constants::NAMEID_ENTITY);
         $a->setIssuer($issuer);
 
-        $audience = array_merge([$spMetadata->getString('entityid')], $spMetadata->getArray('audience', []));
+        $audience = array_merge([$spMetadata->getString('entityid')], $spMetadata->getOptionalArray('audience', []));
         $a->setValidAudiences($audience);
 
         $a->setNotBefore($now - 30);

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -458,7 +458,7 @@ class SAML2
 
         $IDPList = array_unique(array_merge($IDPList, $spMetadata->getArrayizeString('IDPList', [])));
         if ($ProxyCount === null) {
-            $ProxyCount = $spMetadata->getInteger('ProxyCount', null);
+            $ProxyCount = $spMetadata->getOptionalInteger('ProxyCount', null);
         }
 
         if (!$forceAuthn) {
@@ -1151,9 +1151,9 @@ class SAML2
 
         $a->setNotBefore($now - 30);
 
-        $assertionLifetime = $spMetadata->getInteger('assertion.lifetime', null);
+        $assertionLifetime = $spMetadata->getOptionalInteger('assertion.lifetime', null);
         if ($assertionLifetime === null) {
-            $assertionLifetime = $idpMetadata->getInteger('assertion.lifetime', 300);
+            $assertionLifetime = $idpMetadata->getOptionalInteger('assertion.lifetime', 300);
         }
         $a->setNotOnOrAfter($now + $assertionLifetime);
 
@@ -1171,7 +1171,7 @@ class SAML2
             $sessionStart = $state['AuthnInstant'];
         }
 
-        $sessionLifetime = $config->getInteger('session.duration', 8 * 60 * 60);
+        $sessionLifetime = $config->getOptionalInteger('session.duration', 8 * 60 * 60);
         $a->setSessionNotOnOrAfter($sessionStart + $sessionLifetime);
 
         $randomUtils = new Utils\Random();
@@ -1397,9 +1397,9 @@ class SAML2
         $lr->setSessionIndex($association['saml:SessionIndex']);
         $lr->setNameId($association['saml:NameID']);
 
-        $assertionLifetime = $spMetadata->getInteger('assertion.lifetime', null);
+        $assertionLifetime = $spMetadata->getOptionalInteger('assertion.lifetime', null);
         if ($assertionLifetime === null) {
-            $assertionLifetime = $idpMetadata->getInteger('assertion.lifetime', 300);
+            $assertionLifetime = $idpMetadata->getOptionalInteger('assertion.lifetime', 300);
         }
         $lr->setNotOnOrAfter(time() + $assertionLifetime);
 

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -255,7 +255,7 @@ class SAML2
 
         $skipEndpointValidation = false;
         if ($authnRequestSigned === true) {
-            $skipEndpointValidationWhenSigned = $spMetadata->getValue('skipEndpointValidationWhenSigned', false);
+            $skipEndpointValidationWhenSigned = $spMetadata->getOptionalValue('skipEndpointValidationWhenSigned', false);
             if (is_bool($skipEndpointValidationWhenSigned) === true) {
                 $skipEndpointValidation = $skipEndpointValidationWhenSigned;
             } elseif (is_callable($skipEndpointValidationWhenSigned) === true) {
@@ -305,13 +305,13 @@ class SAML2
         $httpUtils = new Utils\HTTP();
 
         $supportedBindings = [Constants::BINDING_HTTP_POST];
-        if ($idpMetadata->getBoolean('saml20.sendartifact', false)) {
+        if ($idpMetadata->getOptionalBoolean('saml20.sendartifact', false)) {
             $supportedBindings[] = Constants::BINDING_HTTP_ARTIFACT;
         }
-        if ($idpMetadata->getBoolean('saml20.hok.assertion', false)) {
+        if ($idpMetadata->getOptionalBoolean('saml20.hok.assertion', false)) {
             $supportedBindings[] = Constants::BINDING_HOK_SSO;
         }
-        if ($idpMetadata->getBoolean('saml20.ecp', false)) {
+        if ($idpMetadata->getOptionalBoolean('saml20.ecp', false)) {
             $supportedBindings[] = Constants::BINDING_PAOS;
         }
 
@@ -462,7 +462,7 @@ class SAML2
         }
 
         if (!$forceAuthn) {
-            $forceAuthn = $spMetadata->getBoolean('ForceAuthn', false);
+            $forceAuthn = $spMetadata->getOptionalBoolean('ForceAuthn', false);
         }
 
         $sessionLostParams = [
@@ -844,7 +844,7 @@ class SAML2
         $metadata['keys'] = $keys;
 
         // add ArtifactResolutionService endpoint, if enabled
-        if ($config->getBoolean('saml20.sendartifact', false)) {
+        if ($config->getOptionalBoolean('saml20.sendartifact', false)) {
             $metadata['ArtifactResolutionService'][] = [
                 'index' => 0,
                 'Binding' => Constants::BINDING_SOAP,
@@ -853,7 +853,7 @@ class SAML2
         }
 
         // add Holder of Key, if enabled
-        if ($config->getBoolean('saml20.hok.assertion', false)) {
+        if ($config->getOptionalBoolean('saml20.hok.assertion', false)) {
             array_unshift(
                 $metadata['SingleSignOnService'],
                 [
@@ -865,7 +865,7 @@ class SAML2
         }
 
         // add ECP profile, if enabled
-        if ($config->getBoolean('saml20.ecp', false)) {
+        if ($config->getOptionalBoolean('saml20.ecp', false)) {
             $metadata['SingleSignOnService'][] = [
                 'index' => 0,
                 'Binding' => Constants::BINDING_SOAP,
@@ -1001,9 +1001,9 @@ class SAML2
         Configuration $spMetadata,
         array $attributes
     ): array {
-        $base64Attributes = $spMetadata->getBoolean('base64attributes', null);
+        $base64Attributes = $spMetadata->getOptionalBoolean('base64attributes', null);
         if ($base64Attributes === null) {
-            $base64Attributes = $idpMetadata->getBoolean('base64attributes', false);
+            $base64Attributes = $idpMetadata->getOptionalBoolean('base64attributes', false);
         }
 
         if ($base64Attributes) {
@@ -1129,9 +1129,9 @@ class SAML2
         $httpUtils = new Utils\HTTP();
         $now = time();
 
-        $signAssertion = $spMetadata->getBoolean('saml20.sign.assertion', null);
+        $signAssertion = $spMetadata->getOptionalBoolean('saml20.sign.assertion', null);
         if ($signAssertion === null) {
-            $signAssertion = $idpMetadata->getBoolean('saml20.sign.assertion', true);
+            $signAssertion = $idpMetadata->getOptionalBoolean('saml20.sign.assertion', true);
         }
 
         $config = Configuration::getInstance();
@@ -1190,7 +1190,7 @@ class SAML2
             $hokAssertion = true;
         }
         if ($hokAssertion === null) {
-            $hokAssertion = $idpMetadata->getBoolean('saml20.hok.assertion', false);
+            $hokAssertion = $idpMetadata->getOptionalBoolean('saml20.hok.assertion', false);
         }
 
         if ($hokAssertion) {
@@ -1238,7 +1238,7 @@ class SAML2
         $a->setSubjectConfirmation([$sc]);
 
         // add attributes
-        if ($spMetadata->getBoolean('simplesaml.attributes', true)) {
+        if ($spMetadata->getOptionalBoolean('simplesaml.attributes', true)) {
             $attributeNameFormat = self::getAttributeNameFormat($idpMetadata, $spMetadata);
             $a->setAttributeNameFormat($attributeNameFormat);
             $attributes = self::encodeAttributes($idpMetadata, $spMetadata, $state['Attributes']);
@@ -1293,9 +1293,9 @@ class SAML2
 
         $a->setNameId($nameId);
 
-        $encryptNameId = $spMetadata->getBoolean('nameid.encryption', null);
+        $encryptNameId = $spMetadata->getOptionalBoolean('nameid.encryption', null);
         if ($encryptNameId === null) {
-            $encryptNameId = $idpMetadata->getBoolean('nameid.encryption', false);
+            $encryptNameId = $idpMetadata->getOptionalBoolean('nameid.encryption', false);
         }
         if ($encryptNameId) {
             $a->encryptNameId(\SimpleSAML\Module\saml\Message::getEncryptionKey($spMetadata));
@@ -1324,9 +1324,9 @@ class SAML2
         Configuration $spMetadata,
         Assertion $assertion
     ) {
-        $encryptAssertion = $spMetadata->getBoolean('assertion.encryption', null);
+        $encryptAssertion = $spMetadata->getOptionalBoolean('assertion.encryption', null);
         if ($encryptAssertion === null) {
-            $encryptAssertion = $idpMetadata->getBoolean('assertion.encryption', false);
+            $encryptAssertion = $idpMetadata->getOptionalBoolean('assertion.encryption', false);
         }
         if (!$encryptAssertion) {
             // we are _not_ encrypting this assertion, and are therefore done
@@ -1403,9 +1403,9 @@ class SAML2
         }
         $lr->setNotOnOrAfter(time() + $assertionLifetime);
 
-        $encryptNameId = $spMetadata->getBoolean('nameid.encryption', null);
+        $encryptNameId = $spMetadata->getOptionalBoolean('nameid.encryption', null);
         if ($encryptNameId === null) {
-            $encryptNameId = $idpMetadata->getBoolean('nameid.encryption', false);
+            $encryptNameId = $idpMetadata->getOptionalBoolean('nameid.encryption', false);
         }
         if ($encryptNameId) {
             $lr->encryptNameId(\SimpleSAML\Module\saml\Message::getEncryptionKey($spMetadata));
@@ -1429,9 +1429,9 @@ class SAML2
         Configuration $spMetadata,
         string $consumerURL
     ): Response {
-        $signResponse = $spMetadata->getBoolean('saml20.sign.response', null);
+        $signResponse = $spMetadata->getOptionalBoolean('saml20.sign.response', null);
         if ($signResponse === null) {
-            $signResponse = $idpMetadata->getBoolean('saml20.sign.response', true);
+            $signResponse = $idpMetadata->getOptionalBoolean('saml20.sign.response', true);
         }
 
         $r = new Response();

--- a/modules/saml/lib/IdP/SAML2.php
+++ b/modules/saml/lib/IdP/SAML2.php
@@ -876,7 +876,7 @@ class SAML2
         // add organization information
         if ($config->hasValue('OrganizationName')) {
             $metadata['OrganizationName'] = $config->getLocalizedString('OrganizationName');
-            $metadata['OrganizationDisplayName'] = $config->getLocalizedString(
+            $metadata['OrganizationDisplayName'] = $config->getOptionalLocalizedString(
                 'OrganizationDisplayName',
                 $metadata['OrganizationName']
             );

--- a/modules/saml/lib/IdP/SQLNameID.php
+++ b/modules/saml/lib/IdP/SQLNameID.php
@@ -159,7 +159,7 @@ class SQLNameID
     private static function getStore(): Store\SQLStore
     {
         $config = Configuration::getInstance();
-        $storeType = $config->getString('store.type', 'phpsession');
+        $storeType = $config->getOptionalString('store.type', 'phpsession');
 
         $store = StoreFactory::getInstance($storeType);
         Assert::isInstanceOf(

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -43,7 +43,7 @@ class Message
         Configuration $dstMetadata,
         SignedElement $element
     ): void {
-        $dstPrivateKey = $dstMetadata->getString('signature.privatekey', null);
+        $dstPrivateKey = $dstMetadata->getOptionalString('signature.privatekey', null);
         $cryptoUtils = new Utils\Crypto();
 
         if ($dstPrivateKey !== null) {
@@ -56,9 +56,9 @@ class Message
             $certArray = $cryptoUtils->loadPublicKey($srcMetadata, false);
         }
 
-        $algo = $dstMetadata->getString('signature.algorithm', null);
+        $algo = $dstMetadata->getOptionalString('signature.algorithm', null);
         if ($algo === null) {
-            $algo = $srcMetadata->getString('signature.algorithm', XMLSecurityKey::RSA_SHA256);
+            $algo = $srcMetadata->getOptionalString('signature.algorithm', XMLSecurityKey::RSA_SHA256);
         }
 
         $privateKey = new XMLSecurityKey($algo, ['type' => 'private']);
@@ -254,15 +254,15 @@ class Message
         Configuration $dstMetadata,
         $encryptionMethod = null
     ): array {
-        $sharedKey = $srcMetadata->getString('sharedkey', null);
+        $sharedKey = $srcMetadata->getOptionalString('sharedkey', null);
         if ($sharedKey !== null) {
             if ($encryptionMethod !== null) {
                 $algo = $encryptionMethod->getAlgorithm();
             } else {
-                $algo = $srcMetadata->getString('sharedkey_algorithm', null);
+                $algo = $srcMetadata->getOptionalString('sharedkey_algorithm', null);
                 if ($algo === null) {
                     // If no algorithm is supplied or configured, use a sane default as a last resort
-                    $algo = $dstMetadata->getString('sharedkey_algorithm', XMLSecurityKey::AES128_GCM);
+                    $algo = $dstMetadata->getOptionalString('sharedkey_algorithm', XMLSecurityKey::AES128_GCM);
                 }
             }
 
@@ -880,7 +880,7 @@ class Message
      */
     public static function getEncryptionKey(Configuration $metadata): XMLSecurityKey
     {
-        $sharedKey = $metadata->getString('sharedkey', null);
+        $sharedKey = $metadata->getOptionalString('sharedkey', null);
         if ($sharedKey !== null) {
             $key = new XMLSecurityKey(XMLSecurityKey::AES128_CBC);
             $key->loadKey($sharedKey);

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -495,8 +495,12 @@ class Message
         $issuer = new Issuer();
         $issuer->setValue($spMetadata->getString('entityid'));
         $ar->setIssuer($issuer);
-        $ar->setAssertionConsumerServiceIndex($spMetadata->getInteger('AssertionConsumerServiceIndex', null));
-        $ar->setAttributeConsumingServiceIndex($spMetadata->getInteger('AttributeConsumingServiceIndex', null));
+        $ar->setAssertionConsumerServiceIndex(
+            $spMetadata->getOptionalInteger('AssertionConsumerServiceIndex', null)
+        );
+        $ar->setAttributeConsumingServiceIndex(
+            $spMetadata->getOptionalInteger('AttributeConsumingServiceIndex', null)
+        );
 
         if ($spMetadata->hasValue('AuthnContextClassRef')) {
             $accr = $spMetadata->getArrayizeString('AuthnContextClassRef');
@@ -652,7 +656,7 @@ class Message
 
         // check various properties of the assertion
         $config = Configuration::getInstance();
-        $allowed_clock_skew = $config->getInteger('assertion.allowed_clock_skew', 180);
+        $allowed_clock_skew = $config->getOptionalInteger('assertion.allowed_clock_skew', 180);
         $options = [
             'options' => [
                 'default' => 180,

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -483,7 +483,7 @@ class Message
         $ar->setForceAuthn($spMetadata->getOptionalBoolean('ForceAuthn', false));
         $ar->setIsPassive($spMetadata->getOptionalBoolean('IsPassive', false));
 
-        $protbind = $spMetadata->getValueValidate('ProtocolBinding', [
+        $protbind = $spMetadata->getOptionalValueValidate('ProtocolBinding', [
             Constants::BINDING_HTTP_POST,
             Constants::BINDING_HOK_SSO,
             Constants::BINDING_HTTP_ARTIFACT,
@@ -504,7 +504,7 @@ class Message
 
         if ($spMetadata->hasValue('AuthnContextClassRef')) {
             $accr = $spMetadata->getArrayizeString('AuthnContextClassRef');
-            $comp = $spMetadata->getValueValidate('AuthnContextComparison', [
+            $comp = $spMetadata->getOptionalValueValidate('AuthnContextComparison', [
                 Constants::COMPARISON_EXACT,
                 Constants::COMPARISON_MINIMUM,
                 Constants::COMPARISON_MAXIMUM,

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -320,9 +320,9 @@ class Message
         Configuration $srcMetadata,
         Configuration $dstMetadata
     ): array {
-        $blacklist = $srcMetadata->getArray('encryption.blacklisted-algorithms', null);
+        $blacklist = $srcMetadata->getOptionalArray('encryption.blacklisted-algorithms', null);
         if ($blacklist === null) {
-            $blacklist = $dstMetadata->getArray('encryption.blacklisted-algorithms', [XMLSecurityKey::RSA_1_5]);
+            $blacklist = $dstMetadata->getOptionalArray('encryption.blacklisted-algorithms', [XMLSecurityKey::RSA_1_5]);
         }
         return $blacklist;
     }

--- a/modules/saml/lib/Message.php
+++ b/modules/saml/lib/Message.php
@@ -97,21 +97,21 @@ class Message
     ): void {
         $signingEnabled = null;
         if ($message instanceof LogoutRequest || $message instanceof LogoutResponse) {
-            $signingEnabled = $srcMetadata->getBoolean('sign.logout', null);
+            $signingEnabled = $srcMetadata->getOptionalBoolean('sign.logout', null);
             if ($signingEnabled === null) {
-                $signingEnabled = $dstMetadata->getBoolean('sign.logout', null);
+                $signingEnabled = $dstMetadata->getOptionalBoolean('sign.logout', null);
             }
         } elseif ($message instanceof AuthnRequest) {
-            $signingEnabled = $srcMetadata->getBoolean('sign.authnrequest', null);
+            $signingEnabled = $srcMetadata->getOptionalBoolean('sign.authnrequest', null);
             if ($signingEnabled === null) {
-                $signingEnabled = $dstMetadata->getBoolean('sign.authnrequest', null);
+                $signingEnabled = $dstMetadata->getOptionalBoolean('sign.authnrequest', null);
             }
         }
 
         if ($signingEnabled === null) {
-            $signingEnabled = $dstMetadata->getBoolean('redirect.sign', null);
+            $signingEnabled = $dstMetadata->getOptionalBoolean('redirect.sign', null);
             if ($signingEnabled === null) {
-                $signingEnabled = $srcMetadata->getBoolean('redirect.sign', false);
+                $signingEnabled = $srcMetadata->getOptionalBoolean('redirect.sign', false);
             }
         }
         if (!$signingEnabled) {
@@ -203,14 +203,14 @@ class Message
     ): bool {
         $enabled = null;
         if ($message instanceof LogoutRequest || $message instanceof LogoutResponse) {
-            $enabled = $srcMetadata->getBoolean('validate.logout', null);
+            $enabled = $srcMetadata->getOptionalBoolean('validate.logout', null);
             if ($enabled === null) {
-                $enabled = $dstMetadata->getBoolean('validate.logout', null);
+                $enabled = $dstMetadata->getOptionalBoolean('validate.logout', null);
             }
         } elseif ($message instanceof AuthnRequest) {
-            $enabled = $srcMetadata->getBoolean('validate.authnrequest', null);
+            $enabled = $srcMetadata->getOptionalBoolean('validate.authnrequest', null);
             if ($enabled === null) {
-                $enabled = $dstMetadata->getBoolean('validate.authnrequest', null);
+                $enabled = $dstMetadata->getOptionalBoolean('validate.authnrequest', null);
             }
         }
 
@@ -222,9 +222,9 @@ class Message
         ) {
             $enabled = true;
         } elseif ($enabled === null) {
-            $enabled = $srcMetadata->getBoolean('redirect.validate', null);
+            $enabled = $srcMetadata->getOptionalBoolean('redirect.validate', null);
             if ($enabled === null) {
-                $enabled = $dstMetadata->getBoolean('redirect.validate', false);
+                $enabled = $dstMetadata->getOptionalBoolean('redirect.validate', false);
             }
         }
 
@@ -349,9 +349,9 @@ class Message
         Assert::isInstanceOfAny($assertion, [Assertion::class, EncryptedAssertion::class]);
 
         if ($assertion instanceof Assertion) {
-            $encryptAssertion = $srcMetadata->getBoolean('assertion.encryption', null);
+            $encryptAssertion = $srcMetadata->getOptionalBoolean('assertion.encryption', null);
             if ($encryptAssertion === null) {
-                $encryptAssertion = $dstMetadata->getBoolean('assertion.encryption', false);
+                $encryptAssertion = $dstMetadata->getOptionalBoolean('assertion.encryption', false);
             }
             if ($encryptAssertion) {
                 /* The assertion was unencrypted, but we have encryption enabled. */
@@ -480,8 +480,8 @@ class Message
             $ar->setNameIdPolicy($policy);
         }
 
-        $ar->setForceAuthn($spMetadata->getBoolean('ForceAuthn', false));
-        $ar->setIsPassive($spMetadata->getBoolean('IsPassive', false));
+        $ar->setForceAuthn($spMetadata->getOptionalBoolean('ForceAuthn', false));
+        $ar->setIsPassive($spMetadata->getOptionalBoolean('IsPassive', false));
 
         $protbind = $spMetadata->getValueValidate('ProtocolBinding', [
             Constants::BINDING_HTTP_POST,
@@ -702,9 +702,9 @@ class Message
             }
 
             // is SSO with HoK enabled? IdP remote metadata overwrites SP metadata configuration
-            $hok = $idpMetadata->getBoolean('saml20.hok.assertion', null);
+            $hok = $idpMetadata->getOptionalBoolean('saml20.hok.assertion', null);
             if ($hok === null) {
-                $hok = $spMetadata->getBoolean('saml20.hok.assertion', false);
+                $hok = $spMetadata->getOptionalBoolean('saml20.hok.assertion', false);
             }
             if ($method === Constants::CM_BEARER && $hok) {
                 $lastError = 'Bearer SubjectConfirmation received, but Holder-of-Key SubjectConfirmation needed';
@@ -824,7 +824,7 @@ class Message
         // as far as we can tell, the assertion is valid
 
         // maybe we need to base64 decode the attributes in the assertion?
-        if ($idpMetadata->getBoolean('base64attributes', false)) {
+        if ($idpMetadata->getOptionalBoolean('base64attributes', false)) {
             $attributes = $assertion->getAttributes();
             $newAttributes = [];
             foreach ($attributes as $name => $values) {

--- a/modules/saml/lib/SP/LogoutStore.php
+++ b/modules/saml/lib/SP/LogoutStore.php
@@ -214,7 +214,7 @@ class LogoutStore
         }
 
         $config = Configuration::getInstance();
-        $storeType = $config->getString('store.type', 'phpsession');
+        $storeType = $config->getOptionalString('store.type', 'phpsession');
 
         $store = StoreFactory::getInstance($storeType);
         if ($store === false) {
@@ -253,7 +253,7 @@ class LogoutStore
     public static function logoutSessions(string $authId, NameID $nameId, array $sessionIndexes)
     {
         $config = Configuration::getInstance();
-        $storeType = $config->getString('store.type', 'phpsession');
+        $storeType = $config->getOptionalString('store.type', 'phpsession');
 
         $store = StoreFactory::getInstance($storeType);
         if ($store === false) {

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -34,7 +34,7 @@ $entityId = $source->getEntityId();
 $spconfig = $source->getMetadata();
 $metaArray20 = $source->getHostedMetadata();
 
-$storeType = $config->getString('store.type', 'phpsession');
+$storeType = $config->getOptionalString('store.type', 'phpsession');
 $store = StoreFactory::getInstance($storeType);
 
 $metaBuilder = new Metadata\SAMLBuilder($entityId);

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -13,7 +13,7 @@ if (!array_key_exists('PATH_INFO', $_SERVER)) {
 }
 
 $config = Configuration::getInstance();
-if ($config->getBoolean('admin.protectmetadata', false)) {
+if ($config->getOptionalBoolean('admin.protectmetadata', false)) {
     $authUtils = new Utils\Auth();
     $authUtils->requireAdmin();
 }

--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -128,7 +128,7 @@ if ($state) {
     }
 } else {
     // this is an unsolicited response
-    $relaystate = $spMetadata->getString('RelayState', $response->getRelayState());
+    $relaystate = $spMetadata->getOptionalString('RelayState', $response->getRelayState());
     $state = [
         'saml:sp:isUnsolicited' => true,
         'saml:sp:AuthId'        => $sourceId,

--- a/modules/saml/www/sp/saml2-acs.php
+++ b/modules/saml/www/sp/saml2-acs.php
@@ -101,7 +101,7 @@ if (!empty($stateId)) {
     }
 }
 
-$enableUnsolicited = $spMetadata->getBoolean('enable_unsolicited', true);
+$enableUnsolicited = $spMetadata->getOptionalBoolean('enable_unsolicited', true);
 if ($state === null && $enableUnsolicited === false) {
     throw new Error\BadRequest('Unsolicited responses are denied by configuration.');
 }
@@ -119,7 +119,7 @@ if ($state) {
     Assert::keyExists($state, 'ExpectedIssuer');
     if ($state['ExpectedIssuer'] !== $issuer) {
         $idpMetadata = $source->getIdPMetadata($issuer);
-        $idplist = $idpMetadata->getArrayize('IDPList', []);
+        $idplist = $idpMetadata->getOptionalArrayize('IDPList', []);
         if (!in_array($state['ExpectedIssuer'], $idplist, true)) {
             Logger::warning(
                 'The issuer of the response not match to the identity provider we sent the request to.'
@@ -159,7 +159,7 @@ $attributes = [];
 $foundAuthnStatement = false;
 
 $config = Configuration::getInstance();
-$storeType = $config->getString('store.type', 'phpsession');
+$storeType = $config->getOptionalString('store.type', 'phpsession');
 
 $store = StoreFactory::getInstance($storeType);
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -308,33 +308,42 @@ class ConfigurationTest extends ClearStateTestCase
     {
         $c = Configuration::loadFromArray([
             'str_opt' => 'Hello World!',
+            'wrong_opt' => true,
         ]);
-        $this->assertEquals($c->getString('missing_opt', '--missing--'), '--missing--');
-        $this->assertEquals($c->getString('str_opt', '--missing--'), 'Hello World!');
-    }
 
+        // Normal use
+        $this->assertEquals($c->getString('str_opt'), 'Hello World!');
 
-    /**
-     * Test \SimpleSAML\Configuration::getString() missing option
-     */
-    public function testGetStringMissing(): void
-    {
-        $this->expectException(Exception::class);
-        $c = Configuration::loadFromArray([]);
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
         $c->getString('missing_opt');
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getString('wrong_opt');
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getString() wrong option
+     * Test \SimpleSAML\Configuration::getOptionalString() missing option
      */
-    public function testGetStringWrong(): void
+    public function testGetOptionalString(): void
     {
-        $this->expectException(Exception::class);
         $c = Configuration::loadFromArray([
-            'wrong' => false,
+            'str_opt' => 'Hello World!',
+            'wrong_opt' => true,
         ]);
-        $c->getString('wrong');
+
+        // Normal use
+        $this->assertEquals($c->getOptionalString('str_opt', 'Hello World!'), 'Hello World!');
+        $this->assertEquals($c->getOptionalString('str_opt', 'something else'), 'Hello World!');
+
+        // Missing option
+        $this->assertEquals($c->getOptionalString('missing_opt', 'Hello World!'), 'Hello World!');
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalString('wrong_opt', 'Hello World!');
     }
 
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -256,34 +256,48 @@ class ConfigurationTest extends ClearStateTestCase
         $c = Configuration::loadFromArray([
             'true_opt' => true,
             'false_opt' => false,
+            'wrong_opt' => 'true',
         ]);
-        $this->assertEquals($c->getBoolean('missing_opt', '--missing--'), '--missing--');
-        $this->assertEquals($c->getBoolean('true_opt', '--missing--'), true);
-        $this->assertEquals($c->getBoolean('false_opt', '--missing--'), false);
-    }
 
+        // Normal use
+        $this->assertTrue($c->getBoolean('true_opt'));
+        $this->assertFalse($c->getBoolean('false_opt'));
 
-    /**
-     * Test \SimpleSAML\Configuration::getBoolean() missing option
-     */
-    public function testGetBooleanMissing(): void
-    {
-        $this->expectException(Exception::class);
-        $c = Configuration::loadFromArray([]);
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
         $c->getBoolean('missing_opt');
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getBoolean('wrong_opt');
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getBoolean() wrong option
+     * Test \SimpleSAML\Configuration::getOptionalBoolean()
      */
-    public function testGetBooleanWrong(): void
+    public function testGetOptionalBoolean(): void
     {
-        $this->expectException(Exception::class);
         $c = Configuration::loadFromArray([
-            'wrong' => 'true',
+            'true_opt' => true,
+            'false_opt' => false,
+            'wrong_opt' => 'true',
         ]);
-        $c->getBoolean('wrong');
+
+        // Normal use
+        $this->assertTrue($c->getOptionalBoolean('true_opt', true));
+        $this->assertTrue($c->getOptionalBoolean('true_opt', false));
+        $this->assertFalse($c->getOptionalBoolean('false_opt', false));
+        $this->assertFalse($c->getOptionalBoolean('false_opt', true));
+
+        // Missing option
+        $this->assertEquals($c->getOptionalBoolean('missing_opt', null), null);
+        $this->assertEquals($c->getOptionalBoolean('missing_opt', false), false);
+        $this->assertEquals($c->getOptionalBoolean('missing_opt', true), true);
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalBoolean('wrong_opt', null);
     }
 
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -647,25 +647,30 @@ class ConfigurationTest extends ClearStateTestCase
         $c = Configuration::loadFromArray([
             'opt' => ['a' => 42],
         ]);
-        $this->assertNull($c->getConfigItem('missing_opt', null));
+
         $opt = $c->getConfigItem('opt');
-        $notOpt = $c->getConfigItem('notOpt');
         $this->assertInstanceOf(Configuration::class, $opt);
-        $this->assertInstanceOf(Configuration::class, $notOpt);
-        $this->assertEquals($opt->getValue('a'), 42);
+
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
+        $c->getConfigItem('missing_opt');
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getConfigItem() wrong option
+     * Test \SimpleSAML\Configuration::getOptionalConfigItem()
      */
-    public function testGetConfigItemWrong(): void
+    public function testGetOptionalConfigItem(): void
     {
-        $this->expectException(Exception::class);
         $c = Configuration::loadFromArray([
-            'opt' => 'not_an_array',
+            'opt' => ['a' => 42],
         ]);
-        $c->getConfigItem('opt');
+
+        $opt = $c->getOptionalConfigItem('opt', null);
+        $this->assertInstanceOf(Configuration::class, $opt);
+
+        // Missing option
+        $this->assertNull($c->getOptionalConfigItem('missing_opt', null));
     }
 
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -557,10 +557,36 @@ class ConfigurationTest extends ClearStateTestCase
             'opt_int' => 42,
             'opt_str' => 'string',
         ]);
-        $this->assertEquals($c->getArrayize('missing_opt', '--missing--'), '--missing--');
+
+        // Normal use
         $this->assertEquals($c->getArrayize('opt'), ['a', 'b', 'c']);
         $this->assertEquals($c->getArrayize('opt_int'), [42]);
         $this->assertEquals($c->getArrayize('opt_str'), ['string']);
+
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
+        $c->getArrayize('missing_opt');
+    }
+
+
+    /**
+     * Test \SimpleSAML\Configuration::getOptionalArrayize()
+     */
+    public function testGetOptionalArrayize(): void
+    {
+        $c = Configuration::loadFromArray([
+            'opt' => ['a', 'b', 'c'],
+            'opt_int' => 42,
+            'opt_str' => 'string',
+        ]);
+
+        // Normal use
+        $this->assertEquals($c->getOptionalArrayize('opt', ['d']), ['a', 'b', 'c']);
+        $this->assertEquals($c->getOptionalArrayize('opt_int', [1]), [42]);
+        $this->assertEquals($c->getOptionalArrayize('opt_str', ['test']), ['string']);
+
+        // Missing option
+        $this->assertEquals($c->getOptionalArrayize('missing_opt', ['test']), ['test']);
     }
 
 
@@ -572,24 +598,44 @@ class ConfigurationTest extends ClearStateTestCase
         $c = Configuration::loadFromArray([
             'opt' => ['a', 'b', 'c'],
             'opt_str' => 'string',
+            'opt_wrong' => 4,
         ]);
-        $this->assertEquals($c->getArrayizeString('missing_opt', '--missing--'), '--missing--');
+
+        // Normale use
         $this->assertEquals($c->getArrayizeString('opt'), ['a', 'b', 'c']);
         $this->assertEquals($c->getArrayizeString('opt_str'), ['string']);
+
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
+        $c->getArrayizeString('missing_opt');
+
+        // Wrong option
+        $this->expectException(AssertionFailedException::class);
+        $c->getArrayizeString('opt_wrong');
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getArrayizeString() option
-     * with an array that contains something that isn't a string.
+     * Test \SimpleSAML\Configuration::getOptionalArrayizeString()
      */
-    public function testGetArrayizeStringWrongValue(): void
+    public function testGetOptionalArrayizeString(): void
     {
-        $this->expectException(Exception::class);
         $c = Configuration::loadFromArray([
-            'opt' => ['a', 'b', 42],
+            'opt' => ['a', 'b', 'c'],
+            'opt_str' => 'string',
+            'opt_wrong' => 4,
         ]);
-        $c->getArrayizeString('opt');
+
+        // Normale use
+        $this->assertEquals($c->getOptionalArrayizeString('opt', ['d']), ['a', 'b', 'c']);
+        $this->assertEquals($c->getOptionalArrayizeString('opt_str', ['test']), ['string']);
+
+        // Missing option
+        $this->assertEquals($c->getOptionalArrayizeString('missing_opt', ['test']), ['test']);
+
+        // Wrong option
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalArrayizeString('opt_wrong', ['test']);
     }
 
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -467,21 +467,38 @@ class ConfigurationTest extends ClearStateTestCase
         $c = Configuration::loadFromArray([
             'opt' => 'b',
         ]);
-        $this->assertEquals($c->getValueValidate('missing_opt', ['a', 'b', 'c'], '--missing--'), '--missing--');
+
+        // Normal use
         $this->assertEquals($c->getValueValidate('opt', ['a', 'b', 'c']), 'b');
+
+        // Value not allowed
+        $this->expectException(AssertionFailedException::class);
+        $c->getValueValidate('opt', ['d', 'e', 'f']);
+
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
+        $c->getValueValidate('missing_opt', ['a', 'b', 'c']);
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getValueValidate() wrong option
+     * Test \SimpleSAML\Configuration::getOptionalValueValidate()
      */
-    public function testGetValueValidateWrong(): void
+    public function testGetOptionalValueValidate(): void
     {
-        $this->expectException(Exception::class);
         $c = Configuration::loadFromArray([
-            'opt' => 'd',
+            'opt' => 'b',
         ]);
-        $c->getValueValidate('opt', ['a', 'b', 'c']);
+
+        // Normal use
+        $this->assertEquals($c->getOptionalValueValidate('opt', ['a', 'b', 'c'], 'f'), 'b');
+
+        // Missing option
+        $this->assertEquals($c->getOptionalValueValidate('missing_opt', ['a', 'b', 'c'], 'f'), 'f');
+
+        // Value not allowed
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalValueValidate('opt', ['d', 'e', 'f'], 'c');
     }
 
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -354,33 +354,42 @@ class ConfigurationTest extends ClearStateTestCase
     {
         $c = Configuration::loadFromArray([
             'int_opt' => 42,
+            'wrong_opt' => 'test',
         ]);
-        $this->assertEquals($c->getInteger('missing_opt', '--missing--'), '--missing--');
-        $this->assertEquals($c->getInteger('int_opt', '--missing--'), 42);
-    }
 
+        // Normal use
+        $this->assertEquals($c->getInteger('int_opt'), 42);
 
-    /**
-     * Test \SimpleSAML\Configuration::getInteger() missing option
-     */
-    public function testGetIntegerMissing(): void
-    {
-        $this->expectException(Exception::class);
-        $c = Configuration::loadFromArray([]);
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
         $c->getInteger('missing_opt');
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getInteger('wrong_opt');
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getInteger() wrong option
+     * Test \SimpleSAML\Configuration::getOptionalInteger()
      */
-    public function testGetIntegerWrong(): void
+    public function testGetOptionalInteger(): void
     {
-        $this->expectException(Exception::class);
         $c = Configuration::loadFromArray([
-            'wrong' => '42',
+            'int_opt' => 42,
+            'wrong_opt' => 'test',
         ]);
-        $c->getInteger('wrong');
+
+
+        // Normal use
+        $this->assertEquals($c->getOptionalInteger('int_opt', 42), 42);
+
+        // Missing option
+        $this->assertEquals($c->getOptionalInteger('missing_opt', 32), 32);
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalInteger('wrong_opt', 10);
     }
 
 
@@ -390,36 +399,63 @@ class ConfigurationTest extends ClearStateTestCase
     public function testGetIntegerRange(): void
     {
         $c = Configuration::loadFromArray([
-            'int_opt' => 42,
+            'min_opt' => 0,
+            'max_opt' => 100,
+            'wrong_opt' => 'test',
         ]);
-        $this->assertEquals($c->getIntegerRange('missing_opt', 0, 100, '--missing--'), '--missing--');
-        $this->assertEquals($c->getIntegerRange('int_opt', 0, 100), 42);
+
+        // Normal use
+        $this->assertEquals($c->getIntegerRange('min_opt', 0, 100), 0);
+        $this->assertEquals($c->getIntegerRange('max_opt', 0, 100), 100);
+
+        // Missing option
+        $this->expectException(AssertionFailedException::class);
+        $c->getIntegerRange('missing_opt', 0, 100);
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getIntegerRange('wrong_opt', 0, 100);
+
+        // Below range
+        $this->expectException(AssertionFailedException::class);
+        $c->getIntegerRange('min_opt', 1, 100);
+
+        // Above range
+        $this->expectException(AssertionFailedException::class);
+        $c->getIntegerRange('max_opt', 0, 99);
     }
 
 
     /**
-     * Test \SimpleSAML\Configuration::getIntegerRange() below limit
+     * Test \SimpleSAML\Configuration::getOptionalIntegerRange()
      */
-    public function testGetIntegerRangeBelow(): void
+    public function testGetOptionalIntegerRange(): void
     {
-        $this->expectException(Exception::class);
         $c = Configuration::loadFromArray([
-            'int_opt' => 9,
+            'min_opt' => 0,
+            'max_opt' => 100,
+            'wrong_opt' => 'test',
         ]);
-        $this->assertEquals($c->getIntegerRange('int_opt', 10, 100), 42);
-    }
 
 
-    /**
-     * Test \SimpleSAML\Configuration::getIntegerRange() above limit
-     */
-    public function testGetIntegerRangeAbove(): void
-    {
-        $this->expectException(Exception::class);
-        $c = Configuration::loadFromArray([
-            'int_opt' => 101,
-        ]);
-        $this->assertEquals($c->getIntegerRange('int_opt', 10, 100), 42);
+        // Normal use
+        $this->assertEquals($c->getOptionalIntegerRange('min_opt', 0, 100, 50), 0);
+        $this->assertEquals($c->getOptionalIntegerRange('max_opt', 0, 100, 50), 100);
+
+        // Missing option
+        $this->assertEquals($c->getOptionalIntegerRange('missing_opt', 0, 100, 50), 50);
+
+        // Invalid option type
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalIntegerRange('wrong_opt', 0, 100, null);
+
+        // Below range
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalIntegerRange('min_opt', 1, 100, null);
+
+        // Above range
+        $this->expectException(AssertionFailedException::class);
+        $c->getOptionalIntegerRange('max_opt', 0, 99, null);
     }
 
 

--- a/tests/lib/SimpleSAML/ConfigurationTest.php
+++ b/tests/lib/SimpleSAML/ConfigurationTest.php
@@ -494,11 +494,12 @@ class ConfigurationTest extends ClearStateTestCase
         $this->assertEquals($c->getOptionalValueValidate('opt', ['a', 'b', 'c'], 'f'), 'b');
 
         // Missing option
-        $this->assertEquals($c->getOptionalValueValidate('missing_opt', ['a', 'b', 'c'], 'f'), 'f');
+        $this->assertEquals($c->getOptionalValueValidate('missing_opt', ['a', 'b', 'c'], 'b'), 'b');
 
         // Value not allowed
         $this->expectException(AssertionFailedException::class);
         $c->getOptionalValueValidate('opt', ['d', 'e', 'f'], 'c');
+        $c->getOptionalValueValidate('missing_opt', ['d', 'e', 'f'], 'c');
     }
 
 
@@ -1011,9 +1012,11 @@ class ConfigurationTest extends ClearStateTestCase
                 'no' => 'Hei Verden!',
             ],
         ]);
-        $this->assertEquals($c->getLocalizedString('missing_opt', '--missing--'), '--missing--');
         $this->assertEquals($c->getLocalizedString('str_opt'), ['en' => 'Hello World!']);
         $this->assertEquals($c->getLocalizedString('str_array'), ['en' => 'Hello World!', 'no' => 'Hei Verden!']);
+
+        $this->expectException(AssertionFailedException::class);
+        $c->getLocalizedString('missing_opt');
     }
 
 

--- a/tests/lib/SimpleSAML/Store/StoreFactoryTest.php
+++ b/tests/lib/SimpleSAML/Store/StoreFactoryTest.php
@@ -32,7 +32,7 @@ class StoreFactoryTest extends TestCase
         Configuration::loadFromArray([], '[ARRAY]', 'simplesaml');
 
         $config = Configuration::getInstance();
-        $storeType = $config->getString('store.type', 'phpsession');
+        $storeType = $config->getOptionalString('store.type', 'phpsession');
 
         /** @var false $store */
         $store = StoreFactory::getInstance($storeType);
@@ -66,7 +66,7 @@ class StoreFactoryTest extends TestCase
     public function memcacheStore(): void
     {
         Configuration::loadFromArray([
-            'store.type'                    => 'memcache',
+            'store.type' => 'memcache',
         ], '[ARRAY]', 'simplesaml');
 
         $config = Configuration::getInstance();
@@ -166,7 +166,7 @@ class StoreFactoryTest extends TestCase
     protected function tearDown(): void
     {
         $config = Configuration::getInstance();
-        $storeType = $config->getString('store.type', 'phpsession');
+        $storeType = $config->getOptionalString('store.type', 'phpsession');
 
         /** @var \SimpleSAML\Store\StoreInterface $store */
         $store = StoreFactory::getInstance($storeType);

--- a/tests/modules/saml/lib/IdP/SQLNameIDTest.php
+++ b/tests/modules/saml/lib/IdP/SQLNameIDTest.php
@@ -86,15 +86,15 @@ class SQLNameIDTest extends TestCase
     {
         $config = [
             'database.dsn'         => 'sqlite::memory:',
-            'database.username'    => null,
-            'database.password'    => null,
+            'database.username'    => '',
+            'database.password'    => '',
             'database.prefix'      => 'phpunit_',
             'database.persistent'  => true,
             'database.secondaries' => [
                 [
                     'dsn'      => 'sqlite::memory:',
-                    'username' => null,
-                    'password' => null,
+                    'username' => '',
+                    'password' => '',
                 ],
             ],
         ];

--- a/tests/modules/saml/lib/IdP/SQLNameIDTest.php
+++ b/tests/modules/saml/lib/IdP/SQLNameIDTest.php
@@ -86,15 +86,15 @@ class SQLNameIDTest extends TestCase
     {
         $config = [
             'database.dsn'         => 'sqlite::memory:',
-            'database.username'    => '',
-            'database.password'    => '',
+            'database.username'    => null,
+            'database.password'    => null,
             'database.prefix'      => 'phpunit_',
             'database.persistent'  => true,
             'database.secondaries' => [
                 [
                     'dsn'      => 'sqlite::memory:',
-                    'username' => '',
-                    'password' => '',
+                    'username' => null,
+                    'password' => null,
                 ],
             ],
         ];

--- a/www/errorreport.php
+++ b/www/errorreport.php
@@ -48,7 +48,7 @@ $data['version'] = $config->getVersion();
 $data['hostname'] = php_uname('n');
 $data['directory'] = dirname(dirname(__FILE__));
 
-if ($config->getBoolean('errorreporting', true)) {
+if ($config->getOptionalBoolean('errorreporting', true)) {
     $mail = new SimpleSAML\Utils\EMail('SimpleSAMLphp error report from ' . $email);
     $mail->setData($data);
     if ($email) {

--- a/www/index.php
+++ b/www/index.php
@@ -5,5 +5,5 @@ require_once('_include.php');
 $config = \SimpleSAML\Configuration::getInstance();
 $httpUtils = new \SimpleSAML\Utils\HTTP();
 
-$redirect = $config->getString('frontpage.redirect', SimpleSAML\Module::getModuleURL('core/welcome'));
+$redirect = $config->getOptionalString('frontpage.redirect', SimpleSAML\Module::getModuleURL('core/welcome'));
 $httpUtils->redirectTrustedURL($redirect);

--- a/www/saml2/idp/ArtifactResolutionService.php
+++ b/www/saml2/idp/ArtifactResolutionService.php
@@ -35,7 +35,7 @@ if (!$idpMetadata->getOptionalBoolean('saml20.sendartifact', false)) {
     throw new Error\Error('NOACCESS');
 }
 
-$storeType = $config->getString('store.type', 'phpsession');
+$storeType = $config->getOptionalString('store.type', 'phpsession');
 $store = StoreFactory::getInstance($storeType);
 if ($store === false) {
     throw new Exception('Unable to send artifact without a datastore configured.');

--- a/www/saml2/idp/ArtifactResolutionService.php
+++ b/www/saml2/idp/ArtifactResolutionService.php
@@ -23,7 +23,7 @@ use SimpleSAML\Metadata;
 use SimpleSAML\Store\StoreFactory;
 
 $config = Configuration::getInstance();
-if (!$config->getBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
+if (!$config->getOptionalBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
     throw new Error\Error('NOACCESS', null, 403);
 }
 
@@ -31,7 +31,7 @@ $metadata = Metadata\MetaDataStorageHandler::getMetadataHandler();
 $idpEntityId = $metadata->getMetaDataCurrentEntityID('saml20-idp-hosted');
 $idpMetadata = $metadata->getMetaDataConfig($idpEntityId, 'saml20-idp-hosted');
 
-if (!$idpMetadata->getBoolean('saml20.sendartifact', false)) {
+if (!$idpMetadata->getOptionalBoolean('saml20.sendartifact', false)) {
     throw new Error\Error('NOACCESS');
 }
 

--- a/www/saml2/idp/SSOService.php
+++ b/www/saml2/idp/SSOService.php
@@ -22,7 +22,7 @@ use SimpleSAML\Module;
 Logger::info('SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService');
 
 $config = Configuration::getInstance();
-if (!$config->getBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
+if (!$config->getOptionalBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
     throw new Error\Error('NOACCESS', null, 403);
 }
 

--- a/www/saml2/idp/SingleLogoutService.php
+++ b/www/saml2/idp/SingleLogoutService.php
@@ -22,7 +22,7 @@ use SimpleSAML\Utils;
 Logger::info('SAML2.0 - IdP.SingleLogoutService: Accessing SAML 2.0 IdP endpoint SingleLogoutService');
 
 $config = Configuration::getInstance();
-if (!$config->getBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
+if (!$config->getOptionalBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
     throw new Error\Error('NOACCESS', null, 403);
 }
 

--- a/www/saml2/idp/initSLO.php
+++ b/www/saml2/idp/initSLO.php
@@ -14,7 +14,7 @@ use SimpleSAML\Utils;
 Logger::info('SAML2.0 - IdP.initSLO: Accessing SAML 2.0 IdP endpoint init Single Logout');
 
 $config = Configuration::getInstance();
-if (!$config->getBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
+if (!$config->getOptionalBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
     throw new Error\Error('NOACCESS', null, 403);
 }
 

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -9,12 +9,12 @@ use SimpleSAML\Module\saml\IdP\SAML2 as SAML2_IdP;
 use SimpleSAML\Utils;
 
 $config = Configuration::getInstance();
-if (!$config->getBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
+if (!$config->getOptionalBoolean('enable.saml20-idp', false) || !Module::isModuleEnabled('saml')) {
     throw new Error\Error('NOACCESS', null, 403);
 }
 
 // check if valid local session exists
-if ($config->getBoolean('admin.protectmetadata', false)) {
+if ($config->getOptionalBoolean('admin.protectmetadata', false)) {
     $authUtils = new Utils\Auth();
     $authUtils->requireAdmin();
 }


### PR DESCRIPTION
The current getters are too loosely typed and can return virtually anything as a default value.
This PR changes this and makes the signatures as strict as we possibly can;  The value must exist and the return-type is guaranteed to be of the expected type.
Additionally we're adding a getOptional* variant that returns null or the expected type. The 'default' parameter will no longer be optional here. It should be much clearer that when using getOptional*, you must check the return-value for a possible null-case. This also helps static analysis tools; Psalm is able to detect +4% of the var-types.