### PR TITLE
entityID change affects saml:SP too

### DIFF
--- a/config-templates/authsources.php
+++ b/config-templates/authsources.php
@@ -27,8 +27,7 @@ $config = [
         'saml:SP',
 
         // The entity ID of this SP.
-        // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
-        'entityID' => null,
+        'entityID' => 'https://myapp.example.org/',
 
         // The entity ID of the IdP this SP should contact.
         // Can be NULL/unset, in which case the user will be shown a list of available IdPs.

--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -35,8 +35,9 @@ composer require simplesamlphp/simplesamlphp-module-ldap --update-no-dev
 - All support for the Shibboleth 1.3 / SAML 1.1 protocol has been removed.
 - Sessions are no longer backwards compatible with previous versions. Make sure to clear your session cache during
   the upgrade process. How to do this depends on your session backend.
-- EntityIDs are no longer auto-generated. Make sure to set it to something sensible in the array-keys in
-  `metadata/saml20-idp-hosted.php` (or to the existing entityID when upgrading an existing installation).
+- EntityIDs are no longer auto-generated. Make sure to set something sensible in the array-keys in
+  `metadata/saml20-idp-hosted.php` and for any saml:SP in `config/authsources.php` (or to the existing entityIDs when
+  upgrading an existing installation).
   If you are using a database to store metadata, make sure to replace any __DYNAMIC% entityID's with
   a real value manually. Dynamic records are no longer loaded from the database.
 - SAML endpoints have changed, meaning that a metadata exchange with your peers _could_ be necessary depending on

--- a/metadata-templates/saml20-idp-hosted.php
+++ b/metadata-templates/saml20-idp-hosted.php
@@ -6,7 +6,7 @@
  * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
  */
 
-$metadata['urn:x-simplesamlphp:idp'] = [
+$metadata['urn:x-simplesamlphp:example-idp'] = [
     /*
      * The hostname of the server (VHOST) that will use this SAML entity.
      *

--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -216,7 +216,7 @@ The following attributes are available:
 :   Note that this option can be set for each IdP in the [IdP-remote metadata](./simplesamlphp-reference-idp-remote).
 
 `entityID`
-:   The entity ID this SP should use.
+:   The entity ID this SP should use. (Must be set or an error will be generated.)
 
 :   The entity ID must be a URI, that is unlikely to change for technical or political
     reasons. We recommend it to be a domain name, like above, if your organization's main

--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -96,6 +96,11 @@ class SP extends \SimpleSAML\Auth\Source
             Constants::SAML2INT_ENTITYID_MAX_LENGTH,
             sprintf('The entityID cannot be longer than %d characters.', Constants::SAML2INT_ENTITYID_MAX_LENGTH)
         );
+        Assert::notEq(
+            $entityId,
+            'https://myapp.example.org/',
+            'Please set a valid and unique entityID',
+        );
 
         $this->entityId = $entityId;
         $this->idp = $this->metadata->getOptionalString('idp', null);

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
@@ -125,6 +125,14 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
         // add the entity id of an entry to each entry in the metadata
         foreach ($metadataSet as $entityId => &$entry) {
             $entry['entityid'] = $entityId;
+            // check we're not seeing the entityID from the metadata-template
+            if ($set === 'saml20-idp-hosted') {
+                Assert::notEq(
+                    $entityId,
+                    'urn:x-simplesamlphp:example-idp',
+                    'Please set a valid and unique entityID',
+                );
+            }
         }
 
         $this->cachedMetadata[$set] = $metadataSet;

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -8,11 +8,14 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use SAML2\AuthnRequest;
 use SAML2\Constants;
+use SAML2\XML\Chunk;
+use SAML2\XML\DOMDocumentFactory;
 use SAML2\Exception\Protocol\NoAvailableIDPException;
 use SAML2\Exception\Protocol\NoSupportedIDPException;
 use SAML2\LogoutRequest;
 use SAML2\Utils;
 use SAML2\XML\saml\NameID;
+use SimpleSAML\Assert\AssertionFailedException;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error\Exception;
 use SimpleSAML\Test\Metadata\MetaDataStorageSourceTest;
@@ -1504,9 +1507,9 @@ class SPTest extends ClearStateTestCase
         $nameId = new NameID();
         $nameId->setValue('someone@example.com');
 
-        $dom = \SAML2\DOMDocumentFactory::create();
+        $dom = DOMDocumentFactory::create();
         $extension = $dom->createElementNS('urn:some:namespace', 'MyLogoutExtension');
-        $extChunk = [new \SAML2\XML\Chunk($extension)];
+        $extChunk = [new Chunk($extension)];
 
         $entityId = "https://engine.surfconext.nl/authentication/idp/metadata";
         $xml = MetaDataStorageSourceTest::generateIdpMetadataXml($entityId);
@@ -1550,7 +1553,7 @@ class SPTest extends ClearStateTestCase
     {
         $info = ['AuthId' => 'default-sp'];
         $config = ['entityID' => 'https://myapp.example.org/'];
-        $this->expectException(\SimpleSAML\Assert\AssertionFailedException::class);
+        $this->expectException(AssertionFailedException::class);
         $this->expectExceptionMessageMatches('/entityID/');
         $as = new SpTester($info, $config);
     }

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -1542,4 +1542,16 @@ class SPTest extends ClearStateTestCase
         $this->assertEquals('MyLogoutExtension', $q[0]->firstChild->localName);
         $this->assertEquals('urn:some:namespace', $q[0]->firstChild->namespaceURI);
     }
+
+    /*
+     * Test using the entityID from config-templates/authsources.php
+     */
+    public function testSampleEntityIdException(): void
+    {
+        $info = ['AuthId' => 'default-sp'];
+        $config = ['entityID' => 'https://myapp.example.org/'];
+        $this->expectException(\SimpleSAML\Assert\AssertionFailedException::class);
+        $this->expectExceptionMessageMatches('/entityID/');
+        $as = new SpTester($info, $config);
+    }
 }

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use SAML2\AuthnRequest;
 use SAML2\Constants;
 use SAML2\XML\Chunk;
-use SAML2\XML\DOMDocumentFactory;
+use SAML2\DOMDocumentFactory;
 use SAML2\Exception\Protocol\NoAvailableIDPException;
 use SAML2\Exception\Protocol\NoSupportedIDPException;
 use SAML2\LogoutRequest;

--- a/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
+++ b/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Test\Metadata;
 
 use Exception;
+use SimpleSAML\Assert\AssertionFailedException;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error\MetadataNotFound;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
@@ -156,7 +157,7 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
      */
     public function testSampleEntityIdException(): void
     {
-        $this->expectException(\SimpleSAML\Assert\AssertionFailedException::class);
+        $this->expectException(AssertionFailedException::class);
         $this->expectExceptionMessageMatches('/entityID/');
         $this->handler->getMetaDataCurrent('saml20-idp-hosted');
     }

--- a/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
+++ b/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
@@ -150,4 +150,14 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
         $this->expectException(MetadataNotFound::class, "METADATANOTFOUND('%ENTITYID%' => 'doesnotexist')");
         $this->handler->getMetaData('doesnotexist', 'saml20-sp-remote');
     }
+
+    /*
+     * Test using the entityID from metadata-templates/saml20-idp-hosted.php
+     */
+    public function testSampleEntityIdException(): void
+    {
+        $this->expectException(\SimpleSAML\Assert\AssertionFailedException::class);
+        $this->expectExceptionMessageMatches('/entityID/');
+        $this->handler->getMetaDataCurrent('saml20-idp-hosted');
+    }
 }

--- a/tests/src/SimpleSAML/Metadata/test-metadata/source1/saml20-idp-hosted.php
+++ b/tests/src/SimpleSAML/Metadata/test-metadata/source1/saml20-idp-hosted.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This set uses the example entityID from metadata-templates
+ * and is deliberately expected to generate an exception
+ * when loaded. It shouldn't be used in other tests.
+ */
+
+$metadata['urn:x-simplesamlphp:example-idp'] = [
+    'auth' => 'example-userpass',
+];


### PR DESCRIPTION
Update the examples and documentation for saml:SP to be consistent with the notion that entityIDs are no longer
dynamically generated if the 'entityID' config option is null.