### PR TITLE
Refactor scoping code in the SP class

### DIFF
--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -531,13 +531,16 @@ class SP extends \SimpleSAML\Auth\Source
             }
         }
 
-        $IDPList = [];
         $requesterID = [];
 
         /* Only check for real info for Scoping element if we are going to send Scoping element */
         if ($this->disable_scoping !== true && $idpMetadata->getOptionalBoolean('disable_scoping', false) !== true) {
-            if (isset($state['saml:IDPList'])) {
-                $IDPList = $state['saml:IDPList'];
+            if (isset($state['IDPList'])) {
+                $ar->setIDPList($state['IDPList']);
+            } elseif (!empty($this->metadata->getOptionalArray('IDPList', []))) {
+                $ar->setIDPList($this->metadata->getArray('IDPList'));
+            } elseif (!empty($idpMetadata->getOptionalArray('IDPList', []))) {
+                $ar->setIDPList($idpMetadata->getArray('IDPList'));
             }
 
             if (isset($state['saml:ProxyCount']) && $state['saml:ProxyCount'] !== null) {
@@ -559,16 +562,6 @@ class SP extends \SimpleSAML\Auth\Source
         } else {
             Logger::debug('Disabling samlp:Scoping for ' . var_export($idpMetadata->getString('entityid'), true));
         }
-
-        $ar->setIDPList(
-            array_unique(
-                array_merge(
-                    $this->metadata->getOptionalArray('IDPList', []),
-                    $idpMetadata->getOptionalArray('IDPList', []),
-                    (array) $IDPList
-                )
-            )
-        );
 
         $ar->setRequesterID($requesterID);
 

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -468,7 +468,8 @@ class SPTest extends ClearStateTestCase
     }
 
     /**
-     * Test that IDPList with multiple valid idp and no SP config idp results in discovery redirect
+     * Test that adding IDPList to the state (of an AuthRequest)
+     * will result in that IDP being added to the scope
      */
     public function testSPIdpListScoping(): void
     {

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -483,6 +483,44 @@ class SPTest extends ClearStateTestCase
     }
 
     /**
+     * Test that adding IDPList to the idp metadata
+     * will result in that IDP being added to the scope
+     */
+    public function testIdpMetadataScoping(): void
+    {
+        $this->idpConfigArray['IDPList'] = ['https://scope.example.com'];
+        $ar = $this->createAuthnRequest([]);
+
+        $this->assertTrue(
+            in_array('https://scope.example.com', $ar->getIDPList())
+        );
+    }
+
+    /**
+     * Test that adding IDPList to the config
+     * will result in that IDP being added to the scope
+     */
+    public function testRemoteMetadataScoping(): void
+    {
+        $info = ['AuthId' => 'default-sp'];
+        $config = [
+            'IDPList' => ['https://scope.example.com']
+        ];
+        $as = new SpTester($info, $config);
+
+        /** @var \SAML2\AuthnRequest $ar */
+        try {
+            $as->startSSO2Test($this->getIdpMetadata(), []);
+            $this->assertTrue(false, 'Expected ExitTestException');
+        } catch (ExitTestException $e) {
+            ['ar' => $ar] = $e->getTestResult();
+            $this->assertTrue(
+                in_array('https://scope.example.com', $ar->getIDPList())
+            );
+        }
+    }
+
+    /**
      * Test for the hosted metadata generation with a custom entityID
      */
     public function testMetadataHostedSetEntityId(): void

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -530,8 +530,12 @@ class SPTest extends ClearStateTestCase
      * then the idp config array.
      * @dataProvider getScopingOrders
      */
-    public function testSPIdpListScopingOrder(?array $stateIdpList, ?array $idpConfigArray, ?array $remoteMetadata, string $expectedScope): void
-    {
+    public function testSPIdpListScopingOrder(
+        ?array $stateIdpList,
+        ?array $idpConfigArray,
+        ?array $remoteMetadata,
+        string $expectedScope
+    ): void {
         $info = ['AuthId' => 'default-sp'];
         $state = [];
         if (isset($stateIdpList)) {

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -468,6 +468,20 @@ class SPTest extends ClearStateTestCase
     }
 
     /**
+     * Test that IDPList with multiple valid idp and no SP config idp results in discovery redirect
+     */
+    public function testSPIdpListScoping(): void
+    {
+        $ar = $this->createAuthnRequest([
+            'IDPList' => ['https://scope.example.com']
+        ]);
+
+        $this->assertTrue(
+            in_array('https://scope.example.com', $ar->getIDPList())
+        );
+    }
+
+    /**
      * Test for the hosted metadata generation with a custom entityID
      */
     public function testMetadataHostedSetEntityId(): void


### PR DESCRIPTION
Make sure the `saml:IDPList` and `IDPList` parameters are not overloaded. From now on, saml:IDPList is being used when SSP is used as a proxy while the IDPList parameter is used when SSP is used as in SP-mode and you want to apply scoping to your AuthnRequest.

See https://github.com/simplesamlphp/simplesamlphp/pull/1563 and  for the full explanation of the changes.

Solves https://github.com/simplesamlphp/simplesamlphp/issues/1562