### PR TITLE
Reinstate url-based authentication

### DIFF
--- a/modules/core/routing/routes/routes.yml
+++ b/modules/core/routing/routes/routes.yml
@@ -4,6 +4,9 @@ core-welcome:
 core-account-disco-clearchoices:
     path:       /account/disco/clearchoices
     defaults:   { _controller: 'SimpleSAML\Module\core\Controller\Login::cleardiscochoices' }
+core-legacy-login:
+    path:       /login/{as}
+    defaults:   { _controller: 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction', path: /module.php/saml/sp/login/{as}, permanent: true }
 core-loginuserpass:
     path:       /loginuserpass
     defaults:   { _controller: 'SimpleSAML\Module\core\Controller\Login::loginuserpass' }

--- a/modules/core/src/Controller/Exception.php
+++ b/modules/core/src/Controller/Exception.php
@@ -75,7 +75,7 @@ class Exception
         $t->data['cardinalityErrorAttributes'] = $state['core:cardinality:errorAttributes'];
         if (isset($state['Source']['auth'])) {
             $t->data['LogoutURL'] = Module::getModuleURL(
-                'core/login/' . urlencode($state['Source']['auth'])
+                'saml/sp/login/' . urlencode($state['Source']['auth'])
             );
         }
 

--- a/modules/saml/routing/routes/routes.yaml
+++ b/modules/saml/routing/routes/routes.yaml
@@ -7,6 +7,9 @@ saml-disco:
 saml-sp-discoResponse:
     path:       /sp/discoResponse
     defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::discoResponse' }
+saml-sp-login:
+    path:       /sp/login/{sourceId}
+    defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::login' }
 saml-sp-wrongAuthnContextClassRef:
     path:       /sp/wrongAuthnContextClassRef
     defaults:   { _controller: 'SimpleSAML\Module\saml\Controller\ServiceProvider::wrongAuthnContextClassRef' }

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -132,13 +132,6 @@ class ServiceProvider
             'ReturnTo' => $httpUtils->checkURLAllowed($returnTo),
         ];
 
-        /**
-         * Allows a saml:idp query string parameter specify the IdP entity ID to be used
-         * as used by the DiscoJuice embedded client.
-         */
-        if (!empty($request->query->has('saml:idp'))) {
-            $options['saml:idp'] = $request->query->get('saml:idp');
-        }
         $as->requireAuth($options);
 
         return new RunnableResponse([$httpUtils, 'redirectTrustedURL'], [$returnTo]);

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -106,7 +106,7 @@ class ServiceProvider
 
 
     /**
-     * Start single sign-on for an SP identified with the specified entityID
+     * Start single sign-on for an SP identified with the specified Authsource ID
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $sourceId

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -106,6 +106,46 @@ class ServiceProvider
 
 
     /**
+     * Start single sign-on for an SP identified with the specified entityID
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param string $sourceId
+     * @return \SimpleSAML\HTTP\RunnableResponse
+     */
+    public function login(Request $request, string $sourceId): RunnableResponse
+    {
+        $as = new Auth\Simple($sourceId);
+        if (!($as->getAuthSource() instanceof SP)) {
+            throw new Error\Exception('Authsource must be of type saml:SP.');
+        }
+
+        if (!$request->query->has('ReturnTo')) {
+            throw new Error\BadRequest('Missing ReturnTo parameter.');
+        }
+        $returnTo = $request->query->get('ReturnTo');
+
+        /**
+         * Setting up the options for the requireAuth() call later..
+         */
+        $httpUtils = new Utils\HTTP();
+        $options = [
+            'ReturnTo' => $httpUtils->checkURLAllowed($returnTo),
+        ];
+
+        /**
+         * Allows a saml:idp query string parameter specify the IdP entity ID to be used
+         * as used by the DiscoJuice embedded client.
+         */
+        if (!empty($request->query->has('saml:idp'))) {
+            $options['saml:idp'] = $request->query->get('saml:idp');
+        }
+        $as->requireAuth($options);
+
+        return new RunnableResponse([$httpUtils, 'redirectTrustedURL'], [$returnTo]);
+    }
+
+
+    /**
      * Handler for response from IdP discovery service.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request

--- a/src/SimpleSAML/Auth/Simple.php
+++ b/src/SimpleSAML/Auth/Simple.php
@@ -320,8 +320,7 @@ class Simple
             $returnTo = $httpUtils->getSelfURL();
         }
 
-        $login = Module::getModuleURL('core/login/' . urlencode($this->authSource), [
-            'AuthId'   => $this->authSource,
+        $login = Module::getModuleURL('saml/sp/login/' . urlencode($this->authSource), [
             'ReturnTo' => $returnTo,
         ]);
 


### PR DESCRIPTION
Restores the functionality to trigger authentication by URL.
To not expose individual authsources like we did before, a check was added to test the passed authsource to be saml:SP. Those are the only ones safe to expose like this.

Closes #1682