### PR TITLE
AttributeAlter:  Add option to merge target attribute values

### DIFF
--- a/modules/core/docs/authproc_attributealter.md
+++ b/modules/core/docs/authproc_attributealter.md
@@ -39,10 +39,10 @@ Parameters
     If no other values exist, the attribute will be removed completely.
     This parameter is OPTIONAL.
 
-`merge`
-:   A boolean indicating whether the altered values must be merged with the
-    target attribute values, or if the target attribute should be overwritten.
-    Defaults to `false`.
+`%merge`
+:   Indicates whether the altered values must be merged with the target attribute values. The default
+    behaviour is to overwrite the target attribute completely.
+    This parameter is OPTIONAL.
     
 Examples
 --------

--- a/modules/core/docs/authproc_attributealter.md
+++ b/modules/core/docs/authproc_attributealter.md
@@ -38,6 +38,11 @@ Parameters
 :   Indicates that the whole value of the attribute should be removed completely if there is a match.
     If no other values exist, the attribute will be removed completely.
     This parameter is OPTIONAL.
+
+`merge`
+:   A boolean indicating whether the altered values must be merged with the
+    target attribute values, or if the target attribute should be overwritten.
+    Defaults to `false`.
     
 Examples
 --------

--- a/modules/core/lib/Auth/Process/AttributeAlter.php
+++ b/modules/core/lib/Auth/Process/AttributeAlter.php
@@ -165,7 +165,10 @@ class AttributeAlter extends Auth\ProcessingFilter
                     if ($this->subject === $this->target) {
                         $value = $new_value;
                     } else if ($this->merge === true) {
-                        $attributes[$this->target][$value] = $new_value;
+                        $attributes[$this->target] = array_values(
+                            array_diff($attributes[$this->target], [$value])
+                        );
+                        $attributes[$this->target][] = $new_value;
                     } else {
                         $attributes[$this->target] = [$new_value];
                     }

--- a/modules/core/lib/Auth/Process/AttributeAlter.php
+++ b/modules/core/lib/Auth/Process/AttributeAlter.php
@@ -79,6 +79,8 @@ class AttributeAlter extends Auth\ProcessingFilter
                     $this->replace = true;
                 } elseif ($value === '%remove') {
                     $this->remove = true;
+                } elseif ($value === '%merge') {
+                    $this->merge = true;
                 } else {
                     throw new Error\Exception('Unknown flag : ' . var_export($value, true));
                 }
@@ -95,9 +97,6 @@ class AttributeAlter extends Auth\ProcessingFilter
             } elseif ($name === 'target') {
                 // Set target
                 $this->target = $value;
-            } elseif ($name === 'merge') {
-                // Set the  merging strategy
-                $this->merge = $value;
             }
         }
     }

--- a/tests/modules/core/lib/Auth/Process/AttributeAlterTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeAlterTest.php
@@ -82,6 +82,34 @@ class AttributeAlterTest extends TestCase
 
 
     /**
+     * Test the most basic functionality with merging strategy.
+     */
+    public function testMergeWithTarget(): void
+    {
+        $config = [
+            'subject' => 'test',
+            'target' => 'test2',
+            'pattern' => '/wrong/',
+            'replacement' => 'right',
+            '%merge'
+        ];
+
+        $request = [
+            'Attributes' => [
+                 'test' => ['wrong'],
+                 'test2' => ['somethingelse'],
+             ],
+        ];
+
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey('test2', $attributes);
+        $this->assertEquals($attributes['test'], ['wrong']);
+        $this->assertEquals($attributes['test2'], ['right', 'somethingelse']);
+    }
+
+
+    /**
      * Module is a no op if subject attribute is not present.
      */
     public function testNomatch(): void
@@ -152,6 +180,31 @@ class AttributeAlterTest extends TestCase
         $result = self::processFilter($config, $request);
         $attributes = $result['Attributes'];
         $this->assertEquals($attributes['test'], ['right']);
+    }
+
+
+    /**
+     * Test replacing attribute value with merging strategy.
+     */
+    public function testReplaceMergeMatchWithTarget(): void
+    {
+        $config = [
+            'subject' => 'source',
+            'pattern' => '/wrong/',
+            'replacement' => 'right',
+            'target' => 'test',
+            '%replace',
+            '%merge',
+        ];
+        $request = [
+            'Attributes' => [
+                'source' => ['wrong'],
+                'test'   => ['wrong', 'somethingelse'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertEquals($attributes['test'], ['somethingelse', 'right']);
     }
 
 


### PR DESCRIPTION
Use case for this would be to run two consecutive AttributeAlter filters using different source attributes, but the same target-attribute. It is implemented in a backwards compatible way, however, I feel that merging would be the logical default.