### PR TITLE
Fix NameID generation

### DIFF
--- a/docs/simplesamlphp-googleapps.md
+++ b/docs/simplesamlphp-googleapps.md
@@ -154,13 +154,19 @@ In the `saml20-sp-remote.php` file we will configure an entry for Google Workspa
        * This example shows an example config that works with Google Workspace (G Suite / Google Apps) for education.
        * What is important is that you have an attribute in your IdP that maps to the local part of the email address
        * at Google Workspace. E.g. if your google account is foo.com, and you have a user with email john@foo.com, then you
-       * must set the simplesaml.nameidattribute to be the name of an attribute that for this user has the value of 'john'.
+       * must properly configure the saml:AttributeNameID authproc-filter with the name of an attribute that for this user has the value of 'john'.
        */
       $metadata['https://www.google.com/a/g.feide.no'] => [
         'AssertionConsumerService'   => 'https://www.google.com/a/g.feide.no/acs', 
         'NameIDFormat'               => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
-        'simplesaml.nameidattribute' => 'uid',
-        'simplesaml.attributes'      => false
+        'simplesaml.attributes'      => false,
+        'authproc'                   => [
+          1 => [
+            'saml:AttributeNameID',
+            'attribute' => 'uid',
+            'format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+          ],
+        ],
       ];
 
 You must also map some attributes received from the authentication module into email field sent to Google Workspace. In this example, the  `uid` attribute is set.  When you later configure the IdP to connect to a LDAP directory or some other authentication source, make sure that the `uid` attribute is set properly, or you can configure another attribute to use here. The `uid` attribute contains the local part of the user name.

--- a/docs/simplesamlphp-reference-sp-remote.md
+++ b/docs/simplesamlphp-reference-sp-remote.md
@@ -238,19 +238,6 @@ The following options can be set:
 :   Note that this option also exists in the IdP-hosted metadata.
     The value in the SP-remote metadata overrides the value in the IdP-hosted metadata.
 
-`simplesaml.nameidattribute`
-:   When the value of the `NameIDFormat`-option is set to either
-    `email` or `persistent`, this is the name of the attribute which
-    should be used as the value of the `NameID`. The attribute must
-    be in the set of attributes exported to the SP (that is, be in
-    the `attributes` array). For more advanced control over `NameID`,
-    including the ability to specify any attribute regardless of
-    the set sent to the SP, see the [NameID processing filters](./saml:nameid).
-    Note that the value of the attribute is collected **after** authproc-filters have run.
-
-:   Typical values can be `mail` for when using the `email` format,
-    and `eduPersonTargetedID` when using the `persistent` format.
-
 `simplesaml.attributes`
 :   Whether the SP should receive any attributes from the IdP. The
     default value is `TRUE`.

--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -41,6 +41,7 @@ The date formatting when specifying a custom logging string has been changed fro
 deprecated `strftime()` format to PHP's `date()` format.
 
 Configuration options that have been removed:
+ - simplesaml.nameidattribute. Use the appropriate authproc-filters instead
  - languages[priorities]
  - attributes.extradictionaries. Add an attributes.po to your configured theme instead.
  - admin.protectindexpage. Replaced by the admin module which always requires login.

--- a/metadata-templates/saml20-sp-remote.php
+++ b/metadata-templates/saml20-sp-remote.php
@@ -18,13 +18,19 @@ $metadata['https://saml2sp.example.org'] = [
  * This example shows an example config that works with Google Workspace (G Suite / Google Apps) for education.
  * What is important is that you have an attribute in your IdP that maps to the local part of the email address at
  * Google Workspace. In example, if your Google account is foo.com, and you have a user that has an email john@foo.com,
- * then you must set the simplesaml.nameidattribute to be the name of an attribute that for this user has the
- * value of 'john'.
+ * then you must properly configure the saml:AttributeNameID authproc-filter with the name of an attribute that for
+ * this user has the value of 'john'.
  */
 $metadata['google.com'] = [
     'AssertionConsumerService' => 'https://www.google.com/a/g.feide.no/acs',
     'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
-    'simplesaml.nameidattribute' => 'uid',
+    'authproc' => [
+      1 => [
+        'saml:AttributeNameID',
+        'attribute' => 'uid',
+        'format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+      ],
+    ],
     'simplesaml.attributes' => false,
 ];
 


### PR DESCRIPTION
We are unable to generate persistent NameIDs based on `simplesaml.nameidattribute`, since we have removed this attribute.
The only way to generate a persistent NameID is to use the appropriate authproc-filter.

This PR cleans up old code & logs and checks point 6 of #1643