### PR TITLE
Feature: Add auth source selector

### DIFF
--- a/modules/core/docs/authsource_selector.md
+++ b/modules/core/docs/authsource_selector.md
@@ -1,0 +1,56 @@
+# Authentication source selector
+
+The Authentication source selector is a special kind of Authentication Source
+that delegates the actual authentication to a secondary Authentication Source
+based on some form of policy decision.
+
+## AbstractSourceSelector
+
+The AbstractSourceSelector extends from `\SimpleSAML\Auth\Source` and as such
+act as an Authentication Source. Any derivative classes must implement the
+abstract `selectAuthSource` method. This method must return the name of the
+Authentication Source to use, based on whatever logic is necessary.
+
+## IPSourceSelector
+
+The IPSourceSelector is an implementation of the `AbstractSourceSelector` and
+uses the client IP to decide what Authentication Source is called.
+It works by defining zones with corresponding IP-ranges and Authentication
+Sources. The 'default' zone is required and acts as a fallback when none
+of the zones match a client's IP-address.
+
+An example configuration would look like this:
+
+```php
+    'selector' => [
+        'core:IPSourceSelector',
+
+        'zones' => [
+            'internal' => [
+                'source' => 'ldap',
+                'subnet' => [
+                    '10.0.0.0/8',
+                    '2001:0DB8::/108',
+                ],
+            ],
+
+            'other' => [
+                'source' => 'radius',
+                'subnet' => [
+                    '172.16.0.0/12',
+                    '2002:1234::/108',
+                ],
+            ],
+
+            'default' => 'yubikey',
+        ],
+    ],
+```
+
+## YourCustomSourceSelector
+
+If you have a use-case for a custom Authentication source selector, all you
+have to do is to create your own class, make it extend `AbstractSourceSelector`
+and make it implement the abstract `selectAuthSource` method containing
+your own logic. The method should return the name of the Authentication
+source to use.

--- a/modules/core/lib/Auth/Source/AbstractSourceSelector.php
+++ b/modules/core/lib/Auth/Source/AbstractSourceSelector.php
@@ -65,7 +65,7 @@ abstract class AbstractSourceSelector extends Auth\Source
             throw new Exception('Invalid authentication source: ' . $source);
         }
 
-        new RunnableResponse([static::class, 'doAuthentication'], [$as, $state]);
+        static::doAuthentication($as, $state);
     }
 
 

--- a/modules/core/lib/Auth/Source/AbstractSourceSelector.php
+++ b/modules/core/lib/Auth/Source/AbstractSourceSelector.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\core\Auth\Source;
+
+use Exception;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Auth;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error;
+use SimpleSAML\HTTP\RunnableResponse;
+use SimpleSAML\Session;
+
+/**
+ * Authentication source which delegates authentication to secondary
+ * authentication sources based on policy decision
+ *
+ * @package SimpleSAMLphp
+ */
+abstract class AbstractSourceSelector extends Auth\Source
+{
+    /**
+     * @var array  The names of all the configured auth sources
+     */
+    protected array $validSources;
+
+
+    /**
+     * Constructor for this authentication source.
+     *
+     * @param array $info Information about this authentication source.
+     * @param array $config Configuration.
+     */
+    public function __construct(array $info, array $config)
+    {
+        // Call the parent constructor first, as required by the interface
+        parent::__construct($info, $config);
+
+        $authsources = Configuration::getConfig('authsources.php');
+        $this->validSources = array_keys($authsources->toArray());
+    }
+
+
+    /**
+     * Process a request.
+     *
+     * If an authentication source returns from this function, it is assumed to have
+     * authenticated the user, and should have set elements in $state with the attributes
+     * of the user.
+     *
+     * If the authentication process requires additional steps which make it impossible to
+     * complete before returning from this function, the authentication source should
+     * save the state, and at a later stage, load the state, update it with the authentication
+     * information about the user, and call completeAuth with the state array.
+     *
+     * @param array &$state Information about the current authentication.
+     */
+    public function authenticate(array &$state): void
+    {
+        $source = $this->selectAuthSource();
+        $as = Auth\Source::getById($source);
+
+        if ($as === null || !in_array($source, $this->validSources, true)) {
+            throw new Exception('Invalid authentication source: ' . $source);
+        }
+
+        new RunnableResponse([self::class, 'doAuthentication'], [$as, $state]);
+    }
+
+
+    /**
+     * @param \SimpleSAML\Auth\Source $as
+     * @param array $state
+     * @return void
+     */
+    public static function doAuthentication(Auth\Source $as, array $state): void
+    {
+        try {
+            $as->authenticate($state);
+        } catch (Error\Exception $e) {
+            Auth\State::throwException($state, $e);
+        } catch (Exception $e) {
+            $e = new Error\UnserializableException($e);
+            Auth\State::throwException($state, $e);
+        }
+
+        Auth\Source::completeAuth($state);
+    }
+
+
+    /**
+     * Decide what authsource to use.
+     *
+     * @param array &$state Information about the current authentication.
+     * @return string
+     */
+    abstract protected function selectAuthSource(): string;
+}

