### PR TITLE
Remove base64attributes feature

### DIFF
--- a/docs/simplesamlphp-reference-idp-hosted.md
+++ b/docs/simplesamlphp-reference-idp-hosted.md
@@ -147,9 +147,7 @@ The following SAML 2.0 options are available:
 :   -   `string`: Will include the attribute as a normal string. This is
         the default.
 
-:   -   `base64`: Store the attribute as a base64 encoded string. This
-        is the default when the `base64attributes`-option is set to
-        `TRUE`.
+:   -   `base64`: Store the attribute as a base64 encoded string.
 
 :   -   `raw`: Store the attribute without any modifications. This
         makes it possible to include raw XML in the response.

--- a/docs/simplesamlphp-reference-sp-remote.md
+++ b/docs/simplesamlphp-reference-sp-remote.md
@@ -31,10 +31,6 @@ The following options can be set:
 :   Used to manipulate attributes, and limit access for each SP. See
     the [authentication processing filter manual](simplesamlphp-authproc).
 
-`base64attributes`
-:   Whether attributes sent to this SP should be base64 encoded. The
-    default is `FALSE`.
-
 `description`
 :   A description of this SP. Will be used by various modules when they
     need to show a description of the SP to the user.
@@ -104,9 +100,7 @@ The following options can be set:
 :   -   `string`: Will include the attribute as a normal string. This is
         the default.
 
-:   -   `base64`: Store the attribute as a base64 encoded string. This
-        is the default when the `base64attributes`-option is set to
-        `TRUE`.
+:   -   `base64`: Store the attribute as a base64 encoded string.
 
 :   -   `raw`: Store the attribute without any modifications. This
         makes it possible to include raw XML in the response.

--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -974,16 +974,7 @@ class SAML2
         Configuration $spMetadata,
         array $attributes
     ): array {
-        $base64Attributes = $spMetadata->getOptionalBoolean('base64attributes', null);
-        if ($base64Attributes === null) {
-            $base64Attributes = $idpMetadata->getOptionalBoolean('base64attributes', false);
-        }
-
-        if ($base64Attributes) {
-            $defaultEncoding = 'base64';
-        } else {
-            $defaultEncoding = 'string';
-        }
+        $defaultEncoding = 'string';
 
         $srcEncodings = $idpMetadata->getOptionalArray('attributeencodings', []);
         $dstEncodings = $spMetadata->getOptionalArray('attributeencodings', []);

--- a/modules/saml/src/Message.php
+++ b/modules/saml/src/Message.php
@@ -829,21 +829,6 @@ class Message
         }
         // as far as we can tell, the assertion is valid
 
-        // maybe we need to base64 decode the attributes in the assertion?
-        if ($idpMetadata->getOptionalBoolean('base64attributes', false)) {
-            $attributes = $assertion->getAttributes();
-            $newAttributes = [];
-            foreach ($attributes as $name => $values) {
-                $newAttributes[$name] = [];
-                foreach ($values as $value) {
-                    foreach (explode('_', $value) as $v) {
-                        $newAttributes[$name][] = base64_decode($v);
-                    }
-                }
-            }
-            $assertion->setAttributes($newAttributes);
-        }
-
         // decrypt the NameID element if it is encrypted
         if ($assertion->isNameIdEncrypted()) {
             try {


### PR DESCRIPTION
This would encode all attributes sent by the IdP (or decode received by the SP) with base64. As far as I could deduce this is from the early days of federation, used nowhere anymore, no one came forward that did, but cannot get certainty. Best way to find out might just be to drop it and the 2.0 release seems the good moment. We can easily reinstate it if some use case does turn up.

Note that the IdP can still perform this behaviour with the more generic attributeencodings feature.