### PR TITLE
translateFromArray needs a FALLBACKLANGUAGE

### DIFF
--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -139,6 +139,8 @@ class Translate
             return null;
         } elseif (isset($translations[$context['currentLanguage']])) {
             return $translations[$context['currentLanguage']];
+        } elseif (isset($translations[Language::FALLBACKLANGUAGE])) {
+            return $translations[Language::FALLBACKLANGUAGE];
         }
 
         // nothing we can use, return null so that we can set a default

--- a/tests/src/SimpleSAML/Locale/TranslateTest.php
+++ b/tests/src/SimpleSAML/Locale/TranslateTest.php
@@ -24,4 +24,34 @@ class TranslateTest extends TestCase
         $testString = 'Blablabla';
         $this->assertEquals($testString, $t->noop($testString));
     }
+
+    /**
+     * Test SimpleSAML\Locale\Translate::translateFromArray().
+     */
+    public function testTranslateFromArray(): void
+    {
+        $result = Translate::translateFromArray(
+            ['currentLanguage' => 'ia',],
+            [ 'ia' => 'interlingua', 'en' => 'english',]
+        );
+        $this->assertEquals('interlingua', $result);
+    }
+
+    public function testTranslateFromArrayFallback(): void
+    {
+        $result = Translate::translateFromArray(
+            ['currentLanguage' => 'ia',],
+            [ 'eo' => 'esperanto', 'en' => 'english',]
+        );
+        $this->assertEquals('english', $result);
+    }
+
+    public function testTranslateFromArrayFail(): void
+    {
+        $result = Translate::translateFromArray(
+            ['currentLanguage' => 'ia',],
+            [ 'eo' => 'esperanto',]
+        );
+        $this->assertEquals(null, $result);
+    }
 }


### PR DESCRIPTION
Currently, the translateFromArray filter has no fallback to a default locale/language. This makes it behave differently to the trans tag/filter in Twig and the old translation system. It can result in nothing being displayed even though the array it is passed contains an entry matching the default language (hardcoded as 'en').

Because this is a static function, determining the 'language.default' from the config is expensive. But the existing trans filter (as implemented in TwigTranslator.php) already uses Language::FALLBACKLANGUAGE as the default locale and that class is already loaded. So using that constant here is consistent with the other Twig translation functions.