--- a/modules/core/lib/Auth/Source/AbstractSourceSelector.php
+++ b/modules/core/lib/Auth/Source/AbstractSourceSelector.php
@@ -65,7 +65,7 @@ abstract class AbstractSourceSelector extends Auth\Source
             throw new Exception('Invalid authentication source: ' . $source);
         }
 
-        new RunnableResponse([self::class, 'doAuthentication'], [$as, $state]);
+        new RunnableResponse([static::class, 'doAuthentication'], [$as, $state]);
     }
 
 

--- a/modules/core/lib/Auth/Source/IPSourceSelector.php
+++ b/modules/core/lib/Auth/Source/IPSourceSelector.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\core\Auth\Source;
+
+use Exception;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Auth;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error;
+use SimpleSAML\HTTP\RunnableResponse;
+use SimpleSAML\Session;
+use SimpleSAML\Utils;
+
+/**
+ * Authentication source which delegates authentication to secondary
+ * authentication sources based on the client's source IP
+ *
+ * @package simplesamlphp/simplesamlphp
+ */
+class IPSourceSelector extends AbstractSourceSelector
+{
+    /**
+     * The key of the AuthId field in the state.
+     */
+    public const AUTHID = '\SimpleSAML\Module\core\Auth\Source\IPSourceSelector.AuthId';
+
+    /**
+     * The string used to identify our states.
+     */
+    public const STAGEID = '\SimpleSAML\Module\core\Auth\Source\IPSourceSelector.StageId';
+
+    /**
+     * The key where the sources is saved in the state.
+     */
+    public const SOURCESID = '\SimpleSAML\Module\core\Auth\Source\IPSourceSelector.SourceId';
+
+    /**
+     * @param string  The name of the primary authsource
+     */
+    protected string $primarySource;
+
+    /**
+     * @param string  The name of the secondary authsource
+     */
+    protected string $secondarySource;
+
+    /**
+     * @param array  The IP-ranges (CIDR notation) for the primary authsource
+     */
+    protected array $ipRanges;
+
+
+    /**
+     * Constructor for this authentication source.
+     *
+     * @param array $info Information about this authentication source.
+     * @param array $config Configuration.
+     */
+    public function __construct(array $info, array $config)
+    {
+        // Call the parent constructor first, as required by the interface
+        parent::__construct($info, $config);
+
+        Assert::keyExists($config, 'primarySource');
+        Assert::stringNotEmpty($config['primarySource']);
+        $this->primarySource = $config['primarySource'];
+
+        Assert::keyExists($config, 'secondarySource');
+        Assert::stringNotEmpty($config['secondarySource']);
+        $this->secondarySource = $config['secondarySource'];
+
+        Assert::keyExists($config, 'secondarySourceRanges');
+        $this->ipRanges = $config['secondarySourceRanges'];
+    }
+
+
+    /**
+     * Decide what authsource to use.
+     *
+     * @param array &$state Information about the current authentication.
+     * @return string
+     */
+    protected function selectAuthSource(): string
+    {
+        $netUtils = new Utils\Net();
+
+        foreach ($this->ipRanges as $range) {
+            if ($netUtils->ipCIDRcheck($range)) {
+                // Client's IP is in one of the ranges for the secondary auth source
+                return $this->secondarySource;
+            }
+        }
+
+        return $this->primarySource;
+    }
+}

--- a/modules/core/lib/Auth/Source/IPSourceSelector.php
+++ b/modules/core/lib/Auth/Source/IPSourceSelector.php
@@ -10,6 +10,7 @@ use SimpleSAML\Auth;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error;
 use SimpleSAML\HTTP\RunnableResponse;
+use SimpleSAML\Logger;
 use SimpleSAML\Session;
 use SimpleSAML\Utils;
 
@@ -86,13 +87,17 @@ class IPSourceSelector extends AbstractSourceSelector
     {
         $netUtils = new Utils\Net();
 
+        $ip = $_SERVER['REMOTE_ADDR'];
+        $source = $this->primarySource;
         foreach ($this->ipRanges as $range) {
-            if ($netUtils->ipCIDRcheck($range)) {
+            if ($netUtils->ipCIDRcheck($range, $ip)) {
                 // Client's IP is in one of the ranges for the secondary auth source
-                return $this->secondarySource;
+                $source = $this->secondarySource;
+                break;
             }
         }
 
-        return $this->primarySource;
+        Logger::info(sprintf("core:IPSourceSelector:  Selecting authsource `%s` based on client IP %s", $source, $ip));
+        return $source;
     }
 }

