### PR TITLE
Drop covers lines from tests

### DIFF
--- a/tests/modules/admin/src/Controller/ConfigTest.php
+++ b/tests/modules/admin/src/Controller/ConfigTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Set of tests for the controllers in the "admin" module.
  *
- * @covers \SimpleSAML\Module\admin\Controller\Config
  * @package SimpleSAML\Test
  */
 class ConfigTest extends TestCase

--- a/tests/modules/admin/src/Controller/FederationTest.php
+++ b/tests/modules/admin/src/Controller/FederationTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 /**
  * Set of tests for the controllers in the "admin" module.
  *
- * @covers \SimpleSAML\Module\admin\Controller\Federation
  * @package SimpleSAML\Test
  */
 class FederationTest extends TestCase

--- a/tests/modules/admin/src/Controller/SandboxTest.php
+++ b/tests/modules/admin/src/Controller/SandboxTest.php
@@ -13,7 +13,6 @@ use SimpleSAML\XHTML\Template;
 /**
  * Set of tests for the controllers in the "admin" module.
  *
- * @covers \SimpleSAML\Module\admin\Controller\Sandbox
  * @package SimpleSAML\Test
  */
 class SandboxTest extends TestCase

--- a/tests/modules/admin/src/Controller/TestTest.php
+++ b/tests/modules/admin/src/Controller/TestTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Set of tests for the controllers in the "admin" module.
  *
- * @covers \SimpleSAML\Module\admin\Controller\Test
  * @package SimpleSAML\Test
  */
 class TestTest extends TestCase

--- a/tests/modules/core/src/Auth/Process/AttributeAddTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeAddTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Module\core\Auth\Process\AttributeAdd;
 /**
  * Test for the core:AttributeAdd filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\AttributeAdd
  */
 class AttributeAddTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/AttributeAlterTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeAlterTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Module\core\Auth\Process\AttributeAlter;
 /**
  * Test for the core:AttributeAlter filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\AttributeAlter
  */
 class AttributeAlterTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/AttributeCopyTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeCopyTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Module\core\Auth\Process\AttributeCopy;
 /**
  * Test for the core:AttributeCopy filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\AttributeCopy
  */
 class AttributeCopyTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/AttributeLimitTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeLimitTest.php
@@ -12,7 +12,6 @@ use SimpleSAML\Module\core\Auth\Process\AttributeLimit;
 /**
  * Test for the core:AttributeLimit filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\AttributeLimit
  */
 class AttributeLimitTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/AttributeMapTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeMapTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Module\core\Auth\Process\AttributeMap;
 /**
  * Test for the core:AttributeMap filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\AttributeMap
  */
 class AttributeMapTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/AttributeValueMapTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeValueMapTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Module\core\Auth\Process\AttributeValueMap;
 /**
  * Test for the core:AttributeValueMap filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\AttributeValueMap
  */
 class AttributeValueMapTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/CardinalitySingleTest.php
+++ b/tests/modules/core/src/Auth/Process/CardinalitySingleTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Module\core\Auth\Process\CardinalitySingle;
 /**
  * Test for the core:CardinalitySingle filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\CardinalitySingle
  */
 class CardinalitySingleTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/CardinalityTest.php
+++ b/tests/modules/core/src/Auth/Process/CardinalityTest.php
@@ -13,7 +13,6 @@ use SimpleSAML\Utils;
 /**
  * Test for the core:Cardinality filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\Cardinality
  */
 class CardinalityTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/PHPTest.php
+++ b/tests/modules/core/src/Auth/Process/PHPTest.php
@@ -12,7 +12,6 @@ use SimpleSAML\Module\core\Auth\Process\PHP;
 /**
  * Test for the core:PHP filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\PHP
  */
 class PHPTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/ScopeAttributeTest.php
+++ b/tests/modules/core/src/Auth/Process/ScopeAttributeTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Module\core\Auth\Process\ScopeAttribute;
 /**
  * Test for the core:ScopeAttribute filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\ScopeAttribute
  */
 class ScopeAttributeTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/ScopeFromAttributeTest.php
+++ b/tests/modules/core/src/Auth/Process/ScopeFromAttributeTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Module\core\Auth\Process\ScopeFromAttribute;
 /**
  * Test for the core:ScopeFromAttribute filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\ScopeFromAttribute
  */
 class ScopeFromAttributeTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Process/TargetedIDTest.php
