### PR TITLE
Support ACL's when connecting to Redis store.

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -1204,9 +1204,18 @@ $config = [
     'store.redis.port' => 6379,
 
     /*
-     * The password to use when connecting to a password-protected Redis instance.
+     * The credentials to use when connecting to Redis.
+     *
+     * If your Redis server is using the legacy password protection (config
+     * directive "requirepass" in redis.conf) then you should only provide
+     * a password.
+     *
+     * If your Redis server is using ACL's (which are recommended as of
+     * Redis 6+) then you should provide both a username and a password.
+     * See https://redis.io/docs/manual/security/acl/
      */
-    'store.redis.password' => null,
+    'store.redis.username' => '',
+    'store.redis.password' => '',
 
     /*
      * The prefix we should use on our Redis datastore.

--- a/docs/simplesamlphp-maintenance.md
+++ b/docs/simplesamlphp-maintenance.md
@@ -161,7 +161,11 @@ The required tables are created automatically. If you are storing data from mult
 
 To store sessions in Redis, set the `store.type` option to `redis`.
 
-By default SimpleSAMLphp will attempt to connect to Redis on the `localhost` at port `6379`. These can be configured via the `store.redis.host` and `store.redis.port` options, respectively. You may also set a key prefix with the `store.redis.prefix` option. For Redis instances that [require authentication](https://redis.io/commands/auth), use the `store.redis.password` option.
+By default SimpleSAMLphp will attempt to connect to Redis on the `localhost` at port `6379`. These can be configured via the `store.redis.host` and `store.redis.port` options, respectively. You may also set a key prefix with the `store.redis.prefix` option.
+
+For Redis instances that [require authentication](https://redis.io/commands/auth):
+* If authentication is managed with the `requirepass` directive (legacy password protection): use the `store.redis.password` option
+* If authentication is managed with [ACL's](https://redis.io/docs/manual/security/acl/) (which are recommended as of Redis 6): use the `store.redis.password` and `store.redis.username` options
 
 ## Metadata storage
 

--- a/src/SimpleSAML/Store/RedisStore.php
+++ b/src/SimpleSAML/Store/RedisStore.php
@@ -39,6 +39,7 @@ class RedisStore implements StoreInterface
             $port = $config->getOptionalInteger('store.redis.port', 6379);
             $prefix = $config->getOptionalString('store.redis.prefix', 'SimpleSAMLphp');
             $password = $config->getOptionalString('store.redis.password', null);
+            $username = $config->getOptionalString('store.redis.username', null);
             $database = $config->getOptionalInteger('store.redis.database', 0);
 
             $redis = new Client(
@@ -47,7 +48,9 @@ class RedisStore implements StoreInterface
                     'host' => $host,
                     'port' => $port,
                     'database' => $database,
-                ] + (!empty($password) ? ['password' => $password] : []),
+                ]
+                + (!empty($password) ? ['password' => $password] : [])
+                + (!empty($username) ? ['username' => $username] : []),
                 [
                     'prefix' => $prefix,
                 ]

--- a/tests/src/SimpleSAML/Store/RedisStoreTest.php
+++ b/tests/src/SimpleSAML/Store/RedisStoreTest.php
@@ -128,6 +128,21 @@ class RedisStoreTest extends TestCase
         $this->assertInstanceOf(Store\RedisStore::class, $this->store);
     }
 
+    /**
+     * @test
+     */
+    public function testRedisInstanceWithPasswordAndUsername(): void
+    {
+        $config = Configuration::loadFromArray([
+            'store.type' => 'redis',
+            'store.redis.prefix' => 'phpunit_',
+            'store.redis.password' => 'password',
+            'store.redis.username' => 'username',
+        ], '[ARRAY]', 'simplesaml');
+
+        $this->assertInstanceOf(Store\RedisStore::class, $this->store);
+    }
+
 
     /**
      * @test


### PR DESCRIPTION
This library currently supports connections to a password-protected Redis instance ([documentation](https://simplesamlphp.org/docs/1.17/simplesamlphp-maintenance.html#configuring-redis-storage)).

However, there are two ways to protect Redis ([documentation](https://redis.io/commands/auth/)):
1. Legacy password protection (config directive `requirepass` in `redis.conf`)
2. Or [ACL's](https://redis.io/docs/manual/security/acl/), which provide control over what commands and keys a client has access to ; those are especially useful when securing a Redis server used by multiple applications

As of Redis 6+, ACL's are the preferred way to protect a Redis instance ([documentation](https://github.com/redis/redis/blob/6.0/redis.conf#L784-L788)). Note that the legacy password protection still works in Redis 6+ and is compatible with ACL's: under the hood it just sets an ACL rule for the default user.

Is it possible to support ACL's ?

Predis does support ACL's ([documentation](https://github.com/predis/predis#connecting-to-redis)): we just need to pass an extra parameter `username` to the constructor if one was provided in SimpleSAMLphp's `config.php`.

What the library does currently (legacy password protection):

```
$client = new Client([
  ...
  'password' => 'mypassword',
]);
```

What it needs to do to support ACL's (only if a username was provided):

```
$client = new Client([
  ...
  'username' => 'myusername',
  'password' => 'mypassword',
]);
```