### PR TITLE
Emit ETag header for IdP metadata

### DIFF
--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -243,6 +243,7 @@ try {
         $t->show();
     } else {
         header('Content-Type: application/samlmetadata+xml');
+        header('E-tag: ' . hash('sha256', $metaxml));
 
         echo $metaxml;
         exit(0);

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -243,7 +243,7 @@ try {
         $t->show();
     } else {
         header('Content-Type: application/samlmetadata+xml');
-        header('E-tag: ' . hash('sha256', $metaxml));
+        header('ETag: "' . hash('sha256', $metaxml) . '"');
 
         echo $metaxml;
         exit(0);


### PR DESCRIPTION
This allows metadata aggregators to cache IdP metadata.