+++ b/tests/modules/core/src/Auth/Process/TargetedIDTest.php
@@ -15,7 +15,6 @@ use SimpleSAML\Utils;
 /**
  * Test for the core:TargetedID filter.
  *
- * @covers \SimpleSAML\Module\core\Auth\Process\TargetedID
  */
 class TargetedIDTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/Source/IPSourceSelectorTest.php
+++ b/tests/modules/core/src/Auth/Source/IPSourceSelectorTest.php
@@ -14,8 +14,6 @@ use SimpleSAML\HTTP\RunnableResponse;
 use SimpleSAML\Module\core\Auth\Source\IPSourceSelector;
 
 /**
- * @covers \SimpleSAML\Module\core\Auth\Source\AbstractSourceSelector
- * @covers \SimpleSAML\Module\core\Auth\Source\IPSourceSelector
  */
 class IPSourceSelectorTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/UserPassBaseTest.php
+++ b/tests/modules/core/src/Auth/UserPassBaseTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Error\Error as SspError;
 use SimpleSAML\Module\core\Auth\UserPassBase;
 
 /**
- * @covers \SimpleSAML\Module\core\Auth\UserPassBase
  */
 class UserPassBaseTest extends TestCase
 {

--- a/tests/modules/core/src/Auth/UserPassOrgBaseTest.php
+++ b/tests/modules/core/src/Auth/UserPassOrgBaseTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use SimpleSAML\Module\core\Auth\UserPassOrgBase;
 
 /**
- * @covers \SimpleSAML\Module\core\Auth\UserPassOrgBase
  */
 class UserPassOrgBaseTest extends TestCase
 {

--- a/tests/modules/core/src/Controller/ErrorReportTest.php
+++ b/tests/modules/core/src/Controller/ErrorReportTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Set of tests for the controllers in the "core" module.
  *
- * @covers \SimpleSAML\Module\core\Controller\ErrorReport
  * @package SimpleSAML\Test
  */
 class ErrorReportTest extends TestCase

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpFoundation\Request;
  * For now, this test extends ClearStateTestCase so that it doesn't interfere with other tests. Once every class has
  * been made PSR-7-aware, that won't be necessary any longer.
  *
- * @covers \SimpleSAML\Module\core\Controller\Login
  * @package SimpleSAML\Test
  */
 class LoginTest extends ClearStateTestCase

--- a/tests/modules/core/src/Controller/LogoutTest.php
+++ b/tests/modules/core/src/Controller/LogoutTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
  * For now, this test extends ClearStateTestCase so that it doesn't interfere with other tests. Once every class has
  * been made PSR-7-aware, that won't be necessary any longer.
  *
- * @covers \SimpleSAML\Module\core\Controller\Logout
  * @package SimpleSAML\Test
  */
 class LogoutTest extends ClearStateTestCase

--- a/tests/modules/core/src/Storage/SQLPermanentStorageTest.php
+++ b/tests/modules/core/src/Storage/SQLPermanentStorageTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Module\core\Storage\SQLPermanentStorage;
 /**
  * Test for the SQLPermanentStorage class.
  *
- * @covers \SimpleSAML\Module\core\Storage\SQLPermanentStorage
  */
 class SQLPermanentStorageTest extends TestCase
 {

--- a/tests/modules/cron/src/Controller/CronTest.php
+++ b/tests/modules/cron/src/Controller/CronTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Set of tests for the controllers in the "cron" module.
  *
- * @covers \SimpleSAML\Module\cron\Controller\Cron
  * @package SimpleSAML\Test
  */
 class CronTest extends TestCase

--- a/tests/modules/exampleauth/src/Controller/ExampleAuthTest.php
+++ b/tests/modules/exampleauth/src/Controller/ExampleAuthTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Set of tests for the controllers in the "exampleauth" module.
  *
- * @covers \SimpleSAML\Module\exampleauth\Controller\ExampleAuth
  */
 class ExampleAuthTest extends TestCase
 {

--- a/tests/modules/multiauth/src/Auth/Source/MultiAuthTest.php
+++ b/tests/modules/multiauth/src/Auth/Source/MultiAuthTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Module\multiauth\Auth\Source\MultiAuth;
 
 /**
- * @covers \SimpleSAML\Module\multiauth\Auth\Source\MultiAuth
  */
 class MultiAuthTest extends ClearStateTestCase
 {

--- a/tests/modules/saml/src/Auth/Process/FilterScopesTest.php
+++ b/tests/modules/saml/src/Auth/Process/FilterScopesTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Module\saml\Auth\Process\FilterScopes;
 /**
  * Test for the saml:FilterScopes filter.
  *
- * @covers \SimpleSAML\Module\saml\Auth\Process\FilterScopes
  *
  * @package SimpleSAMLphp
  */

--- a/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
+++ b/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
@@ -13,7 +13,6 @@ use SAML2\Constants;
 /**
  * Test for the saml:NameIDAttribute filter.
  *
- * @covers \SimpleSAML\Module\saml\Auth\Process\NameIDAttribute
  *
  * @package SimpleSAMLphp
  */

--- a/tests/modules/saml/src/Auth/Process/PairwiseIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/PairwiseIDTest.php
@@ -15,7 +15,6 @@ use SimpleSAML\Module\saml\Auth\Process\PairwiseID;
 /**
  * Test for the saml:PairwiseID filter.
  *
- * @covers \SimpleSAML\Module\saml\Auth\Process\PairwiseID
  */
 class PairwiseIDTest extends TestCase
 {

--- a/tests/modules/saml/src/Auth/Process/SubjectIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/SubjectIDTest.php
@@ -15,7 +15,6 @@ use SimpleSAML\Module\saml\Auth\Process\SubjectID;
 /**
  * Test for the saml:SubjectID filter.
  *
- * @covers \SimpleSAML\Module\saml\Auth\Process\SubjectID
  */
 class SubjectIDTest extends TestCase
 {

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -23,7 +23,6 @@ use SimpleSAML\Test\Utils\SpTester;
 /**
  * Set of test cases for \SimpleSAML\Module\saml\Auth\Source\SP.
  *
- * @covers \SimpleSAML\Module\saml\Auth\Source\SP
  */
 class SPTest extends ClearStateTestCase
 {

--- a/tests/modules/saml/src/Controller/DiscoTest.php
+++ b/tests/modules/saml/src/Controller/DiscoTest.php
@@ -13,7 +13,6 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Set of tests for the controllers in the "saml" module.
  *
- * @covers \SimpleSAML\Module\saml\Controller\Disco
  * @package SimpleSAML\Test
  */
 class DiscoTest extends TestCase

--- a/tests/modules/saml/src/Controller/MetadataTest.php
+++ b/tests/modules/saml/src/Controller/MetadataTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Set of tests for the controllers in the "saml" module.
  *
- * @covers \SimpleSAML\Module\saml\Controller\Metadata
  * @package SimpleSAML\Test
  */
 class MetadataTest extends TestCase

--- a/tests/modules/saml/src/Controller/ProxyTest.php
+++ b/tests/modules/saml/src/Controller/ProxyTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Set of tests for the controllers in the "saml" module.
  *
- * @covers \SimpleSAML\Module\saml\Controller\Proxy
  * @package SimpleSAML\Test
  */
 class ProxyTest extends TestCase

--- a/tests/modules/saml/src/Controller/ServiceProviderTest.php
+++ b/tests/modules/saml/src/Controller/ServiceProviderTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Set of tests for the controllers in the "saml" module.
  *
- * @covers \SimpleSAML\Module\saml\Controller\ServiceProvider
  * @package SimpleSAML\Test
  */
 class ServiceProviderTest extends TestCase

--- a/tests/modules/saml/src/IdP/SAML2Test.php
+++ b/tests/modules/saml/src/IdP/SAML2Test.php
@@ -15,7 +15,6 @@ use SimpleSAML\Module\saml\IdP\SAML2;
 use SimpleSAML\TestUtils\ClearStateTestCase;
 
 /**
- * @covers \SimpleSAML\Module\saml\IdP\SAML2
  */
 class SAML2Test extends ClearStateTestCase
 {

--- a/tests/modules/saml/src/IdP/SQLNameIDTest.php
+++ b/tests/modules/saml/src/IdP/SQLNameIDTest.php
@@ -15,7 +15,6 @@ use SimpleSAML\Store\StoreFactory;
 /**
  * Test for the SQLNameID helper class.
  *
- * @covers \SimpleSAML\Module\saml\IdP\SQLNameID
  *
  * @package SimpleSAMLphp
  */

--- a/tests/src/SimpleSAML/Auth/SimpleTest.php
+++ b/tests/src/SimpleSAML/Auth/SimpleTest.php
@@ -12,7 +12,6 @@ use SimpleSAML\TestUtils\ClearStateTestCase;
 /**
  * Tests for \SimpleSAML\Auth\Simple
  *
- * @covers \SimpleSAML\Auth\Simple
  */
 class SimpleTest extends ClearStateTestCase
 {

--- a/tests/src/SimpleSAML/Auth/SourceTest.php
+++ b/tests/src/SimpleSAML/Auth/SourceTest.php
@@ -13,7 +13,6 @@ use SimpleSAML\Test\Utils\TestAuthSourceFactory;
 /**
  * Tests for \SimpleSAML\Auth\Source
  *
- * @covers \SimpleSAML\Auth\Source
  */
 class SourceTest extends ClearStateTestCase
 {

--- a/tests/src/SimpleSAML/Auth/StateTest.php
+++ b/tests/src/SimpleSAML/Auth/StateTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Auth;
 /**
  * Tests for \SimpleSAML\Auth\State
  *
- * @covers \SimpleSAML\Auth\State
  */
 class StateTest extends TestCase
 {

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -14,7 +14,6 @@ use SimpleSAML\TestUtils\ClearStateTestCase;
 /**
  * Tests for \SimpleSAML\Configuration
  *
- * @covers \SimpleSAML\Configuration
  */
 class ConfigurationTest extends ClearStateTestCase
 {

--- a/tests/src/SimpleSAML/DatabaseTest.php
+++ b/tests/src/SimpleSAML/DatabaseTest.php
@@ -21,7 +21,6 @@ use SimpleSAML\Database;
  * should be created for test cases to ensure that it will work
  * in an environment.
  *
- * @covers \SimpleSAML\Database
  *
  * @package SimpleSAMLphp
  */

--- a/tests/src/SimpleSAML/Locale/LanguageTest.php
+++ b/tests/src/SimpleSAML/Locale/LanguageTest.php
@@ -9,7 +9,6 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Locale\Language;
 
 /**
- * @covers \SimpleSAML\Locale\Language
  */
 class LanguageTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Locale/LocalizationTest.php
+++ b/tests/src/SimpleSAML/Locale/LocalizationTest.php
@@ -9,7 +9,6 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Locale\Localization;
 
 /**
- * @covers \SimpleSAML\Locale\Localization
  */
 class LocalizationTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Locale/TranslateTest.php
+++ b/tests/src/SimpleSAML/Locale/TranslateTest.php
@@ -9,7 +9,6 @@ use SimpleSAML\Configuration;
 use SimpleSAML\Locale\Translate;
 
 /**
- * @covers \SimpleSAML\Locale\Translate
  */
 class TranslateTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Metadata/SAMLBuilderTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLBuilderTest.php
@@ -12,7 +12,6 @@ use SimpleSAML\Module\saml\Auth\Source\SP;
 /**
  * Class SAMLBuilderTest
  *
- * @covers \SimpleSAML\Metadata\SAMLBuilder
  */
 class SAMLBuilderTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
@@ -14,7 +14,6 @@ use SimpleSAML\Metadata\SAMLParser;
 /**
  * Test SAML parsing
  *
- * @covers \SimpleSAML\Metadata\SAMLParser
  */
 class SAMLParserTest extends \SimpleSAML\Test\SigningTestCase
 {

--- a/tests/src/SimpleSAML/ModuleTest.php
+++ b/tests/src/SimpleSAML/ModuleTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Module;
 use Symfony\Component\Filesystem\Path;
 
 /**
- * @covers \SimpleSAML\Module
  */
 class ModuleTest extends TestCase
 {

--- a/tests/src/SimpleSAML/SessionHandlerPHPTest.php
+++ b/tests/src/SimpleSAML/SessionHandlerPHPTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\SessionHandlerPHP;
 use SimpleSAML\Configuration;
 
 /**
- * @covers \SimpleSAML\SessionHandlerPHP
  */
 class SessionHandlerPHPTest extends ClearStateTestCase
 {

--- a/tests/src/SimpleSAML/SessionTest.php
+++ b/tests/src/SimpleSAML/SessionTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Session;
 use SimpleSAML\Configuration;
 
 /**
- * @covers \SimpleSAML\Session
  */
 class SessionTest extends ClearStateTestCase
 {

--- a/tests/src/SimpleSAML/Store/RedisStoreTest.php
+++ b/tests/src/SimpleSAML/Store/RedisStoreTest.php
@@ -17,7 +17,6 @@ use SimpleSAML\Store\StoreFactory;
  * For the full copyright and license information, please view the LICENSE file that was distributed with this source
  * code.
  *
- * @covers \SimpleSAML\Store\RedisStore
  * @package simplesamlphp/simplesamlphp
  */
 class RedisStoreTest extends TestCase

--- a/tests/src/SimpleSAML/Store/SQLStoreTest.php
+++ b/tests/src/SimpleSAML/Store/SQLStoreTest.php
@@ -15,7 +15,6 @@ use SimpleSAML\Store\StoreFactory;
  * For the full copyright and license information, please view the LICENSE file that was distributed with this source
  * code.
  *
- * @covers \SimpleSAML\Store\SQLStore
  * @package simplesamlphp/simplesamlphp
  */
 class SQLStoreTest extends TestCase

--- a/tests/src/SimpleSAML/Store/StoreFactoryTest.php
+++ b/tests/src/SimpleSAML/Store/StoreFactoryTest.php
@@ -19,7 +19,6 @@ use SimpleSAML\Store\StoreFactory;
  * For the full copyright and license information, please view the LICENSE file that was
  * distributed with this source code.
  *
- * @covers \SimpleSAML\Store\StoreFactory
  * @package simplesamlphp/simplesamlphp
  */
 class StoreFactoryTest extends TestCase

--- a/tests/src/SimpleSAML/Utils/ArraysTest.php
+++ b/tests/src/SimpleSAML/Utils/ArraysTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\Arrays.
  *
- * @covers \SimpleSAML\Utils\Arrays
  */
 class ArraysTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/AttributesTest.php
+++ b/tests/src/SimpleSAML/Utils/AttributesTest.php
@@ -12,7 +12,6 @@ use SimpleSAML\Utils\Attributes;
 /**
  * Tests for SimpleSAML\Utils\Attributes.
  *
- * @covers \SimpleSAML\Utils\Attributes
  */
 class AttributesTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/Config/MetadataTest.php
+++ b/tests/src/SimpleSAML/Utils/Config/MetadataTest.php
@@ -15,7 +15,6 @@ use TypeError;
 /**
  * Tests related to SAML metadata.
  *
- * @covers \SimpleSAML\Utils\Config
  */
 class MetadataTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/ConfigTest.php
+++ b/tests/src/SimpleSAML/Utils/ConfigTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\Config
  *
- * @covers \SimpleSAML\Utils\Config
  */
 class ConfigTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/CryptoTest.php
+++ b/tests/src/SimpleSAML/Utils/CryptoTest.php
@@ -16,7 +16,6 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\Crypto.
  *
- * @covers \SimpleSAML\Utils\Crypto
  */
 class CryptoTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/EMailTest.php
+++ b/tests/src/SimpleSAML/Utils/EMailTest.php
@@ -13,7 +13,6 @@ use SimpleSAML\Utils\EMail;
 /**
  * A base SSP test case that tests some simple e-mail related calls
  *
- * @covers \SimpleSAML\Utils\EMail
  */
 class EMailTest extends ClearStateTestCase
 {

--- a/tests/src/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/src/SimpleSAML/Utils/HTTPTest.php
@@ -11,7 +11,6 @@ use SimpleSAML\TestUtils\ClearStateTestCase;
 use SimpleSAML\Utils;
 
 /**
- * @covers \SimpleSAML\Utils\HTTP
  */
 class HTTPTest extends ClearStateTestCase
 {

--- a/tests/src/SimpleSAML/Utils/NetTest.php
+++ b/tests/src/SimpleSAML/Utils/NetTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\Test.
  *
- * @covers \SimpleSAML\Utils\Net
  */
 class NetTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/RandomTest.php
+++ b/tests/src/SimpleSAML/Utils/RandomTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\Random.
  *
- * @covers \SimpleSAML\Utils\Random
  */
 class RandomTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/SystemTest.php
+++ b/tests/src/SimpleSAML/Utils/SystemTest.php
@@ -16,7 +16,6 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\System.
  *
- * @covers \SimpleSAML\Utils\System
  */
 class SystemTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/TimeTest.php
+++ b/tests/src/SimpleSAML/Utils/TimeTest.php
@@ -12,7 +12,6 @@ use SimpleSAML\Error;
 use SimpleSAML\Utils;
 
 /**
- * @covers \SimpleSAML\Utils\Time
  */
 class TimeTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/TranslateTest.php
+++ b/tests/src/SimpleSAML/Utils/TranslateTest.php
@@ -14,7 +14,6 @@ use Symfony\Component\Finder\Finder;
 /**
  * Tests for SimpleSAML\Utils\Translate.
  *
- * @covers \SimpleSAML\Utils\Translate
  */
 class TranslateTest extends TestCase
 {

--- a/tests/src/SimpleSAML/Utils/XMLTest.php
+++ b/tests/src/SimpleSAML/Utils/XMLTest.php
@@ -18,7 +18,6 @@ use SimpleSAML\Utils;
 /**
  * Tests for SimpleSAML\Utils\XML.
  *
- * @covers \SimpleSAML\Utils\XML
  */
 class XMLTest extends TestCase
 {

--- a/tests/src/SimpleSAML/XHTML/TemplateTest.php
+++ b/tests/src/SimpleSAML/XHTML/TemplateTest.php
@@ -10,7 +10,6 @@ use SimpleSAML\Configuration;
 use SimpleSAML\XHTML\Template;
 
 /**
- * @covers \SimpleSAML\XHTML\Template
  */
 class TemplateTest extends TestCase
 {

--- a/tests/src/SimpleSAML/XHTML/TemplateTranslationTest.php
+++ b/tests/src/SimpleSAML/XHTML/TemplateTranslationTest.php
@@ -20,7 +20,6 @@ use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 /**
- * @covers \SimpleSAML\XHTML\Template
  */
 class TemplateTranslationTest extends TestCase
 {

--- a/tests/src/SimpleSAML/XML/ErrorsTest.php
+++ b/tests/src/SimpleSAML/XML/ErrorsTest.php
@@ -14,7 +14,6 @@ use SimpleSAML\XML\Errors;
  * For the full copyright and license information, please view the LICENSE file that was distributed with this source
  * code.
  *
- * @covers \SimpleSAML\XML\Errors
  *
  * @package simplesamlphp/simplesamlphp
  */

--- a/tests/src/SimpleSAML/XML/ParserTest.php
+++ b/tests/src/SimpleSAML/XML/ParserTest.php
@@ -16,7 +16,6 @@ use SimpleSAML\XML\Parser;
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @covers \SimpleSAML\XML\Parser
  */
 class ParserTest extends TestCase
 {

--- a/tests/src/SimpleSAML/XML/SignerTest.php
+++ b/tests/src/SimpleSAML/XML/SignerTest.php
@@ -17,7 +17,6 @@ use SimpleSAML\XML\Signer;
 /**
  * Tests for SimpleSAML\XML\Signer.
  *
- * @covers \SimpleSAML\XML\Signer
  */
 class SignerTest extends SigningTestCase
 {

--- a/tests/src/SimpleSAML/XML/ValidatorTest.php
+++ b/tests/src/SimpleSAML/XML/ValidatorTest.php
@@ -16,7 +16,6 @@ use SimpleSAML\XML\Validator;
 /**
  * Tests for SimpleSAML\XML\Validator.
  *
- * @covers \SimpleSAML\XML\Validator
  */
 class ValidatorTest extends SigningTestCase
 {


### PR DESCRIPTION
The `@covers` lines limit what is counted as coverage to exactly the classes it mentions. I can see the use case for this in some cases (where you have the time and means to explicitly cover each and every method). However, I disagree that _we_ should do that. It's in my opinion perfectly fine if we add unit tests to higher level classes that then indirectly test other classes by invoking them.

Given also that we have a long way to go re coverage I think it's useful that we focus on code that is not run by the testsuite at all, rather than trying to further optimize code that is already (indirectly covered). If lines are hit by the current testsuite, that's already a big bonus versus lines that are not hit at all.

So I propose to remove these annotations from the tests to get a better view of what % of lines/which lines we currently touch with the testsuite and which we don't yet.