### PR TITLE
Registration authority consistency

### DIFF
--- a/src/SimpleSAML/Metadata/SAMLParser.php
+++ b/src/SimpleSAML/Metadata/SAMLParser.php
@@ -919,6 +919,14 @@ class SAMLParser
                     } else {
                         $ret['RegistrationInfo']['authority'] = $e->getRegistrationAuthority();
                     }
+                    $registrationInstant = $e->getRegistrationInstant();
+                    if ($registrationInstant !== null) {
+                        $ret['RegistrationInfo']['instant'] = $registrationInstant;
+                    }
+                    $registrationPolicy = $e->getRegistrationPolicy();
+                    if (!empty($registrationPolicy)) {
+                        $ret['RegistrationInfo']['policies'] = $registrationPolicy;
+                    }
                 }
                 if ($e instanceof EntityAttributes && !empty($e->getChildren())) {
                     foreach ($e->getChildren() as $attr) {

--- a/src/SimpleSAML/Metadata/SAMLParser.php
+++ b/src/SimpleSAML/Metadata/SAMLParser.php
@@ -908,16 +908,16 @@ class SAMLParser
                 if ($e instanceof RegistrationInfo) {
                     // Registration Authority cannot be overridden (warn only if override attempts to change the value)
                     if (
-                        isset($ret['RegistrationInfo']['registrationAuthority'])
-                        && $ret['RegistrationInfo']['registrationAuthority'] !== $e->getRegistrationAuthority()
+                        isset($ret['RegistrationInfo']['authority'])
+                        && $ret['RegistrationInfo']['authority'] !== $e->getRegistrationAuthority()
                     ) {
                         Logger::warning(
                             'Invalid attempt to override registrationAuthority \''
-                            . $ret['RegistrationInfo']['registrationAuthority']
+                            . $ret['RegistrationInfo']['authority']
                             . "' with '{$e->getRegistrationAuthority()}'"
                         );
                     } else {
-                        $ret['RegistrationInfo']['registrationAuthority'] = $e->getRegistrationAuthority();
+                        $ret['RegistrationInfo']['authority'] = $e->getRegistrationAuthority();
                     }
                 }
                 if ($e instanceof EntityAttributes && !empty($e->getChildren())) {

--- a/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
@@ -24,7 +24,7 @@ class SAMLParserTest extends \SimpleSAML\Test\SigningTestCase
     public function testRegistrationInfo(): void
     {
         $expected = [
-            'registrationAuthority' => 'https://incommon.org',
+            'authority' => 'https://incommon.org',
         ];
 
         $document = DOMDocumentFactory::fromString(
@@ -57,7 +57,7 @@ XML
     public function testRegistrationInfoInheritance(): void
     {
         $expected = [
-            'registrationAuthority' => 'https://incommon.org',
+            'authority' => 'https://incommon.org',
         ];
 
         $document = DOMDocumentFactory::fromString(

--- a/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
@@ -40,7 +40,6 @@ class SAMLParserTest extends \SimpleSAML\Test\SigningTestCase
 XML
         );
 
-
         $entities = SAMLParser::parseDescriptorsElement($document->documentElement);
         $this->assertArrayHasKey('theEntityID', $entities);
         // RegistrationInfo is accessible in the SP or IDP metadata accessors
@@ -98,6 +97,72 @@ XML
 
         /** @var array $metadata */
         $metadata = $entities['subEntityIdOverride']->getMetadata20SP();
+        $this->assertEquals($expected, $metadata['RegistrationInfo']);
+    }
+
+
+    /**
+     * Test Registration Info is parsed
+     */
+    public function testRegistrationPolicy(): void
+    {
+        $expected = [
+            'authority' => 'https://safire.ac.za',
+            'policies' => [ 'en' => 'https://safire.ac.za/safire/policy/mrps/v20190207.html' ],
+        ];
+
+        $document = DOMDocumentFactory::fromString(
+            <<<XML
+<EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+  <EntityDescriptor entityID="theEntityID">
+    <Extensions>
+      <mdrpi:RegistrationInfo registrationAuthority="https://safire.ac.za">
+        <mdrpi:RegistrationPolicy xml:lang="en">https://safire.ac.za/safire/policy/mrps/v20190207.html</mdrpi:RegistrationPolicy>
+      </mdrpi:RegistrationInfo>
+    </Extensions>
+    <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+  </EntityDescriptor>
+</EntitiesDescriptor>
+XML
+        );
+
+        $entities = SAMLParser::parseDescriptorsElement($document->documentElement);
+        $this->assertArrayHasKey('theEntityID', $entities);
+        // RegistrationInfo is accessible in the SP or IDP metadata accessors
+        /** @var array $metadata */
+        $metadata = $entities['theEntityID']->getMetadata20SP();
+        $this->assertEquals($expected, $metadata['RegistrationInfo']);
+    }
+
+
+    /**
+     * Test Registration Info is parsed
+     */
+    public function testRegistrationInstant(): void
+    {
+        $expected = [
+            'authority' => 'https://safire.ac.za',
+            'instant' => 1675861615,
+        ];
+
+        $document = DOMDocumentFactory::fromString(
+            <<<XML
+<EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+  <EntityDescriptor entityID="theEntityID">
+    <Extensions>
+      <mdrpi:RegistrationInfo registrationAuthority="https://safire.ac.za" registrationInstant="2023-02-08T13:06:55Z" />
+    </Extensions>
+    <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+  </EntityDescriptor>
+</EntitiesDescriptor>
+XML
+        );
+
+        $entities = SAMLParser::parseDescriptorsElement($document->documentElement);
+        $this->assertArrayHasKey('theEntityID', $entities);
+        // RegistrationInfo is accessible in the SP or IDP metadata accessors
+        /** @var array $metadata */
+        $metadata = $entities['theEntityID']->getMetadata20SP();
         $this->assertEquals($expected, $metadata['RegistrationInfo']);
     }
 


### PR DESCRIPTION
The public documentation for the mdrpi extensions uses keys of `authority`, `identity`, and `policies`. However, SAMLBuilder creates PHP-style metadata with different keys which is inconsistent. This patch changes the behaviour to make `authority` behave consistently and adds support for the other two options.