### PR TITLE
Make all NameID authproc-filters use identifyingAttribute

### DIFF
--- a/docs/simplesamlphp-googleapps.md
+++ b/docs/simplesamlphp-googleapps.md
@@ -145,13 +145,13 @@ In the `saml20-sp-remote.php` file we will configure an entry for Google Workspa
  * must properly configure the saml:AttributeNameID authproc-filter with the name of an attribute that for this user has the value of 'john'.
  */
 $metadata['https://www.google.com/a/g.feide.no'] => [
-    'AssertionConsumerService' => 'https://www.google.com/a/g.feide.no/acs', 
+    'AssertionConsumerService' => 'https://www.google.com/a/g.feide.no/acs',
     'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
     'simplesaml.attributes' => false,
     'authproc' => [
         1 => [
           'saml:AttributeNameID',
-          'attribute' => 'uid',
+          'identifyingAttribute' => 'uid',
           'format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
         ],
     ],

--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -29,6 +29,8 @@ composer require simplesamlphp/simplesamlphp-module-ldap --update-no-dev
   by setting `validate.authnrequest` to `false`. If unset (or set to true) signatures will be
   validated if present and requests not passing validation will be refused.
 - In the  core:TargetedID authproc-filter, the `attributename` setting has been renamed to `identifyingAttribute`.
+  Similarly, in the  saml:AttributeNameID, saml:PersistentNameID and saml:SQLPersistentNameId authproc-filters, the
+  `attribute` setting has been renamed to `identifyingAttribute` for consistency with other NameID filters.
 - The default encryption algorithm is set from `AES128_CBC` to `AES128_GCM`.
   It is possible to switch back via the `sharedkey_algorithm`.
   Note however that CBC is vulnerable to the Padding oracle attack.

--- a/metadata-templates/saml20-sp-remote.php
+++ b/metadata-templates/saml20-sp-remote.php
@@ -27,7 +27,7 @@ $metadata['google.com'] = [
     'authproc' => [
       1 => [
         'saml:AttributeNameID',
-        'attribute' => 'uid',
+        'identifyingAttribute' => 'uid',
         'format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
       ],
     ],

--- a/modules/core/docs/authproc_targetedid.md
+++ b/modules/core/docs/authproc_targetedid.md
@@ -3,12 +3,12 @@
 
 This filter generates the `eduPersonTargetedID` attribute for the user.
 
-This filter will use the contents of the attribute set by the `attributename` option as the unique user ID.
+This filter will use the contents of the attribute set by the `identifyingAttribute` option as the unique user ID.
 
 Parameters
 ----------
 
-`attributename`
+`identifyingAttribute`
 :   The name of the attribute we should use for the unique user identifier.
 
     Note: only the first value of the specified attribute is being used for the generation of the identifier.
@@ -26,7 +26,7 @@ A custom attribute:
     'authproc' => [
         50 => [
             'class' => 'core:TargetedID',
-            'attributename' => 'eduPersonPrincipalName'
+            'identifyingAttribute' => 'eduPersonPrincipalName'
         ],
     ],
 

--- a/modules/saml/docs/nameid.md
+++ b/modules/saml/docs/nameid.md
@@ -26,7 +26,7 @@ Uses the value of an attribute to generate a NameID.
 
 **Options**:
 
-`attribute`
+`identifyingAttribute`
 :   The name of the attribute we should use as the unique user ID.
 
 `Format`
@@ -40,7 +40,7 @@ The resulting hash is sent as the persistent NameID.
 
 **Options**:
 
-`attribute`
+`identifyingAttribute`
 :   The name of the attribute we should use as the unique user ID.
 
 ## `saml:TransientNameID`
@@ -60,7 +60,7 @@ See the `store.type` configuration option in `config.php`.
 
 **Options**:
 
-`attribute`
+`identifyingAttribute`
 :   The name of the attribute we should use as the unique user ID.
 
 `allowUnspecified`
@@ -109,11 +109,11 @@ This example makes three NameIDs available:
         ],
         2 => [
             'class' => 'saml:PersistentNameID',
-            'attribute' => 'eduPersonPrincipalName',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
         ],
         3 => [
             'class' => 'saml:AttributeNameID',
-            'attribute' => 'mail',
+            'identifyingAttribute' => 'mail',
             'Format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
         ],
     ],
@@ -126,7 +126,7 @@ Storing persistent NameIDs in a SQL database:
         ],
         2 => [
             'class' => 'saml:SQLPersistentNameID',
-            'attribute' => 'eduPersonPrincipalName',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
         ],
     ],
 
