### PR TITLE
Add symlink for the _autoload_modules file

### DIFF
--- a/lib/_autoload_modules.php
+++ b/lib/_autoload_modules.php
@@ -1,0 +1,1 @@
+../src/_autoload_modules.php


### PR DESCRIPTION
A symlink was recently added for the traditional `_autoload.php` file, but the link to `_autoload_modules.php` was still missing. This was needed to get the modules working properly.