### PR TITLE
Feature: generic templating / emailing

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -96,6 +96,7 @@ $config = [
     //     'username' => 'user@example.org', // optional: if set, enables smtp authentication
     //     'password' => 'password', // optional: if set, enables smtp authentication
     //     'security' => 'tls', // optional: defaults to no smtp security
+    //     'smtpOptions' => [], // optional: passed to stream_context_create when connecting via SMTP
     // ],
     // // sendmail mail transport options
     // 'mail.transport.options' => [

--- a/lib/SimpleSAML/Utils/EMail.php
+++ b/lib/SimpleSAML/Utils/EMail.php
@@ -28,6 +28,12 @@ class EMail
     /** @var \PHPMailer\PHPMailer\PHPMailer The mailer instance */
     private PHPMailer $mail;
 
+    /** @var string $txt_template;
+    private string $txt_template;
+
+    /** @var string $html_template;
+    private string $html_template;
+
 
     /**
      * Constructor
@@ -38,15 +44,25 @@ class EMail
      * @param string $subject The subject of the e-mail
      * @param string $from The from-address (both envelope and header)
      * @param string $to The recipient
+     * @param string $txt_template The template to use for plain text messages
+     * @param string $html_template The template to use for html messages
      *
      * @throws \PHPMailer\PHPMailer\Exception
      */
-    public function __construct(string $subject, string $from = null, string $to = null)
-    {
+    public function __construct(
+        string $subject,
+        string $from = null,
+        string $to = null,
+        string $txt_template = 'mailtxt.twig',
+        string $html_template = 'mailhtml.twig'
+    ) {
         $this->mail = new PHPMailer(true);
         $this->mail->Subject = $subject;
         $this->mail->setFrom($from ?: $this->getDefaultMailAddress());
         $this->mail->addAddress($to ?: $this->getDefaultMailAddress());
+
+        $this->txt_template = $txt_template;
+        $this->html_template = $html_template;
 
         $this->initFromConfig($this);
     }
@@ -132,11 +148,11 @@ class EMail
     {
         if ($plainTextOnly) {
             $this->mail->isHTML(false);
-            $this->mail->Body = $this->generateBody('mailtxt.twig');
+            $this->mail->Body = $this->generateBody($this->txt_template);
         } else {
             $this->mail->isHTML(true);
-            $this->mail->Body = $this->generateBody('mailhtml.twig');
-            $this->mail->AltBody = $this->generateBody('mailtxt.twig');
+            $this->mail->Body = $this->generateBody($this->html_template);
+            $this->mail->AltBody = $this->generateBody($this->txt_template);
         }
 
         $this->mail->send();

--- a/lib/SimpleSAML/Utils/EMail.php
+++ b/lib/SimpleSAML/Utils/EMail.php
@@ -248,11 +248,10 @@ class EMail
         $config = Configuration::getInstance();
 
         $t = new Template($config, $template);
-        $result = $t->getTwig()->render($template, [
-            'subject' => $this->mail->Subject,
-            'text' => $this->text,
-            'data' => $this->data
-        ]);
-        return $result;
+        $t->data['data'] = $this->data;
+        $t->data['subject'] = $this->mail->Subject;
+        $t->data['text'] = $this->text;
+
+        return $t->getContents();
     }
 }

--- a/lib/SimpleSAML/Utils/EMail.php
+++ b/lib/SimpleSAML/Utils/EMail.php
@@ -211,6 +211,11 @@ class EMail
                 if (isset($transportOptions['autotls'])) {
                     $this->mail->SMTPAutoTLS = (bool)$transportOptions['autotls'];
                 }
+
+                // socket options for smtp TLS connection
+                if (isset($transportOptions['smtpOptions'])) {
+                    $this->mail->SMTPOptions = $transportOptions['smtpOptions'];
+                }
                 break;
             //mail transport method
             case 'mail':

--- a/lib/SimpleSAML/Utils/EMail.php
+++ b/lib/SimpleSAML/Utils/EMail.php
@@ -28,10 +28,10 @@ class EMail
     /** @var \PHPMailer\PHPMailer\PHPMailer The mailer instance */
     private PHPMailer $mail;
 
-    /** @var string $txt_template;
+    /** @var string */
     private string $txt_template;
 
-    /** @var string $html_template;
+    /** @var string */
     private string $html_template;
 
 

--- a/lib/SimpleSAML/XHTML/Template.php
+++ b/lib/SimpleSAML/XHTML/Template.php
@@ -540,12 +540,14 @@ class Template extends Response
      * @return string The HTML rendered by this template, as a string.
      * @throws \Exception if the template cannot be found.
      */
-    protected function getContents(): string
+    public function getContents(): string
     {
         $this->twigDefaultContext();
+
         if ($this->controller) {
             $this->controller->display($this->data);
         }
+
         try {
             return $this->twig->render($this->twig_template, $this->data);
         } catch (RuntimeError $e) {


### PR DESCRIPTION
The PR changes the following:
- Exposes Template::getContents, so Twig templates can be used for other things besides showing web pages (i.e. mail templates)
- Change the EMail utility class to use the newly exposed getContents in favour of calling `render()` on the Twig environment. This will make it possible to use templates provided by modules.
- Change the Email utility class constructor so custom templates can be passed.

These changes should not affect backwards compatibility.