### PR TITLE
Fix and improve multiauth module

### DIFF
--- a/modules/multiauth/docs/multiauth.md
+++ b/modules/multiauth/docs/multiauth.md
@@ -34,7 +34,7 @@ authentication source:
                     'en' => 'Log in using a SAML SP',
                     'es' => 'Entrar usando un SP SAML',
                 ],
-                'css-class' => 'SAML',
+                'css_class' => 'SAML',
                 'AuthnContextClassRef' => ['urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI', 'urn:oasis:names:tc:SAML:2.0:ac:classes:MobileTwoFactorContract'],
             ],
             'example-admin' => [
@@ -75,11 +75,11 @@ they want.
 
 Each source in the sources array has a key and a value. As
 mentioned above the key is the authsource identifier and the value
-is another array with optional keys: 'text', 'css-class', 'help', and 'AuthnContextClassRef'.
+is another array with optional keys: 'text', 'css_class', 'help', and 'AuthnContextClassRef'.
 The text element is another array with localized strings for one
 or more languages. These texts will be shown in the selectsource.php
 view. Note that you should at least enter the text in the default
-language as specified in your config.php file. The css-class
+language as specified in your config.php file. The css_class
 element is a string with the css class that will be applied to
 the &lt;li> element in the selectsource.php view. By default the
 authtype of the authsource is used as the css class with colons

--- a/modules/multiauth/templates/selectsource.twig
+++ b/modules/multiauth/templates/selectsource.twig
@@ -5,16 +5,22 @@
     <h2>{{ 'Select an authentication source'|trans }}</h2>
     <p>{{ 'The selected authentication source will be used to authenticate you and and to create a valid session.'|trans }}</p>
 
-    <form action="{{ selfUrl|escape('html') }}" method="get">
-        <input type="hidden" name="AuthState" value="{{ authstate|escape('html') }}">
+    <form>
+        <input type="hidden" name="AuthState" value="{{ authstate }}">
         <ul>
         {% for key, source in sources %}
-            {% set button = ('button-' ~ source.source) %}
-	    <li class="{{ source.css_class|escape('html') }} authsource">
-            <input type="submit" name="source" id="{{ button|escape('html') }}" value="{{ source.text|escape('html') }}"{%- if source.source == preferred %} autofocus{% endif -%}>
-            {% if source.help %}
-              <p>{{ source.help|escape('html') }}</p>
-            {% endif %}
+            {% set button = ('button-' ~ key) %}
+	    <li class="{{ source.css_class|default('') }} authsource">
+              <input type="submit" name="sourceChoice[{{ key }}]"
+                {%- if key == preferred %}
+                    class="pure-button pure-button-active" autofocus
+                {%- else %}
+                    class="pure-button"
+                {% endif %}
+                id="{{ button }}" value="{{ source.text is defined ? source.text|translateFromArray : key }}">
+              {% if source.help is defined %}
+                <p>{{ source.help|translateFromArray }}</p>
+              {% endif %}
             </li>
         {% endfor %}
         </ul>

--- a/resources/css/default.scss
+++ b/resources/css/default.scss
@@ -807,3 +807,6 @@ div.preferredidp {
     float: left;
 }
 
+.authsource {
+    padding: 0.5em;
+}

--- a/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
+++ b/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
@@ -114,8 +114,8 @@ class DiscoControllerTest extends TestCase
                         'multiauth:discovery' => 'foo'
                     ],
                     MultiAuth::SOURCESID => [
-                        'source1' => ['source' => 'admin', 'help' => ['en' => 'help'], 'text' => ['en' => 'text']],
-                        'source2' => ['source' => 'test', 'help' => ['en' => 'help'], 'text' => ['en' => 'text']]
+                        'admin' => ['help' => ['en' => 'help'], 'text' => ['en' => 'text']],
+                        'admin2' => ['help' => ['en' => 'help'], 'text' => ['en' => 'text']]
                     ]
                 ];
             }
