### PR TITLE
Keep the ACS url as it was in 1.19

### DIFF
--- a/docs/simplesamlphp-artifact-idp.md
+++ b/docs/simplesamlphp-artifact-idp.md
@@ -70,12 +70,12 @@ In general, that should look something like:
 'AssertionConsumerService' => [
     [
         'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/assertionConsumerService/default-sp',
+        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
         'index' => 0,
     ],
     [
         'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact',
-        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/assertionConsumerService/default-sp',
+        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
         'index' => 2,
     ],
 ],

--- a/docs/simplesamlphp-hok-idp.md
+++ b/docs/simplesamlphp-hok-idp.md
@@ -66,12 +66,12 @@ In general, this should look like the following code:
 'AssertionConsumerService' => [
     [
         'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/assertionConsumerService/default-sp',
+        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
         'index' => 0,
     ],
     [
         'Binding' => 'urn:oasis:names:tc:SAML:2.0:profiles:holder-of-key:SSO:browser',
-        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/assertionConsumerService/default-sp',
+        'Location' => 'https://sp.example.org/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
         'index' => 4,
     ],
 ],

--- a/docs/simplesamlphp-idp.md
+++ b/docs/simplesamlphp-idp.md
@@ -182,8 +182,8 @@ This is a minimal example of a `metadata/saml20-sp-remote.php` metadata file for
 <?php
 
 $metadata['https://sp.example.org/simplesaml/module.php/saml/sp/metadata.php/default-sp'] = [
-    'AssertionConsumerService' => 'https://sp.example.org/simplesaml/module.php/saml/sp/assertionConsumerService/default-sp',
-    'SingleLogoutService' => 'https://sp.example.org/simplesaml/module.php/saml/sp/singleLogoutService/default-sp',
+    'AssertionConsumerService' => 'https://sp.example.org/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
+    'SingleLogoutService' => 'https://sp.example.org/simplesaml/module.php/saml/sp/saml2-logout.php/default-sp',
 ];
 ```
 

--- a/metadata-templates/saml20-sp-remote.php
+++ b/metadata-templates/saml20-sp-remote.php
@@ -10,8 +10,8 @@
  * Example SimpleSAMLphp SAML 2.0 SP
  */
 $metadata['https://saml2sp.example.org'] = [
-    'AssertionConsumerService' => 'https://saml2.example.org/module.php/saml/sp/assertionConsumerService/default-sp',
-    'SingleLogoutService' => 'https://saml2sp.example.org/module.php/saml/sp/singleLogoutService/default-sp',
+    'AssertionConsumerService' => 'https://saml2.example.org/module.php/saml/sp/saml2-acs.php/default-sp',
+    'SingleLogoutService' => 'https://saml2sp.example.org/module.php/saml/sp/saml2-logout.php/default-sp',
 ];
 
 /*

--- a/modules/core/docs/authproc_attributelimit.md
+++ b/modules/core/docs/authproc_attributelimit.md
@@ -85,8 +85,8 @@ like this:
 Then, add the allowed attributes to each service provider metadata, in the `attributes` option:
 
     $metadata['https://saml2sp.example.org'] = [
-        'AssertionConsumerService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/assertionConsumerService/default-sp',
-        'SingleLogoutService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/singleLogoutService/default-sp',
+        'AssertionConsumerService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
+        'SingleLogoutService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/saml2-logout.php/default-sp',
         ...
         'attributes' => ['cn', 'mail'],
         ...
@@ -96,8 +96,8 @@ Now, let's look to a couple of examples on how to filter out attribute values. F
 to be used by a service provider (among other attributes):
 
     $metadata['https://saml2sp.example.org'] = [
-        'AssertionConsumerService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/assertionConsumerService/default-sp',
-        'SingleLogoutService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/singleLogoutService/default-sp',
+        'AssertionConsumerService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp',
+        'SingleLogoutService' => 'https://saml2sp.example.org/simplesaml/module.php/saml/sp/saml2-logout.php/default-sp',
         ...
         'attributes' => [
             'uid',

--- a/modules/saml/routing/routes/routes.yaml
+++ b/modules/saml/routing/routes/routes.yaml
@@ -11,20 +11,14 @@ saml-sp-wrongAuthnContextClassRef:
     path:       /sp/wrongAuthnContextClassRef
     defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::wrongAuthnContextClassRef' }
 saml-sp-assertionConsumerService:
-    path:       /sp/assertionConsumerService/{sourceId}
+    path:       /sp/saml2-acs.php/{sourceId}
     defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::assertionConsumerService' }
 saml-sp-singleLogoutService:
-    path:       /sp/singleLogoutService/{sourceId}
+    path:       /sp/saml2-logout.php/{sourceId}
     defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::singleLogoutService' }
 saml-sp-metadata:
     path:       /sp/metadata/{sourceId}
     defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::metadata' }
-saml-legacy-sp-assertionConsumerService:
-    path:       /sp/saml2-acs.php/{sourceId}
-    defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::assertionConsumerService', path: /saml/sp/assertionConsumerService, permanent: true }
-saml-legacy-sp-singleLogoutService:
-    path:       /sp/saml2-logout.php/{sourceId}
-    defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::singleLogoutService', path: /saml/sp/singleLogoutService, permanent: true }
 saml-legacy-sp-metadata:
     path:       /sp/metadata.php/{sourceId}
     defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::metadata', path: /saml/sp/metadata, permanent: true }

--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -357,19 +357,19 @@ class SP extends \SimpleSAML\Auth\Source
                 case Constants::BINDING_HTTP_POST:
                     $acs = [
                         'Binding' => Constants::BINDING_HTTP_POST,
-                        'Location' => Module::getModuleURL('saml/sp/assertionConsumerService/' . $this->getAuthId()),
+                        'Location' => Module::getModuleURL('saml/sp/saml2-acs.php/' . $this->getAuthId()),
                     ];
                     break;
                 case Constants::BINDING_HTTP_ARTIFACT:
                     $acs = [
                         'Binding' => Constants::BINDING_HTTP_ARTIFACT,
-                        'Location' => Module::getModuleURL('saml/sp/assertionConsumerService/' . $this->getAuthId()),
+                        'Location' => Module::getModuleURL('saml/sp/saml2-acs.php/' . $this->getAuthId()),
                     ];
                     break;
                 case Constants::BINDING_HOK_SSO:
                     $acs = [
                         'Binding' => Constants::BINDING_HOK_SSO,
-                        'Location' => Module::getModuleURL('saml/sp/assertionConsumerService/' . $this->getAuthId()),
+                        'Location' => Module::getModuleURL('saml/sp/saml2-acs.php/' . $this->getAuthId()),
                         'hoksso:ProtocolBinding' => Constants::BINDING_HTTP_REDIRECT,
                     ];
                     break;
@@ -404,7 +404,7 @@ class SP extends \SimpleSAML\Auth\Source
                 Constants::BINDING_SOAP,
             ]
         );
-        $defaultLocation = Module::getModuleURL('saml/sp/singleLogoutService/' . $this->getAuthId());
+        $defaultLocation = Module::getModuleURL('saml/sp/saml2-logout.php/' . $this->getAuthId());
         $location = $this->metadata->getOptionalString('SingleLogoutServiceLocation', $defaultLocation);
 
         $endpoints = [];
@@ -439,7 +439,7 @@ class SP extends \SimpleSAML\Auth\Source
 
         $ar = Module\saml\Message::buildAuthnRequest($this->metadata, $idpMetadata);
 
-        $ar->setAssertionConsumerServiceURL(Module::getModuleURL('saml/sp/assertionConsumerService/' . $this->authId));
+        $ar->setAssertionConsumerServiceURL(Module::getModuleURL('saml/sp/saml2-acs.php/' . $this->authId));
 
         if (isset($state['\SimpleSAML\Auth\Source.ReturnURL'])) {
             $ar->setRelayState($state['\SimpleSAML\Auth\Source.ReturnURL']);

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -462,7 +462,7 @@ class SPTest extends ClearStateTestCase
         $this->assertIsArray($md['AssertionConsumerService']);
         foreach ($md['AssertionConsumerService'] as $acs) {
             $this->assertEquals(
-                'http://localhost/simplesaml/module.php/saml/sp/assertionConsumerService/' . $spId,
+                'http://localhost/simplesaml/module.php/saml/sp/saml2-acs.php/' . $spId,
                 $acs['Location']
             );
             $this->assertStringStartsWith('urn:oasis:names:tc:SAML:2.0:bindings', $acs['Binding']);
@@ -1382,7 +1382,7 @@ class SPTest extends ClearStateTestCase
         $this->assertIsArray($hok);
         $this->assertEquals('urn:oasis:names:tc:SAML:2.0:profiles:holder-of-key:SSO:browser', $hok['Binding']);
         $this->assertEquals(
-            'http://localhost/simplesaml/module.php/saml/sp/assertionConsumerService/' . $spId,
+            'http://localhost/simplesaml/module.php/saml/sp/saml2-acs.php/' . $spId,
             $hok['Location']
         );
         $this->assertEquals(2, $hok['index']);


### PR DESCRIPTION
This is an approach to solving #1684.

We keep all the benefits of the new structure (controllers, routes etc). The single thing that this changes is which string is used to identify the route. This means that we reap all the benefits while at the same time not cause any unnecessary migration pain on this front. Changing the ACS requires not just the deployer to do something but to coordinate with potentially many IdPs, while we can easily avoid this.

The ACS is used for machine consumption, not to be typed by a human, so which exact string is in the URL really doesn't matter. It's just a number of characters to identify it.

In my opinion this solution is simple and does not require to add more code, require people to upgrade a 1.19 install first and then exchange metadata and then exchange metadata again after upgrading to 2.0, or other complex migration instructions.