### PR TITLE
Run psalm on testsuite with a different errorLevel

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -195,7 +195,11 @@ jobs:
 
       - name: Psalm
         continue-on-error: true
-        run: php vendor/bin/psalm --show-info=true --shepherd --php-version=${{ steps.setup-php.outputs.php-version }}
+        run: php vendor/bin/psalm -c psalm.xml --show-info=true --shepherd --php-version=${{ steps.setup-php.outputs.php-version }}
+
+      - name: Psalm (testsuite)
+        continue-on-error: true
+        run: php vendor/bin/psalm -c psalm-dev.xml --show-info=true --shepherd --php-version=${{ steps.setup-php.outputs.php-version }}
 
       - name: Psalter
         continue-on-error: false

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -198,7 +198,7 @@ jobs:
         run: php vendor/bin/psalm -c psalm.xml --show-info=true --shepherd --php-version=${{ steps.setup-php.outputs.php-version }}
 
       - name: Psalm (testsuite)
-        continue-on-error: true
+        continue-on-error: false
         run: php vendor/bin/psalm -c psalm-dev.xml --show-info=true --shepherd --php-version=${{ steps.setup-php.outputs.php-version }}
 
       - name: Psalter

--- a/psalm-dev.xml
+++ b/psalm-dev.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<psalm
+    name="SimpleSAMLphp testsuite"
+    useDocblockTypes="true"
+    errorLevel="4"
+    reportMixedIssues="false"
+    hideExternalErrors="true"
+    allowStringToStandInForClass="true"
+>
+    <projectFiles>
+        <directory name="tests" />
+
+        <!-- Ignore certain directories -->
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <!-- Ignore UnresolvableInclude on CLI-scripts -->
+        <UnresolvableInclude>
+            <errorLevel type="suppress">
+                <file name="tests/bootstrap.php" />
+                <file name="tests/routers/configLoader.php" />
+            </errorLevel>
+        </UnresolvableInclude>
+
+        <!-- Suppress PossiblyUndefinedGlobalVariable on templates -->
+        <PossiblyUndefinedGlobalVariable>
+            <errorLevel type="suppress">
+                <directory name="tests/src/SimpleSAML/Metadata/test-metadata" />
+            </errorLevel>
+        </PossiblyUndefinedGlobalVariable>
+
+        <!-- Suppress PHPunit-issue -->
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </PropertyNotSetInConstructor>
+
+        <!-- Suppress PHPunit-issue -->
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </InternalMethod>
+
+        <!-- Suppress Psalm-issue - We should be able to fix this with the static return-type in PHP 8.0 -->
+        <UnsafeInstantiation>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </UnsafeInstantiation>
+    </issueHandlers>
+
+    <stubs>
+        <file name="vendor/simplesamlphp/simplesamlphp-test-framework/stubs/krb5.php" />
+        <file name="vendor/simplesamlphp/simplesamlphp-test-framework/stubs/memcache.php" />
+        <file name="vendor/simplesamlphp/simplesamlphp-test-framework/stubs/memcached.php" />
+        <file name="vendor/simplesamlphp/simplesamlphp-test-framework/stubs/predis.php" />
+    </stubs>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,7 +13,6 @@
         <directory name="modules" />
         <directory name="public" />
         <directory name="src/SimpleSAML" />
-        <directory name="tests" />
 
         <!-- Ignore certain directories -->
         <ignoreFiles>
@@ -54,8 +53,6 @@
                 <file name="src/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php" />
                 <file name="src/SimpleSAML/Module.php" />
                 <file name="src/SimpleSAML/XHTML/Template.php" />
-                <file name="tests/bootstrap.php" />
-                <file name="tests/routers/configLoader.php" />
             </errorLevel>
         </UnresolvableInclude>
 
@@ -72,30 +69,8 @@
                 <directory name="config" />
                 <directory name="metadata" />
                 <directory name="modules/adfs/metadata-templates" />
-                <directory name="tests/src/SimpleSAML/Metadata/test-metadata" />
             </errorLevel>
         </PossiblyUndefinedGlobalVariable>
-
-        <!-- Suppress PHPunit-issue -->
-        <PropertyNotSetInConstructor>
-            <errorLevel type="suppress">
-                <directory name="tests" />
-            </errorLevel>
-        </PropertyNotSetInConstructor>
-
-        <!-- Suppress PHPunit-issue -->
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <directory name="tests" />
-            </errorLevel>
-        </InternalMethod>
-
-        <!-- Suppress Psalm-issue - We should be able to fix this with the static return-type in PHP 8.0 -->
-        <UnsafeInstantiation>
-            <errorLevel type="suppress">
-                <directory name="tests" />
-            </errorLevel>
-        </UnsafeInstantiation>
     </issueHandlers>
 
     <stubs>

