### PR TITLE
For PHP8 using Drupal 9

### DIFF
--- a/www/_include.php
+++ b/www/_include.php
@@ -4,7 +4,7 @@
 require_once(dirname(dirname(__FILE__)) . '/lib/_autoload.php');
 
 // enable assertion handler for all pages
-\SimpleSAML\Error\Assertion::installHandler();
+//\SimpleSAML\Error\Assertion::installHandler();
 
 // show error page on unhandled exceptions
 function SimpleSAML_exception_handler($exception)


### PR DESCRIPTION
Fatal error: Uncaught Error: Undefined constant "SimpleSAML\Error\ASSERT_QUIET_EVAL"