### PR TITLE
add Accept HTTP headers to MDQ queries

### DIFF
--- a/lib/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/lib/SimpleSAML/Metadata/Sources/MDQ.php
@@ -287,8 +287,13 @@ class MDQ extends MetaDataStorageSource
 
         Logger::debug(sprintf('%s: downloading metadata for "%s" from [%s]', __CLASS__, $entityId, $mdq_url));
         $httpUtils = new Utils\HTTP();
+        $context = [
+            'http' => [
+                'header' => 'Accept: application/samlmetadata+xml'
+            ]
+        ];
         try {
-            $xmldata = $httpUtils->fetch($mdq_url);
+            $xmldata = $httpUtils->fetch($mdq_url, $context);
         } catch (Exception $e) {
             // Avoid propagating the exception, make sure we can handle the error later
             $xmldata = false;


### PR DESCRIPTION
According to my understanding of the MDQ RFC, the Accept HTTP header is mandatory:

All metadata query requests MUST include the following HTTP headers:

      Accept - this header MUST contain the content-type identifying the
      type, or form, of metadata to be retrieved.  See section 5.3.2 of
      [RFC7231].