### PR TITLE
Actually handle ETag/If-None-Match logic

### DIFF
--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -242,10 +242,16 @@ try {
         $t->data['metadataflat'] = htmlspecialchars($metaflat);
         $t->show();
     } else {
-        header('Content-Type: application/samlmetadata+xml');
-        header('ETag: "' . hash('sha256', $metaxml) . '"');
-
-        echo $metaxml;
+        $etag = '"' . hash('sha256', $metaxml) . '"';
+        if(isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+            if($_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
+                header("HTTP/1.1 304 Not Modified");
+            }
+        } else {
+            header('Content-Type: application/samlmetadata+xml');
+            header('ETag: ' . $etag);
+            echo $metaxml;
+        }
         exit(0);
     }
 } catch (\Exception $exception) {

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -243,10 +243,11 @@ try {
         $t->show();
     } else {
         $etag = '"' . hash('sha256', $metaxml) . '"';
-        if(isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
-            if($_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
+        if (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+            if ($_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
                 header("HTTP/1.1 304 Not Modified");
                 exit(0);
+            }
         }
         header('Content-Type: application/samlmetadata+xml');
         header('ETag: ' . $etag);

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -246,16 +246,11 @@ try {
         if(isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
             if($_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
                 header("HTTP/1.1 304 Not Modified");
-            } else {
-                header('Content-Type: application/samlmetadata+xml');
-                header('ETag: ' . $etag);
-                echo $metaxml;
-            }
-        } else {
-            header('Content-Type: application/samlmetadata+xml');
-            header('ETag: ' . $etag);
-            echo $metaxml;
+                exit(0);
         }
+        header('Content-Type: application/samlmetadata+xml');
+        header('ETag: ' . $etag);
+        echo $metaxml;
         exit(0);
     }
 } catch (\Exception $exception) {

--- a/www/saml2/idp/metadata.php
+++ b/www/saml2/idp/metadata.php
@@ -246,6 +246,10 @@ try {
         if(isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
             if($_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
                 header("HTTP/1.1 304 Not Modified");
+            } else {
+                header('Content-Type: application/samlmetadata+xml');
+                header('ETag: ' . $etag);
+                echo $metaxml;
             }
         } else {
             header('Content-Type: application/samlmetadata+xml');


### PR DESCRIPTION
Sending the `Etag` header was only one part. This MR implement the other part.
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag