### PR TITLE
Document store.redis.password in config.php template.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -1204,6 +1204,11 @@ $config = [
     'store.redis.port' => 6379,
 
     /*
+     * The password to use when connecting to a password-protected Redis instance.
+     */
+    'store.redis.password' => null,
+
+    /*
      * The prefix we should use on our Redis datastore.
      */
     'store.redis.prefix' => 'SimpleSAMLphp',


### PR DESCRIPTION
Any chance `store.redis.password` can be documented in `config-templates/config.php` ?

Support for this option was previously added in https://github.com/simplesamlphp/simplesamlphp/pull/1012 and is documented at https://simplesamlphp.org/docs/1.17/simplesamlphp-maintenance.html#configuring-redis-storage