--- a/tests/modules/core/src/Auth/Process/TargetedIDTest.php
+++ b/tests/modules/core/src/Auth/Process/TargetedIDTest.php
@@ -123,7 +123,7 @@ class TargetedIDTest extends TestCase
         $request = [
             'Attributes' => [
                 'eduPersonPrincipalName' => ['joe'],
-                'eduPersonTargetedID' => [$nameid->toXML()->ownerDocument->saveXML()],
+                'eduPersonTargetedID' => [$nameid->toXML()->ownerDocument?->saveXML()],
             ],
             'Source' => [
                 'metadata-set' => 'saml20-idp-hosted',

--- a/tests/modules/core/src/Controller/LogoutTest.php
+++ b/tests/modules/core/src/Controller/LogoutTest.php
@@ -66,6 +66,7 @@ class LogoutTest extends ClearStateTestCase
 
         $this->assertInstanceOf(RunnableResponse::class, $response);
         $this->assertTrue($response->isSuccessful());
+        /** @psalm-var array $callable */
         $callable = $response->getCallable();
         $this->assertInstanceOf(Auth\Simple::class, $callable[0]);
         $this->assertEquals('logout', $callable[1]);

--- a/tests/modules/cron/src/Controller/CronTest.php
+++ b/tests/modules/cron/src/Controller/CronTest.php
@@ -104,6 +104,7 @@ class CronTest extends TestCase
         $c = new Controller\Cron($this->config, $this->session);
         $response = $c->run('daily', 'secret');
 
+        $this->assertInstanceOf(Template::class, $response);
         $this->assertTrue($response->isSuccessful());
         $this->assertEquals('daily', $response->data['tag']);
         $this->assertFalse($response->data['mail_required']);

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -572,7 +572,7 @@ class SPTest extends ClearStateTestCase
         }
     }
 
-    public function getScopingOrders()
+    public function getScopingOrders(): array
     {
         return [
             [

--- a/tests/modules/saml/src/Controller/MetadataTest.php
+++ b/tests/modules/saml/src/Controller/MetadataTest.php
@@ -165,7 +165,9 @@ class MetadataTest extends TestCase
 
         if ($protected && !$authenticated) {
             $this->assertInstanceOf(RunnableResponse::class, $result);
-            $this->assertEquals("requireAdmin", $result->getCallable()[1]);
+            /** @psalm-var array $callable */
+            $callable = $result->getCallable();
+            $this->assertEquals("requireAdmin", $callable[1]);
         } else {
             $this->assertInstanceOf(Response::class, $result);
         }

--- a/tests/modules/saml/src/Controller/ServiceProviderTest.php
+++ b/tests/modules/saml/src/Controller/ServiceProviderTest.php
@@ -492,7 +492,9 @@ XML;
 
         if ($protected && !$authenticated) {
             $this->assertInstanceOf(RunnableResponse::class, $result);
-            $this->assertEquals("requireAdmin", $result->getCallable()[1]);
+            /** @psalm-var array $callable */
+            $callable = $result->getCallable();
+            $this->assertEquals("requireAdmin", $callable[1]);
         } else {
             $this->assertInstanceOf(Response::class, $result);
         }

--- a/tests/src/SimpleSAML/LoggerTest.php
+++ b/tests/src/SimpleSAML/LoggerTest.php
@@ -128,6 +128,7 @@ class LoggerTest extends TestCase
         Logger::{$method}($payload = "test {$method}");
 
         $logger = Logger::getLoggingHandler();
+        $this->assertInstanceOf(ArrayLogger::class, $logger);
         self::assertMatchesRegularExpression("/\[CL[0-9a-f]{8}\]\ {$payload}$/", $logger->logs[$level][0]);
     }
 }

--- a/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
+++ b/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
@@ -13,7 +13,7 @@ use SimpleSAML\TestUtils\ClearStateTestCase;
 
 class MetaDataStorageHandlerTest extends ClearStateTestCase
 {
-    protected $handler;
+    protected MetadataStorageHandler $handler;
 
     public function setUp(): void
     {

--- a/tests/src/SimpleSAML/Metadata/SAMLBuilderTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLBuilderTest.php
@@ -70,6 +70,7 @@ class SAMLBuilderTest extends TestCase
             $curAttribute = $attributes->item($c);
             $this->assertTrue($curAttribute->hasAttribute("Name"));
             $this->assertFalse($curAttribute->hasAttribute("FriendlyName"));
+            /** @psalm-suppress InvalidArrayOffset */
             $this->assertEquals($metadata['attributes'][$c], $curAttribute->getAttribute("Name"));
         }
 

--- a/tests/src/SimpleSAML/Store/StoreFactoryTest.php
+++ b/tests/src/SimpleSAML/Store/StoreFactoryTest.php
@@ -34,9 +34,7 @@ class StoreFactoryTest extends TestCase
         $config = Configuration::getInstance();
         $storeType = $config->getOptionalString('store.type', 'phpsession');
 
-        /** @var false $store */
         $store = StoreFactory::getInstance($storeType);
-
         $this->assertFalse($store);
     }
 
@@ -53,9 +51,7 @@ class StoreFactoryTest extends TestCase
         $config = Configuration::getInstance();
         $storeType = $config->getString('store.type');
 
-        /** @var false $store */
         $store = StoreFactory::getInstance($storeType);
-
         $this->assertFalse($store);
     }
 


### PR DESCRIPTION
This PR will split psalm-configuration in two and run on our testsuite on a lower errorLevel.
We only want to know about _real_ issues like missing params, not every possible null-value.