### PR TITLE
Error reporting: indicate the actual level instead of always 'Error'

### DIFF
--- a/www/_include.php
+++ b/www/_include.php
@@ -63,9 +63,27 @@ function SimpleSAML_error_handler(
         return false;
     }
 
+    $levels = [
+        \E_DEPRECATED => 'Deprecated',
+        \E_USER_DEPRECATED => 'User Deprecated',
+        \E_NOTICE => 'Notice',
+        \E_USER_NOTICE => 'User Notice',
+        \E_STRICT => 'Runtime Notice',
+        \E_WARNING => 'Warning',
+        \E_USER_WARNING => 'User Warning',
+        \E_COMPILE_WARNING => 'Compile Warning',
+        \E_CORE_WARNING => 'Core Warning',
+        \E_USER_ERROR => 'User Error',
+        \E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
+        \E_COMPILE_ERROR => 'Compile Error',
+        \E_PARSE => 'Parse Error',
+        \E_ERROR => 'Error',
+        \E_CORE_ERROR => 'Core Error',
+    ];
+
     // show an error with a full backtrace
     $context = (is_null($errfile) ? '' : " at $errfile:$errline");
-    $e = new Error\Exception('Error ' . $errno . ' - ' . $errstr . $context);
+    $e = new Error\Exception($levels[$errno] . ' - ' . $errstr . $context);
     $e->logError();
 
     // resume normal error processing


### PR DESCRIPTION
Previously, (just) a warning would be logged as
"Error 2 - something"
"Error 8192 - use of thing is deprecated"

Now this is logged as
"Warning - something"
"Deprecated - use of thing is deprecated"

This should avoid red herrings when debugging an issue when e.g. a warning, notice or even deprecation notice looks like its an actual error while it's not.