### PR TITLE
Remove instruction to run npm install/build from install docs

### DIFF
--- a/docs/simplesamlphp-install-repo.md
+++ b/docs/simplesamlphp-install-repo.md
@@ -3,11 +3,6 @@ Installing SimpleSAMLphp from the repository
 
 These are some notes about running SimpleSAMLphp from the repository.
 
-Prerequisites
--------------
-
-* NodeJS version >= 10.0.
-
 Installing from git
 -------------------
 
@@ -36,17 +31,10 @@ cp metadata/saml20-sp-remote.php.dist metadata/saml20-sp-remote.php
 
 Install the external dependencies with Composer (you can refer to
 [getcomposer.org](https://getcomposer.org/) to get detailed
-instructions on how to install Composer itself) and npm:
+instructions on how to install Composer itself):
 
 ```bash
 php composer.phar install
-npm install
-```
-
-Build the assets:
-
-```bash
-npm run build
 ```
 
 Upgrading
@@ -65,10 +53,8 @@ git fetch origin
 git pull origin master
 ```
 
-Install or upgrade the external dependencies with Composer and npm:
+Install or upgrade the external dependencies with Composer:
 
 ```bash
 php composer.phar install
-npm install
-npm run build
 ```

--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -328,15 +328,6 @@ At the bottom of the admin page there are some green lights. SimpleSAMLphp runs 
 required and recommended prerequisites are met. If any of the lights are red, you may have to install some PHP
 extensions or external PHP packages (e.g. you need the PHP LDAP extension to use the LDAP authentication module).
 
-## Building assets
-
-Run the following commands to build the default theme.
-
-```bash
-npm install
-npm run build
-```
-
 ## Next steps
 
 You have now successfully installed SimpleSAMLphp, and the next steps depend on whether you want to setup a Service
@@ -405,7 +396,7 @@ As an example, let's see how you can install SimpleSAMLphp in your home director
    `https://host.example/~myaccount/`, set the base URL path accordingly:
 
    ```bash
-   'baseurlpath' => 'https://host.example/~myaccount/simplesaml/', 
+   'baseurlpath' => 'https://host.example/~myaccount/simplesaml/',
    ```
 
    Now, you can go to the URL of your installation and check if things work:


### PR DESCRIPTION
Hi, 
since package.json file got removed from simplesamlphp repo in https://github.com/simplesamlphp/simplesamlphp/commit/ad9641785d5e3053ebdaf03d6c32e1e3b273cb11

the instruction in docs related to SSP installation to run the following commands doesn't apply any more:

```
npm install
npm run build
```

This PR simply removes this from docs.

Best regards