### PR TITLE
translation fixes for twig templates

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -14,6 +14,7 @@ Released TBD
   * Fix HTTP status code for error pages (#1585)
   * \SimpleSAML\Utils\HTTP::getFirstPathElement() was marked deprecated
   * Bumped twig and minimist dependencies due to known vulnerabilities (CVE-2022-23614 and CVE-2021-44906)
+  * Minor fixes to the old UI (#1632)
 
 ### saml2 library
   * A mis-use of a constant was fixed (#249) that caused an error with HTTP-Artifact binding.

--- a/modules/core/www/frontpage_federation.php
+++ b/modules/core/www/frontpage_federation.php
@@ -114,26 +114,34 @@ $translators = [
 
 foreach ($metaentries['hosted'] as $index => $entity) {
     foreach ($translators as $old => $new) {
-        if (isset($entity[$old][$language])) {
-            $metaentries['hosted'][$index][$new] = $entity[$old][$language];
-        } elseif (isset($entity[$old][$defaultLanguage])) {
-            $metaentries['hosted'][$index][$new] = $entity[$old][$defaultLanguage];
-        } elseif (isset($entity[$old][$fallbackLanguage])) {
-            $metaentries['hosted'][$index][$new] = $entity[$old][$fallbackLanguage];
+        if (isset($entity[$old])) {
+            if (isset($entity[$old][$language])) {
+                $metaentries['hosted'][$index][$new] = $entity[$old][$language];
+            } elseif (isset($entity[$old][$defaultLanguage])) {
+                $metaentries['hosted'][$index][$new] = $entity[$old][$defaultLanguage];
+            } elseif (isset($entity[$old][$fallbackLanguage])) {
+                $metaentries['hosted'][$index][$new] = $entity[$old][$fallbackLanguage];
+            } elseif (is_array($entity[$old])) {
+                $metaentries['hosted'][$index][$new] = array_values($entity[$old])[0];
+            } else {
+                $metaentries['hosted'][$index][$new] = $entity[$old];
+            }
         }
     }
 }
 foreach ($metaentries['remote'] as $key => $set) {
     foreach ($set as $entityid => $entity) {
         foreach ($translators as $old => $new) {
-            if (isset($entity[$old][$language])) {
-                $metaentries['remote'][$key][$entityid][$new] = $entity[$old][$language];
-            } elseif (isset($entity[$old][$defaultLanguage])) {
-                $metaentries['remote'][$key][$entityid][$new] = $entity[$old][$defaultLanguage];
-            } elseif (isset($entity[$old][$fallbackLanguage])) {
-                $metaentries['remote'][$key][$entityid][$new] = $entity[$old][$fallbackLanguage];
-            } elseif (isset($metaentries['remote'][$key][$entityid][$old])) {
-                $metaentries['remote'][$key][$entityid][$new] = $metaentries['remote'][$key][$entityid][$old];
+            if (isset($entity[$old])) {
+                if (isset($entity[$old][$language])) {
+                    $metaentries['remote'][$key][$entityid][$new] = $entity[$old][$language];
+                } elseif (isset($entity[$old][$defaultLanguage])) {
+                    $metaentries['remote'][$key][$entityid][$new] = $entity[$old][$defaultLanguage];
+                } elseif (isset($entity[$old][$fallbackLanguage])) {
+                    $metaentries['remote'][$key][$entityid][$new] = $entity[$old][$fallbackLanguage];
+                } elseif (isset($metaentries['remote'][$key][$entityid][$old])) {
+                    $metaentries['remote'][$key][$entityid][$new] = $metaentries['remote'][$key][$entityid][$old];
+                }
             }
         }
     }


### PR DESCRIPTION
While it might no longer be needed in the twig-based 2.* version, this is an improvement for the federation-page and translated names that would display as "Array" in the twig-layout of 1.19
