### PR TITLE
Translation contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "symfony/http-kernel": "^5.4||^6",
         "symfony/intl": "^5.4||^6",
         "symfony/routing": "^5.4||^6",
-        "symfony/translation-contracts": "^2.5",
+        "symfony/translation-contracts": "^2.5||^3",
         "symfony/twig-bridge": "^5.4||^6",
         "symfony/var-exporter": "^5.4||^6",
         "symfony/yaml": "^5.4||^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f344a9e5ad324e3d1f9c0b01a1dad30b",
+    "content-hash": "e390f66c66616d117c9f23bbe564a497",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3628,20 +3628,20 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.5.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "136b19dd05cdf0709db6537d058bcab6dd6e2dbe"
+                "reference": "acbfbb274e730e5a0236f619b6168d9dedb3e282"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/136b19dd05cdf0709db6537d058bcab6dd6e2dbe",
-                "reference": "136b19dd05cdf0709db6537d058bcab6dd6e2dbe",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/acbfbb274e730e5a0236f619b6168d9dedb3e282",
+                "reference": "acbfbb274e730e5a0236f619b6168d9dedb3e282",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=8.0.2"
             },
             "suggest": {
                 "symfony/translation-implementation": ""
@@ -3649,7 +3649,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3686,7 +3686,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -3702,7 +3702,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-27T16:58:25+00:00"
+            "time": "2022-06-27T17:10:44+00:00"
         },
         {
             "name": "symfony/twig-bridge",

--- a/src/SimpleSAML/Locale/TwigTranslator.php
+++ b/src/SimpleSAML/Locale/TwigTranslator.php
@@ -48,6 +48,6 @@ class TwigTranslator implements TranslatorInterface
      */
     public function getLocale(): string
     {
-        return 'en';
+        return Language::FALLBACKLANGUAGE;
     }
 }

--- a/src/SimpleSAML/Locale/TwigTranslator.php
+++ b/src/SimpleSAML/Locale/TwigTranslator.php
@@ -36,10 +36,18 @@ class TwigTranslator implements TranslatorInterface
      * @param string|null $domain
      * @param string|null $locale
      */
-    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null)
+    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
     {
         $this->locale = $locale;
 
         return call_user_func_array($this->translator, func_get_args());
+    }
+
+    /**
+     * Returns the default locale.
+     */
+    public function getLocale(): string
+    {
+        return 'en';
     }
 }


### PR DESCRIPTION
This turned out to be slightly less straight forward than expected. I wasn't sure what to do with the new getLocale() method that 3.x requires.

TwigTranslator is a wrapper around an inner callback, the actual implementation then passes in \SimpleSAML\Locale\Translate::translateSingularGettext(), which already now ignores the passed langcode anyway and is also just a wrapper around gettext, whose interface also doesn't expose the active language and internally relies on the locale API.

Unless \Symfony\Bridge\Twig\Extension\TranslationExtension ever decides to use that method or this implementation is used in another context, it doesn't matter. And that seems very unlikely, so I just went with a hardcoded en.

For context: https://github.com/symfony/symfony/issues/40380

Like the other return type changes, this is also backwards compatible with older versions of the interface and PHP 7.4