### PR TITLE
Add support for Redis-Sentinel

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -1221,4 +1221,21 @@ $config = [
      * The prefix we should use on our Redis datastore.
      */
     'store.redis.prefix' => 'SimpleSAMLphp',
+
+    /*
+     * The master group to use for Redis Sentinel.
+     */
+    'store.redis.mastergroup' => 'mymaster',
+
+    /*
+     * The Redis Sentinel hosts.
+     * Example:
+     * array(
+     *     'tcp://[yoursentinel1]:[port]'
+     *     'tcp://[yoursentinel2]:[port]',
+     *     'tcp://[yoursentinel3]:[port]
+     * )
+     */
+    'store.redis.sentinels' => [],
+
 ];

--- a/docs/simplesamlphp-maintenance.md
+++ b/docs/simplesamlphp-maintenance.md
@@ -179,9 +179,28 @@ For Redis instances that [require authentication](https://redis.io/commands/auth
 * If authentication is managed with the `requirepass` directive (legacy password protection): use the `store.redis.password` option
 * If authentication is managed with [ACL's](https://redis.io/docs/manual/security/acl/) (which are recommended as of Redis 6): use the `store.redis.password` and `store.redis.username` options
 
-For Redis servers controlled by [Redis Sentinel](https://redis.io/docs/manual/sentinel/):
-* Configure your sentinels by setting `store.redis.sentinels` to `['tcp://[yoursentinel1]:[port]', 'tcp://[yoursentinel2]:[port]', 'tcp://[yoursentinel3]:[port]']`
-* Configure your master group by setting `store.redis.mastergroup` (`mymaster` by default)
+#### Redis-Sentinel
+
+If your Redis servers are controlled by [Redis-Sentinel](https://redis.io/docs/manual/sentinel/), then configure your sentinels by setting `store.redis.sentinels` to
+
+```
+[
+    'tcp://[yoursentinel1]:[port]',
+    'tcp://[yoursentinel2]:[port]',
+    'tcp://[yoursentinel3]:[port]',
+]
+```
+
+If your sentinels are password-protected and use the same password as your Redis servers, then setting `store.redis.password` is enough. However if your sentinels use a different password than that of your Redis servers, then set the password of each sentinel:
+```
+[
+    'tcp://[yoursentinel1]:[port]?password=[password1]',
+    'tcp://[yoursentinel2]:[port]?password=[password2]',
+    'tcp://[yoursentinel3]:[port]?password=[password3]',
+]
+```
+
+Configure your master group by setting `store.redis.mastergroup` (`mymaster` by default).
 
 ## Metadata storage
 

--- a/docs/simplesamlphp-maintenance.md
+++ b/docs/simplesamlphp-maintenance.md
@@ -179,6 +179,10 @@ For Redis instances that [require authentication](https://redis.io/commands/auth
 * If authentication is managed with the `requirepass` directive (legacy password protection): use the `store.redis.password` option
 * If authentication is managed with [ACL's](https://redis.io/docs/manual/security/acl/) (which are recommended as of Redis 6): use the `store.redis.password` and `store.redis.username` options
 
+For Redis servers controlled by [Redis Sentinel](https://redis.io/docs/manual/sentinel/):
+* Configure your sentinels by setting `store.redis.sentinels` to `['tcp://[yoursentinel1]:[port]', 'tcp://[yoursentinel2]:[port]', 'tcp://[yoursentinel3]:[port]']`
+* Configure your master group by setting `store.redis.mastergroup` (`mymaster` by default)
+
 ## Metadata storage
 
 Several metadata storage backends are available by default, including `flatfile`, `serialize`, `mdq` and

--- a/docs/simplesamlphp-maintenance.md
+++ b/docs/simplesamlphp-maintenance.md
@@ -183,7 +183,7 @@ For Redis instances that [require authentication](https://redis.io/commands/auth
 
 If your Redis servers are controlled by [Redis-Sentinel](https://redis.io/docs/manual/sentinel/), then configure your sentinels by setting `store.redis.sentinels` to
 
-```
+```php
 [
     'tcp://[yoursentinel1]:[port]',
     'tcp://[yoursentinel2]:[port]',
@@ -192,7 +192,8 @@ If your Redis servers are controlled by [Redis-Sentinel](https://redis.io/docs/m
 ```
 
 If your sentinels are password-protected and use the same password as your Redis servers, then setting `store.redis.password` is enough. However if your sentinels use a different password than that of your Redis servers, then set the password of each sentinel:
-```
+
+```php
 [
     'tcp://[yoursentinel1]:[port]?password=[password1]',
     'tcp://[yoursentinel2]:[port]?password=[password2]',

--- a/src/SimpleSAML/Store/RedisStore.php
+++ b/src/SimpleSAML/Store/RedisStore.php
@@ -55,7 +55,7 @@ class RedisStore implements StoreInterface
                     + (!empty($username) ? ['username' => $username] : [])
                     + (!empty($password) ? ['password' => $password] : []),
                     [
-                       'prefix' => $prefix,
+                        'prefix' => $prefix,
                     ]
                 );
             } else {

--- a/src/SimpleSAML/Store/RedisStore.php
+++ b/src/SimpleSAML/Store/RedisStore.php
@@ -42,19 +42,38 @@ class RedisStore implements StoreInterface
             $username = $config->getOptionalString('store.redis.username', null);
             $database = $config->getOptionalInteger('store.redis.database', 0);
 
-            $redis = new Client(
-                [
-                    'scheme' => 'tcp',
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => $database,
-                ]
-                + (!empty($password) ? ['password' => $password] : [])
-                + (!empty($username) ? ['username' => $username] : []),
-                [
-                    'prefix' => $prefix,
-                ]
-            );
+            $sentinels = $config->getArray('store.redis.sentinels', []);
+
+            if (empty($sentinels)) {
+                $redis = new Client(
+                    [
+                        'scheme' => 'tcp',
+                        'host' => $host,
+                        'port' => $port,
+                        'database' => $database,
+                    ]
+                    + (!empty($username) ? ['username' => $username] : [])
+                    + (!empty($password) ? ['password' => $password] : []),
+                    [
+                       'prefix' => $prefix,
+                    ]
+                );
+            } else {
+                $mastergroup = $config->getString('store.redis.mastergroup', 'mymaster');
+                $redis = new Client(
+                    $sentinels,
+                    [
+                        'replication' => 'sentinel',
+                        'service' => $mastergroup,
+                        'prefix' => $prefix,
+                        'parameters' => [
+                            'database' => $database,
+                        ]
+                        + (!empty($username) ? ['username' => $username] : [])
+                        + (!empty($password) ? ['password' => $password] : []),
+                    ]
+                );
+            }
         }
 
         $this->redis = $redis;

--- a/src/SimpleSAML/Store/RedisStore.php
+++ b/src/SimpleSAML/Store/RedisStore.php
@@ -42,7 +42,7 @@ class RedisStore implements StoreInterface
             $username = $config->getOptionalString('store.redis.username', null);
             $database = $config->getOptionalInteger('store.redis.database', 0);
 
-            $sentinels = $config->getArray('store.redis.sentinels', []);
+            $sentinels = $config->getOptionalArray('store.redis.sentinels', []);
 
             if (empty($sentinels)) {
                 $redis = new Client(
@@ -59,7 +59,7 @@ class RedisStore implements StoreInterface
                     ]
                 );
             } else {
-                $mastergroup = $config->getString('store.redis.mastergroup', 'mymaster');
+                $mastergroup = $config->getOptionalString('store.redis.mastergroup', 'mymaster');
                 $redis = new Client(
                     $sentinels,
                     [

--- a/tests/src/SimpleSAML/Store/RedisStoreTest.php
+++ b/tests/src/SimpleSAML/Store/RedisStoreTest.php
@@ -143,6 +143,21 @@ class RedisStoreTest extends TestCase
         $this->assertInstanceOf(Store\RedisStore::class, $this->store);
     }
 
+    /**
+     * @covers \SimpleSAML\Store::getInstance
+     * @covers \SimpleSAML\Store\Redis::__construct
+     * @test
+     */
+    public function testRedisSentinelInstance()
+    {
+        $config = Configuration::loadFromArray(array(
+            'store.type' => 'redis',
+            'store.redis.prefix' => 'phpunit_',
+            'store.redis.mastergroup' => 'phpunit_mastergroup',
+            'store.redis.sentinels' => array('tcp://sentinel1', 'tcp://sentinel2', 'tcp://sentinel3'),
+        ), '[ARRAY]', 'simplesaml');
+        $this->assertInstanceOf(Store\RedisStore::class, $this->store);
+    }
 
     /**
      * @test

--- a/tests/src/SimpleSAML/Store/RedisStoreTest.php
+++ b/tests/src/SimpleSAML/Store/RedisStoreTest.php
@@ -148,7 +148,7 @@ class RedisStoreTest extends TestCase
      * @covers \SimpleSAML\Store\Redis::__construct
      * @test
      */
-    public function testRedisSentinelInstance()
+    public function testRedisSentinelInstance(): void
     {
         $config = Configuration::loadFromArray(array(
             'store.type' => 'redis',

--- a/tests/src/SimpleSAML/Store/StoreFactoryTest.php
+++ b/tests/src/SimpleSAML/Store/StoreFactoryTest.php
@@ -86,6 +86,7 @@ class StoreFactoryTest extends TestCase
         Configuration::loadFromArray([
             'store.type'                    => 'redis',
             'store.redis.prefix'            => 'phpunit_',
+            'store.redis.sentinels'         => [],
         ], '[ARRAY]', 'simplesaml');
 
         $config = Configuration::getInstance();


### PR DESCRIPTION
I needed this library to support [Redis-Sentinel](https://redis.io/docs/manual/sentinel/) so I picked up the work started in #1137 / #701 and rolled a new patch (based on e57536d311330a781d6a1ad8d7c1f2fe60fbc35e) that applies against the current master (2.x).

According to the [release notes](https://github.com/simplesamlphp/simplesamlphp/releases/tag/v1.19.6) 1.19.6 was the very last release in the 1.x branch so I won't open a pull request against 1.x.

The patch works fine on my side. There is a gotcha about password-protected instances which does not appear to be documented in the [predis documentation](https://github.com/predis/predis/blob/main/README.md) (I only found out about this via [this comment](https://github.com/predis/predis/issues/783#issuecomment-1191192483)), so I added some details about it to the docs.