### PR TITLE
Remove inappropriate output encoding

### DIFF
--- a/src/SimpleSAML/Error/AuthSource.php
+++ b/src/SimpleSAML/Error/AuthSource.php
@@ -43,8 +43,8 @@ class AuthSource extends Error
         parent::__construct(
             [
                 'AUTHSOURCEERROR',
-                '%AUTHSOURCE%' => htmlspecialchars(var_export($this->authsource, true)),
-                '%REASON%' => htmlspecialchars(var_export($this->reason, true))
+                '%AUTHSOURCE%' => $this->authsource,
+                '%REASON%' => $this->reason
             ],
             $cause
         );

--- a/src/SimpleSAML/Error/MetadataNotFound.php
+++ b/src/SimpleSAML/Error/MetadataNotFound.php
@@ -24,7 +24,7 @@ class MetadataNotFound extends Error
         $this->includeTemplate = 'core:no_metadata.twig';
         parent::__construct([
                 'METADATANOTFOUND',
-                '%ENTITYID%' => htmlspecialchars(var_export($entityId, true))
+                '%ENTITYID%' => $entityId
         ]);
     }
 }

--- a/src/SimpleSAML/Utils/Attributes.php
+++ b/src/SimpleSAML/Utils/Attributes.php
@@ -100,7 +100,7 @@ class Attributes
      *
      * This function takes in a namespaced attribute name and splits it in a namespace/attribute name tuple.
      * When no namespace is found in the attribute name, it will be namespaced with the default namespace.
-     * This default namespace can be overriden by supplying a second parameter to this function.
+     * This default namespace can be overridden by supplying a second parameter to this function.
      *
      * @param string $name The namespaced attribute name.
      * @param string $defaultns The default namespace that should be used when no namespace is found.
@@ -114,6 +114,6 @@ class Attributes
             $defaultns = substr($name, 0, $slash);
             $name = substr($name, $slash + 1);
         }
-        return [htmlspecialchars($defaultns), htmlspecialchars($name)];
+        return [$defaultns, $name];
     }
 }

--- a/src/SimpleSAML/XHTML/IdPDisco.php
+++ b/src/SimpleSAML/XHTML/IdPDisco.php
@@ -18,7 +18,6 @@ use function array_intersect;
 use function array_key_exists;
 use function array_keys;
 use function array_merge;
-use function htmlspecialchars;
 use function preg_match;
 use function sizeof;
 use function strcasecmp;
@@ -631,7 +630,7 @@ class IdPDisco
         $t->data['return'] = $this->returnURL;
         $t->data['returnIDParam'] = $this->returnIdParam;
         $t->data['entityID'] = $this->spEntityId;
-        $t->data['urlpattern'] = htmlspecialchars($httpUtils->getSelfURLNoQuery());
+        $t->data['urlpattern'] = $httpUtils->getSelfURLNoQuery();
         $t->data['rememberenabled'] = $this->config->getOptionalBoolean('idpdisco.enableremember', false);
         $t->data['rememberchecked'] = $this->config->getOptionalBoolean('idpdisco.rememberchecked', false);
         $t->send();

--- a/src/SimpleSAML/XHTML/Template.php
+++ b/src/SimpleSAML/XHTML/Template.php
@@ -39,7 +39,6 @@ use function count;
 use function date;
 use function explode;
 use function hash;
-use function htmlspecialchars;
 use function in_array;
 use function is_null;
 use function key;
@@ -476,10 +475,10 @@ class Template extends Response
                 $url = false;
                 if (!$current) {
                     $httpUtils = new Utils\HTTP();
-                    $url = htmlspecialchars($httpUtils->addURLParameters(
+                    $url = $httpUtils->addURLParameters(
                         '',
                         [$parameterName => $lang]
-                    ));
+                    );
                 }
                 $langmap[$lang] = [
                     'name' => $langname,

--- a/tests/modules/saml/src/Controller/ServiceProviderTest.php
+++ b/tests/modules/saml/src/Controller/ServiceProviderTest.php
@@ -299,8 +299,7 @@ class ServiceProviderTest extends TestCase
         $c = new Controller\ServiceProvider($this->config, $this->session);
 
         $this->expectException(Error\MetadataNotFound::class);
-// Breaks PHP 8.1 tests
-//        $this->expectExceptionMessage("METADATANOTFOUND('%ENTITYID%' => '\'https://engine.test.surfconext.nl/authentication/idp/metadata\'')");
+        $this->expectExceptionMessage("METADATANOTFOUND('%ENTITYID%' => 'https://engine.test.surfconext.nl/authentication/idp/metadata')");
 
         $c->assertionConsumerService('phpunit');
     }
@@ -388,8 +387,7 @@ XML;
         $c = new Controller\ServiceProvider($this->config, $this->session);
 
         $this->expectException(Error\MetadataNotFound::class);
-// Breaks PHP 8.1 tests
-//        $this->expectExceptionMessage("METADATANOTFOUND('%ENTITYID%' => '\'https://engine.test.surfconext.nl/authentication/idp/metadata\'')");
+        $this->expectExceptionMessage("METADATANOTFOUND('%ENTITYID%' => 'TheIssuer')");
 
         $c->singleLogoutService('phpunit');
     }


### PR DESCRIPTION
Output encoding should happen (and it does!) in the view. These are double encodings, and in any case are not appropriate to do in the controllers. As a bonus this fixes tests that were previously broken.