@@ -136,7 +136,7 @@ Generating Persistent NameID and eduPersonTargetedID.
         // Generate the persistent NameID.
         2 => [
             'class' => 'saml:PersistentNameID',
-            'attribute' => 'eduPersonPrincipalName',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
         ],
         // Add the persistent to the eduPersonTargetedID attribute
         60 => [

--- a/modules/saml/src/Auth/Process/AttributeNameID.php
+++ b/modules/saml/src/Auth/Process/AttributeNameID.php
@@ -22,7 +22,7 @@ class AttributeNameID extends BaseNameIDGenerator
      *
      * @var string
      */
-    private string $attribute;
+    private string $identifyingAttribute;
 
 
     /**
@@ -31,7 +31,7 @@ class AttributeNameID extends BaseNameIDGenerator
      * @param array $config Configuration information about this filter.
      * @param mixed $reserved For future use.
      *
-     * @throws \SimpleSAML\Error\Exception If the required options 'Format' or 'attribute' are missing.
+     * @throws \SimpleSAML\Error\Exception If the required options 'Format' or 'identifyingAttribute' are missing.
      */
     public function __construct(array $config, $reserved)
     {
@@ -42,10 +42,10 @@ class AttributeNameID extends BaseNameIDGenerator
         }
         $this->format = (string) $config['Format'];
 
-        if (!isset($config['attribute'])) {
-            throw new Error\Exception("AttributeNameID: Missing required option 'attribute'.");
+        if (!isset($config['identifyingAttribute'])) {
+            throw new Error\Exception("AttributeNameID: Missing required option 'identifyingAttribute'.");
         }
-        $this->attribute = (string) $config['attribute'];
+        $this->identifyingAttribute = (string) $config['identifyingAttribute'];
     }
 
 
@@ -57,26 +57,30 @@ class AttributeNameID extends BaseNameIDGenerator
      */
     protected function getValue(array &$state): ?string
     {
-        if (!isset($state['Attributes'][$this->attribute]) || count($state['Attributes'][$this->attribute]) === 0) {
+        if (
+            !isset($state['Attributes'][$this->identifyingAttribute])
+            || count($state['Attributes'][$this->identifyingAttribute]) === 0
+        ) {
             Logger::warning(
-                'Missing attribute ' . var_export($this->attribute, true) .
+                'Missing attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating attribute NameID.'
             );
             return null;
         }
-        if (count($state['Attributes'][$this->attribute]) > 1) {
+        if (count($state['Attributes'][$this->identifyingAttribute]) > 1) {
             Logger::warning(
-                'More than one value in attribute ' . var_export($this->attribute, true) .
+                'More than one value in attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating attribute NameID.'
             );
             return null;
         }
-        $value = array_values($state['Attributes'][$this->attribute]); // just in case the first index is no longer 0
+        // just in case the first index is no longer 0
+        $value = array_values($state['Attributes'][$this->identifyingAttribute]);
         $value = strval($value[0]);
 
         if (empty($value)) {
             Logger::warning(
-                'Empty value in attribute ' . var_export($this->attribute, true) .
+                'Empty value in attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating attribute NameID.'
             );
             return null;

--- a/modules/saml/src/Auth/Process/PersistentNameID.php
+++ b/modules/saml/src/Auth/Process/PersistentNameID.php
@@ -24,7 +24,7 @@ class PersistentNameID extends BaseNameIDGenerator
      *
      * @var string
      */
-    private string $attribute;
+    private string $identifyingAttribute;
 
 
     /**
@@ -33,7 +33,7 @@ class PersistentNameID extends BaseNameIDGenerator
      * @param array $config Configuration information about this filter.
      * @param mixed $reserved For future use.
      *
-     * @throws \SimpleSAML\Error\Exception If the required option 'attribute' is missing.
+     * @throws \SimpleSAML\Error\Exception If the required option 'identifyingAttribute' is missing.
      */
     public function __construct(array $config, $reserved)
     {
@@ -41,10 +41,10 @@ class PersistentNameID extends BaseNameIDGenerator
 
         $this->format = Constants::NAMEID_PERSISTENT;
 
-        if (!isset($config['attribute'])) {
-            throw new Error\Exception("PersistentNameID: Missing required option 'attribute'.");
+        if (!isset($config['identifyingAttribute'])) {
+            throw new Error\Exception("PersistentNameID: Missing required option 'identifyingAttribute'.");
         }
-        $this->attribute = $config['attribute'];
+        $this->identifyingAttribute = $config['identifyingAttribute'];
     }
 
 
@@ -68,26 +68,30 @@ class PersistentNameID extends BaseNameIDGenerator
         }
         $idpEntityId = $state['Source']['entityid'];
 
-        if (!isset($state['Attributes'][$this->attribute]) || count($state['Attributes'][$this->attribute]) === 0) {
+        if (
+            !isset($state['Attributes'][$this->identifyingAttribute])
+            || count($state['Attributes'][$this->identifyingAttribute]) === 0
+        ) {
             Logger::warning(
-                'Missing attribute ' . var_export($this->attribute, true) .
+                'Missing attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating persistent NameID.'
             );
             return null;
         }
-        if (count($state['Attributes'][$this->attribute]) > 1) {
+        if (count($state['Attributes'][$this->identifyingAttribute]) > 1) {
             Logger::warning(
-                'More than one value in attribute ' . var_export($this->attribute, true) .
+                'More than one value in attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating persistent NameID.'
             );
             return null;
         }
-        $uid = array_values($state['Attributes'][$this->attribute]); // just in case the first index is no longer 0
+        // just in case the first index is no longer 0
+        $uid = array_values($state['Attributes'][$this->identifyingAttribute]);
         $uid = $uid[0];
 
         if (empty($uid)) {
             Logger::warning(
-                'Empty value in attribute ' . var_export($this->attribute, true) .
+                'Empty value in attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating persistent NameID.'
             );
             return null;

--- a/modules/saml/src/Auth/Process/SQLPersistentNameID.php
+++ b/modules/saml/src/Auth/Process/SQLPersistentNameID.php
@@ -23,7 +23,7 @@ class SQLPersistentNameID extends BaseNameIDGenerator
      *
      * @var string
      */
-    private string $attribute;
+    private string $identifyingAttribute;
 
     /**
      * Whether we should create a persistent NameID if not explicitly requested (as saml:PersistentNameID does).
@@ -60,7 +60,7 @@ class SQLPersistentNameID extends BaseNameIDGenerator
      * @param array $config Configuration information about this filter.
      * @param mixed $reserved For future use.
      *
-     * @throws \SimpleSAML\Error\Exception If the 'attribute' option is not specified.
+     * @throws \SimpleSAML\Error\Exception If the 'identifyingAttribute' option is not specified.
      */
     public function __construct(array &$config, $reserved)
     {
@@ -68,10 +68,10 @@ class SQLPersistentNameID extends BaseNameIDGenerator
 
         $this->format = Constants::NAMEID_PERSISTENT;
 
-        if (!isset($config['attribute'])) {
-            throw new Error\Exception("PersistentNameID: Missing required option 'attribute'.");
+        if (!isset($config['identifyingAttribute'])) {
+            throw new Error\Exception("PersistentNameID: Missing required option 'identifyingAttribute'.");
         }
-        $this->attribute = $config['attribute'];
+        $this->identifyingAttribute = $config['identifyingAttribute'];
 
         if (isset($config['allowUnspecified'])) {
             $this->allowUnspecified = (bool) $config['allowUnspecified'];
@@ -137,26 +137,31 @@ class SQLPersistentNameID extends BaseNameIDGenerator
         }
         $idpEntityId = $state['Source']['entityid'];
 
-        if (!isset($state['Attributes'][$this->attribute]) || count($state['Attributes'][$this->attribute]) === 0) {
+        if (
+            !isset($state['Attributes'][$this->identifyingAttribute])
+            || count($state['Attributes'][$this->identifyingAttribute]) === 0
+        ) {
             Logger::warning(
-                'SQLPersistentNameID: Missing attribute ' . var_export($this->attribute, true) .
+                'SQLPersistentNameID: Missing attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating persistent NameID.'
             );
             return null;
         }
-        if (count($state['Attributes'][$this->attribute]) > 1) {
+        if (count($state['Attributes'][$this->identifyingAttribute]) > 1) {
             Logger::warning(
-                'SQLPersistentNameID: More than one value in attribute ' . var_export($this->attribute, true) .
+                'SQLPersistentNameID: More than one value in attribute ' .
+                var_export($this->identifyingAttribute, true) .
                 ' on user - not generating persistent NameID.'
             );
             return null;
         }
-        $uid = array_values($state['Attributes'][$this->attribute]); // just in case the first index is no longer 0
+        // just in case the first index is no longer 0
+        $uid = array_values($state['Attributes'][$this->identifyingAttribute]);
         $uid = $uid[0];
 
         if (empty($uid)) {
             Logger::warning(
-                'Empty value in attribute ' . var_export($this->attribute, true) .
+                'Empty value in attribute ' . var_export($this->identifyingAttribute, true) .
                 ' on user - not generating persistent NameID.'
             );
             return null;


### PR DESCRIPTION
The upgrade notes for 2.0 note that the user id attribute in core:TargetedID has been renamed 'identifyingAttribute'. Similarly, the new PairwiseID and SubjectID filters use 'identifyingAttribute' as well, as does the [consent module](https://github.com/simplesamlphp/simplesamlphp-module-consent/pull/13).

That creates a situation where some NameID-related authproc filters use 'attribute' and some use 'identifyingAttribute' to configure the user-identifying attribute.

It might be desirable to create some consistency and standardise on identifyingAttribute. This pull request does that.

It also updates the documentation in modules/core/docs/authproc_targetedid.md to match the earlier change for core:TargetedID.