### PR TITLE
Add new 2.0 ACS endpoints to metadata

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -6,6 +6,12 @@ SimpleSAMLphp changelog
 This document lists the changes between versions of SimpleSAMLphp.
 See the upgrade notes for specific information about upgrading.
 
+## Version 1.19.7
+
+Released TBD
+
+  * Add new SSP 2.0 metadata endpoints to the SP metadata (#1692).
+
 ## Version 1.19.6
 
 Released 1-7-2022

--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -10,7 +10,10 @@ See the upgrade notes for specific information about upgrading.
 
 Released TBD
 
-  * Add new SSP 2.0 metadata endpoints to the SP metadata (#1692).
+  * Add new SSP 2.0 metadata endpoints to the SP metadata (#1692)
+  * Implement ETag/If-None-Match on IDP metadata endpoint (#1672 + #1673)
+  * Update dependencies to their latest version
+  * Documentation fixes
 
 ## Version 1.19.6
 

--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -219,9 +219,13 @@ Options
 :   *Note*: For this to be added to the metadata, you must also specify the `attributes` and `name` options.
 
 `disable_scoping`
-:    Whether sending of samlp:Scoping elements in authentication requests should be suppressed. The default value is `FALSE`.
-     When set to `TRUE`, no scoping elements will be sent. This does not comply with the SAML2 specification, but allows
-     interoperability with ADFS which [does not support Scoping elements](https://docs.microsoft.com/en-za/azure/active-directory/develop/active-directory-single-sign-on-protocol-reference#scoping).
+:   Whether sending of samlp:Scoping elements in authentication requests should be suppressed. The default value is `FALSE`.
+    When set to `TRUE`, no scoping elements will be sent. This does not comply with the SAML2 specification, but allows
+    interoperability with ADFS which [does not support Scoping elements](https://docs.microsoft.com/en-za/azure/active-directory/develop/active-directory-single-sign-on-protocol-reference#scoping).
+
+`disable_new_endpoints`
+:   Whether publication of SSP 2.0 metadata endpoints should be suppressed. The default value is `FALSE`.
+    When set to `TRUE`, no new endpoints will be published in the SP metadata.
 
 :   Note that this option also exists in the IdP remote configuration. An entry
     in the IdP-remote metadata overrides this the option in the SP

--- a/modules/saml/www/sp/metadata.php
+++ b/modules/saml/www/sp/metadata.php
@@ -110,6 +110,18 @@ foreach ($assertionsconsumerservices as $services) {
     $index++;
 }
 
+// Find all saml2-acs endpoints and make a copy of them with the location set to the new endpoint
+if ($spconfig->getBoolean('disable_new_endpoints', false) !== true) {
+    foreach ($eps as $endpoint) {
+        if (strpos($endpoint['Location'], 'saml2-acs.php') !== false) {
+            $endpoint['Location'] = preg_replace('/saml2-acs.php/', 'assertionConsumerService', $endpoint['Location'], 1);
+            $endpoint['index'] = $index;
+            $eps[] = $endpoint;
+            $index++;
+        }
+    }
+}
+
 $metaArray20['AssertionConsumerService'] = $spconfig->getArray('AssertionConsumerService', $eps);
 
 $keys = [];


### PR DESCRIPTION
This change will start publishing the new SSP 2.0 metadata endpoints in the SP metadata to make an upgrade easier.
The behavior will be enabled by default and can be disabled using a documented setting in the SP configuration.
Partially takes away the pain of #1684 