### PR TITLE
A couple of mdq cache bugs

### DIFF
--- a/lib/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/lib/SimpleSAML/Metadata/Sources/MDQ.php
@@ -172,6 +172,7 @@ class MDQ extends MetaDataStorageSource
          */
         if (($file->getMtime() + $this->cacheLength) <= time()) {
             Logger::debug(sprintf('%s: cache file older that the cachelength option allows.', __CLASS__));
+            $this->fileSystem->remove($cacheFileName);
             return null;
         }
 

--- a/lib/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/lib/SimpleSAML/Metadata/Sources/MDQ.php
@@ -218,12 +218,11 @@ class MDQ extends MetaDataStorageSource
         }
 
         $cacheFileName = $this->getCacheFilename($set, $entityId);
-        $file = new File($cacheFileName);
 
-        Logger::debug(sprintf('%s: Writing cache [%s] => [%s]', __CLASS__, $entityId, strval($file)));
+        Logger::debug(sprintf('%s: Writing cache [%s] => [%s]', __CLASS__, $entityId, $cacheFileName));
 
         /** @psalm-suppress TooManyArguments */
-        $this->fileSystem->appendToFile(strval($file), serialize($data), true);
+        $this->fileSystem->appendToFile($cacheFileName, serialize($data), true);
     }
 
 


### PR DESCRIPTION
I was getting errors like this while testing the mdq component:

May 23 02:41:48 liblynx simplesamlphp[274543]: 3 [553de61cdc] Error writing MDQ result to cache: The file "/var/simplesamlphp/mdq-cache/sp-check/saml20-idp-remote-a3fb2fc38422855a65925d1cdbf96c1e2f654b22.cached.xml" does not exist

Looking at the code, it seems they were coming from this line:

     $file = new File($cacheFileName);

Per vendor/symfony/http-foundation/File/File.php, the constructor by default raises FileNotFoundException unless the optional second parameter is set to $false. I considered adding that parameter, but it looks like the only thing the File object was used for is to pull out the string filename of the file it was created with? So I just removed the object and used the string directly.

Then if the content of the cache file was stale, it appears that the new fresh content would be appended after the old stale content on the existing file? So I updated the cache check to remove the file if it was stale.

Thanks...