@@ -168,8 +168,8 @@ class DiscoControllerTest extends TestCase
                     ],
                     '\SimpleSAML\Auth\Source.id' => 'multi',
                     MultiAuth::SOURCESID => [
-                        'source1' => ['source' => 'admin', 'help' => ['en' => 'help'], 'text' => ['en' => 'text']],
-                        'source2' => ['source' => 'test', 'help' => ['en' => 'help'], 'text' => ['en' => 'text']]
+                        'admin' => ['help' => ['en' => 'help'], 'text' => ['en' => 'text']],
+                        'admin2' => ['help' => ['en' => 'help'], 'text' => ['en' => 'text']]
                     ]
                 ];
             }
@@ -224,8 +224,8 @@ class DiscoControllerTest extends TestCase
                     '\SimpleSAML\Auth\Source.id' => 'multi',
                     MultiAuth::AUTHID => 'bar',
                     MultiAuth::SOURCESID => [
-                        'source1' => ['source' => 'admin', 'help' => ['en' => 'help'], 'text' => ['nl' => 'text']],
-                        'source2' => ['source' => 'test', 'text' => ['en' => 'text'], 'help' => ['nl' => 'help']]
+                        'admin' => ['help' => ['en' => 'help'], 'text' => ['nl' => 'text']],
+                        'admin2' => ['text' => ['en' => 'text'], 'help' => ['nl' => 'help']]
                     ]
                 ];
             }
@@ -256,7 +256,7 @@ class DiscoControllerTest extends TestCase
 
 
     /**
-     * Test that a valid requests results in a RunnableResponse
+     * Test that a valid request results in a RunnableResponse
      * @return void
      */
     public function testDiscoveryDelegateAuth1WithPreviousSource(): void
@@ -280,8 +280,8 @@ class DiscoControllerTest extends TestCase
                     '\SimpleSAML\Auth\Source.id' => 'multi',
                     MultiAuth::AUTHID => 'bar',
                     MultiAuth::SOURCESID => [
-                        'source1' => ['source' => 'admin', 'help' => ['en' => 'help']],
-                        'source2' => ['source' => 'test', 'text' => ['en' => 'text']]
+                        'admin' => ['help' => ['en' => 'help']],
+                        'admin2' => ['text' => ['en' => 'text']]
                     ]
                 ];
             }
@@ -312,7 +312,7 @@ class DiscoControllerTest extends TestCase
 
 
     /**
-     * Test that a valid requests results in a RunnableResponse
+     * Test that a valid request results in a RunnableResponse
      * @return void
      */
     public function testDiscoveryDelegateAuth2(): void
@@ -320,7 +320,7 @@ class DiscoControllerTest extends TestCase
         $request = Request::create(
             '/discovery',
             'GET',
-            ['AuthState' => 'someState', 'src-YWRtaW4=' => 'admin']
+            ['AuthState' => 'someState', 'sourceChoice[admin]' => 'something admin']
         );
 
         $c = new Controller\DiscoController($this->config, $this->session);
@@ -334,8 +334,8 @@ class DiscoControllerTest extends TestCase
                     ],
                     MultiAuth::AUTHID => 'bar',
                     MultiAuth::SOURCESID => [
-                        'source1' => ['source' => 'admin', 'help' => ['en' => 'help'], 'text' => ['en' => 'text']],
-                        'source2' => ['source' => 'test', 'text' => ['en' => 'text'], 'help' => ['en' => 'help']]
+                        'admin' => ['help' => ['en' => 'help'], 'text' => ['en' => 'text']],
+                        'admin2' => ['text' => ['en' => 'text'], 'help' => ['en' => 'help']]
                     ]
                 ];
             }


### PR DESCRIPTION
- Fix several bugs to make it actually work; it was broken in several ways probably due to refactoring in SSP.
- Simplify code a lot, also make use of things we have already available now.
- Move presentation concerns to the template and use standard functionality for translation

A small change needed to be made in the name of the `css_class` setting (previously `css-class`) in the name of simplicity, it seemed better to change that now than to carry more code to convert the name.