### PR TITLE
Remove sources format for multiauth replaced in 1.9

### DIFF
--- a/modules/multiauth/docs/multiauth.md
+++ b/modules/multiauth/docs/multiauth.md
@@ -71,10 +71,7 @@ The keys of the sources array are the identifiers of authentication
 sources defined in the authsources.php configuration file. The
 values are arrays with information used to create the user
 interface that will let the user select the authentication source
-he wants. Older versions of the multiauth module did not have
-this structure and just have the authsources identifiers as the
-values of the sources array. It has been improved in a backwards
-compatible fashion so both cases should work.
+they want.
 
 Each source in the sources array has a key and a value. As
 mentioned above the key is the authsource identifier and the value

--- a/modules/multiauth/src/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/src/Auth/Source/MultiAuth.php
@@ -87,12 +87,6 @@ class MultiAuth extends Auth\Source
         /** @psalm-var array $sources */
         $sources = $config['sources'];
         foreach ($sources as $source => $info) {
-            if (is_int($source)) {
-                // Backwards compatibility
-                $source = $info;
-                $info = [];
-            }
-
             if (array_key_exists('text', $info)) {
                 $text = $info['text'];
             } else {

--- a/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
+++ b/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
@@ -57,8 +57,8 @@ class DiscoControllerTest extends TestCase
                     'multi' => [
                         'multiauth:MultiAuth',
                         'sources' => [
-                            'admin',
-                            'admin2'
+                            'admin' => [],
+                            'admin2' => [],
                         ]
                     ],
                 ],


### PR DESCRIPTION
The old format has been replaced with a new format in SSP 1.9. The new format makes sense and it's now time to stop supporting the legacy format.