### PR TITLE
Micro optimisation and lower memory footprint

### DIFF
--- a/src/SimpleSAML/Database.php
+++ b/src/SimpleSAML/Database.php
@@ -110,14 +110,11 @@ class Database
             $config->getOptionalArray('database.slaves', [])
         );
         foreach ($secondaries as $secondary) {
-            array_push(
-                $this->dbSecondaries,
-                $this->connect(
-                    $secondary['dsn'],
-                    $secondary['username'],
-                    $secondary['password'],
-                    $driverOptions
-                )
+            $this->dbSecondaries[] = $this->connect(
+                $secondary['dsn'],
+                $secondary['username'],
+                $secondary['password'],
+                $driverOptions
             );
         }
         $this->tablePrefix = $config->getOptionalString('database.prefix', '');

--- a/src/SimpleSAML/Logger.php
+++ b/src/SimpleSAML/Logger.php
@@ -530,7 +530,7 @@ class Logger
             if ($statsLog) {
                 $stat = 'STAT ';
             }
-            array_push($replacements, $stat);
+            $replacements[] = $stat;
 
             if (self::$trackid === self::NO_TRACKID && !self::$shuttingDown) {
                 // we have a log without track ID and we are not still shutting down, so defer logging

--- a/src/SimpleSAML/Logger/FileLoggingHandler.php
+++ b/src/SimpleSAML/Logger/FileLoggingHandler.php
@@ -129,8 +129,8 @@ class FileLoggingHandler implements LoggingHandlerInterface
                     $format = $matches[1];
                 }
 
-                array_push($formats, $matches[0]);
-                array_push($replacements, date($format));
+                $formats[] = $matches[0];
+                $replacements[] = date($format);
             }
 
             if (preg_match('/^php:\/\//', $this->logFile)) {

--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -113,11 +113,11 @@ class HTTP
             $current = 'localhost';
         }
 
-        if (strstr($current, ":")) {
+        if (str_contains($current, ":")) {
             $decomposed = explode(":", $current);
             $port = array_pop($decomposed);
             if (!is_numeric($port)) {
-                array_push($decomposed, $port);
+                $decomposed[] = $port;
             }
             $current = implode(":", $decomposed);
         }


### PR DESCRIPTION
Avoid misuse of array_push. PHP 8.x allow us to use the faster `str_contains()`