### PR TITLE
Instruct embedded IE to behave like the most modern browser they can

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -4,6 +4,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <title>{{ pagetitle }}</title>
     <link rel="stylesheet" href="{{ asset("css/stylesheet.css") }}">
     <link rel="icon" href="{{ asset("icons/favicon.ico") }}">


### PR DESCRIPTION
This should prevent issues with e.g. Javascript when using SSP to log into MS applications via their embedded browsers. WIth this setting it should be maximally modern.