### PR TITLE
Add extra optional header template

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -13,6 +13,7 @@
     {% endif %}
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="{{ asset('js/bundle.js') }}" as="script">
+    {{ include('_head.twig', ignore_missing = true) }}
     {% block preload %}{% endblock %}
   </head>
   <body id="{{ templateId }}">


### PR DESCRIPTION
this allows people to add extra header-lines without needing to override the base.twig template completely by creating _head.twig with their own meta/css/... lines. If the template is missing nothing is added.