### PR TITLE
Another definition with same name exists in Session class

### DIFF
--- a/src/SimpleSAML/Session.php
+++ b/src/SimpleSAML/Session.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace SimpleSAML;
 
 use SAML2\XML\saml\AttributeValue;
-use Serializable;
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\Configuration;
 use SimpleSAML\Error;
-use SimpleSAML\Session;
 use SimpleSAML\Utils;
 
 /**
@@ -27,7 +24,6 @@ use SimpleSAML\Utils;
  *
  * @package SimpleSAMLphp
  */
-
 class Session implements Utils\ClearableState
 {
     /**


### PR DESCRIPTION
- Import SimpleSAML\Session twice case warnings.
- Remove other unused imports.