--- a/tests/modules/core/lib/Auth/Source/IPSourceSelectorTest.php
+++ b/tests/modules/core/lib/Auth/Source/IPSourceSelectorTest.php
@@ -41,10 +41,15 @@ class IPSourceSelectorTest extends TestCase
             'selector' => [
                 'core:IPSourceSelector',
 
-                'primarySource' => 'external',
-                'secondarySource' => 'internal',
-                'secondarySourceRanges' => [
-                    '10.0.0.0/8',
+                'zones' => [
+                    'internal' => [
+                        'source' => 'internal',
+                        'subnet' => [
+                            '10.0.0.0/8',
+                        ],
+                    ],
+
+                    'default' => 'external',
                 ],
             ],
 
@@ -62,59 +67,18 @@ class IPSourceSelectorTest extends TestCase
 
     /**
      */
-    public function testPrimarySourceIsRequired(): void
+    public function testDefaultZoneIsRequired(): void
     {
         $this->expectException(AssertionFailedException::class);
-        $this->expectExceptionMessage('Expected the key "primarySource" to exist.');
+        $this->expectExceptionMessage('Expected the key "default" to exist.');
 
         $sourceConfig = Configuration::loadFromArray([
             'selector' => [
                 'core:IPSourceSelector',
 
-                'secondarySource' => 'internal',
-                'secondarySourceRanges' => [],
-            ],
-        ]);
-        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
-
-        new IPSourceSelector(['AuthId' => 'selector'], $sourceConfig->getArray('selector'));
-    }
-
-
-    /**
-     */
-    public function testSecondarySourceIsRequired(): void
-    {
-        $this->expectException(AssertionFailedException::class);
-        $this->expectExceptionMessage('Expected the key "secondarySource" to exist.');
-
-        $sourceConfig = Configuration::loadFromArray([
-            'selector' => [
-                'core:IPSourceSelector',
-
-                'primarySource' => 'internal',
-                'secondarySourceRanges' => [],
-            ],
-        ]);
-        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
-
-        new IPSourceSelector(['AuthId' => 'selector'], $sourceConfig->getArray('selector'));
-    }
-
-
-    /**
-     */
-    public function testSecondarySourceRangesIsRequired(): void
-    {
-        $this->expectException(AssertionFailedException::class);
-        $this->expectExceptionMessage('Expected the key "secondarySourceRanges" to exist.');
-
-        $sourceConfig = Configuration::loadFromArray([
-            'selector' => [
-                'core:IPSourceSelector',
-
-                'primarySource' => 'internal',
-                'secondarySource' => 'internal',
+                'zones' => [
+                    'internal' => [],
+                ],
             ],
         ]);
         Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');

--- a/tests/modules/core/lib/Auth/Source/IPSourceSelectorTest.php
+++ b/tests/modules/core/lib/Auth/Source/IPSourceSelectorTest.php
@@ -46,11 +46,24 @@ class IPSourceSelectorTest extends TestCase
                         'source' => 'internal',
                         'subnet' => [
                             '10.0.0.0/8',
+                            '2001:0DB8::/108',
+                        ],
+                    ],
+
+                    'other' => [
+                        'source' => 'other',
+                        'subnet' => [
+                            '172.16.0.0/12',
+                            '2002:1234::/108',
                         ],
                     ],
 
                     'default' => 'external',
                 ],
+            ],
+
+            'other' => [
+                'core:AdminPassword',
             ],
 
             'internal' => [
@@ -150,7 +163,10 @@ class IPSourceSelectorTest extends TestCase
         return [
             ['127.0.0.2', 'external'],
             ['10.4.13.2', 'internal'],
+            ['2001:0DB8:0000:0000:0000:0000:0000:0000', 'internal'],
             ['145.21.93.97', 'external'],
+            ['172.16.1.2', 'other'],
+            ['2002:1234:0000:0000:0000:0000:0000:0000', 'other'],
         ];
     }
 }

