### PR TITLE
Tone down the error level of missing locale dirs

### DIFF
--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -200,13 +200,13 @@ class Localization
             // Report that the localization for the preferred language is missing
             $error = "Localization not found for langcode '$langcode' at '$langPath', falling back to langcode '" .
                 $defLangcode . "'";
-            Logger::error($_SERVER['PHP_SELF'] . ' - ' . $error);
+            Logger::info($_SERVER['PHP_SELF'] . ' - ' . $error);
             return $langPath;
         }
 
         // Locale for default language missing even, error out
         $error = "Localization directory '$langPath' missing/broken for langcode '$langcode' and domain '$domain'";
-        Logger::critical($_SERVER['PHP_SELF'] . ' - ' . $error);
+        Logger::info($_SERVER['PHP_SELF'] . ' - ' . $error);
         throw new Exception($error);
     }
 


### PR DESCRIPTION
It is quite fine if e.g. a theme does not have its own locales dir. The exception is already caught, so the application does not actually stop. So, notice it but do not raise high alarms.