--- a/tests/modules/core/lib/Auth/Source/IPSourceSelectorTest.php
+++ b/tests/modules/core/lib/Auth/Source/IPSourceSelectorTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\Module\core\Auth\Source;
+
+use Error;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Assert\AssertionFailedException;
+use SimpleSAML\Auth;
+use SimpleSAML\Configuration;
+use SimpleSAML\HTTP\RunnableResponse;
+use SimpleSAML\Module\core\Auth\Source\IPSourceSelector;
+
+/**
+ * @covers \SimpleSAML\Module\core\Auth\Source\AbstractSourceSelector
+ * @covers \SimpleSAML\Module\core\Auth\Source\IPSourceSelector
+ */
+class IPSourceSelectorTest extends TestCase
+{
+    /** @var \SimpleSAML\Configuration */
+    private Configuration $config;
+
+    /** @var \SimpleSAML\Configuration */
+    private Configuration $sourceConfig;
+
+
+    /**
+     */
+    public function setUp(): void
+    {
+        $this->config = Configuration::loadFromArray(
+            ['module.enable' => ['core' => true]],
+            '[ARRAY]',
+            'simplesaml'
+        );
+        Configuration::setPreLoadedConfig($this->config, 'config.php');
+
+        $this->sourceConfig = Configuration::loadFromArray([
+            'selector' => [
+                'core:IPSourceSelector',
+
+                'primarySource' => 'external',
+                'secondarySource' => 'internal',
+                'secondarySourceRanges' => [
+                    '10.0.0.0/8',
+                ],
+            ],
+
+            'internal' => [
+                'core:AdminPassword',
+            ],
+
+            'external' => [
+                'core:AdminPassword',
+            ],
+        ]);
+        Configuration::setPreLoadedConfig($this->sourceConfig, 'authsources.php');
+    }
+
+
+    /**
+     */
+    public function testPrimarySourceIsRequired(): void
+    {
+        $this->expectException(AssertionFailedException::class);
+        $this->expectExceptionMessage('Expected the key "primarySource" to exist.');
+
+        $sourceConfig = Configuration::loadFromArray([
+            'selector' => [
+                'core:IPSourceSelector',
+
+                'secondarySource' => 'internal',
+                'secondarySourceRanges' => [],
+            ],
+        ]);
+        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
+
+        new IPSourceSelector(['AuthId' => 'selector'], $sourceConfig->getArray('selector'));
+    }
+
+
+    /**
+     */
+    public function testSecondarySourceIsRequired(): void
+    {
+        $this->expectException(AssertionFailedException::class);
+        $this->expectExceptionMessage('Expected the key "secondarySource" to exist.');
+
+        $sourceConfig = Configuration::loadFromArray([
+            'selector' => [
+                'core:IPSourceSelector',
+
+                'primarySource' => 'internal',
+                'secondarySourceRanges' => [],
+            ],
+        ]);
+        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
+
+        new IPSourceSelector(['AuthId' => 'selector'], $sourceConfig->getArray('selector'));
+    }
+
+
+    /**
+     */
+    public function testSecondarySourceRangesIsRequired(): void
+    {
+        $this->expectException(AssertionFailedException::class);
+        $this->expectExceptionMessage('Expected the key "secondarySourceRanges" to exist.');
+
+        $sourceConfig = Configuration::loadFromArray([
+            'selector' => [
+                'core:IPSourceSelector',
+
+                'primarySource' => 'internal',
+                'secondarySource' => 'internal',
+            ],
+        ]);
+        Configuration::setPreLoadedConfig($sourceConfig, 'authsources.php');
+
+        new IPSourceSelector(['AuthId' => 'selector'], $sourceConfig->getArray('selector'));
+    }
+
+
+    /**
+     */
+    public function testAuthentication(): void
+    {
+        $info = ['AuthId' => 'selector'];
+        $config = $this->sourceConfig->getArray('selector');
+
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['REQUEST_URI'] = '/';
+
+        $selector = new class ($info, $config) extends IPSourceSelector {
+            /**
+             * @param \SimpleSAML\Auth\Source $as
+             * @param array $state
+             * @return void
+             */
+            public static function doAuthentication(Auth\Source $as, array $state): void
+            {
+                // Dummy
+            }
+        };
+
+        $state = [];
+        $result = $selector->authenticate($state);
+        $this->assertNull($result);
+    }
+
+
+    /**
+     * @dataProvider provideClientIP
+     * @param string $ip  The client IP
+     * @param string $expected  The expected authsource
+     */
+    public function testSelectAuthSource(string $ip, string $expected): void
+    {
+        $info = ['AuthId' => 'selector'];
+        $config = $this->sourceConfig->getArray('selector');
+
+        $_SERVER['REMOTE_ADDR'] = $ip;
+
+        $selector = new class ($info, $config) extends IPSourceSelector {
+            /**
+             * @return string
+             */
+            public function selectAuthSource(): string
+            {
+                return parent::selectAuthSource();
+            }
+        };
+
+        $source = $selector->selectAuthSource();
+        $this->assertEquals($expected, $source);
+    }
+
+
+    /**
+     * @return string
+     */
+    public function provideClientIP(): array
+    {
+        return [
+            ['127.0.0.2', 'external'],
+            ['10.4.13.2', 'internal'],
+            ['145.21.93.97', 'external'],
+        ];
+    }
+}


### PR DESCRIPTION
The PR introduces a new AbstractSourceSelector that can be used to delegate authentication to secondary auth sources based on a policy decision. The first implementation of this is the included IPSourceSelector which picks the secondary auth source based on the user's IP address (i.e. internal or external client).