### PR TITLE
Bugfix: Fix use of back-button

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -5,6 +5,11 @@
 This document lists the changes between versions of SimpleSAMLphp.
 See the upgrade notes for specific information about upgrading.
 
+## Version 2.0.1
+
+* Several issues regarding the use of the back-button were fixed (#1720)
+* Many fixes in documentation
+
 ## Version 2.0.0
 
 * Many changes, upgrades and improvements since the 1.x series.
@@ -16,7 +21,7 @@ See the upgrade notes for specific information about upgrading.
 * Code cleanups, improvements and simplifications.
 * Improved test coverage and more use of standard libraries.
 * Compatibility with modern versions of PHP.
-* Variouw new features, including:
+* Various new features, including:
   * SAML SubjectID and Pairwise ID support
   * Accepting unsolicited responses can be disabled by setting `enable_unsolicited` to `false` in the SP authsource.
   * Certificates and private keys can now be retrieved from a database

--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -9,6 +9,7 @@ See the upgrade notes for specific information about upgrading.
 
 * Several issues regarding the use of the back-button were fixed (#1720)
 * Many fixes in documentation
+* Fixed config/authsources.php.dist so you can just rename it for new deployments to get you started (#1771)
 
 ## Version 2.0.0
 

--- a/modules/admin/src/Controller/Test.php
+++ b/modules/admin/src/Controller/Test.php
@@ -136,6 +136,7 @@ class Test
                 $params = [
                     'ErrorURL' => $url,
                     'ReturnTo' => $url,
+                    Auth\State::RESTART => $url,
                 ];
                 return new RunnableResponse([$authsource, 'login'], [$params]);
             }

--- a/modules/core/public/assets/js/loginuserpass.js
+++ b/modules/core/public/assets/js/loginuserpass.js
@@ -1,6 +1,5 @@
 ready(function () {
     var button = document.getElementById("submit_button");
-    var form = document.getElementById("f");
 
     window.onpageshow  = function () {
         var button = document.getElementById("submit_button");
@@ -13,11 +12,5 @@ ready(function () {
         button.innerHTML = button.getAttribute("data-processing");
         button.disabled = true;
     }
-
-    button.onclick = function () {
-        var form = document.getElementById("f");
-        form.submit();
-        return true;
-    };
 });
 

--- a/modules/core/public/assets/js/loginuserpass.js
+++ b/modules/core/public/assets/js/loginuserpass.js
@@ -1,9 +1,20 @@
 ready(function () {
     var button = document.getElementById("submit_button");
-    button.onclick = function () {
-        this.innerHTML = button.getAttribute("data-processing");
-        this.disabled = true;
+    var form = document.getElementById("f");
 
+    window.onpageshow  = function () {
+        var button = document.getElementById("submit_button");
+        button.innerHTML = button.getAttribute('data-default');
+        button.disabled = false;
+    }
+
+    form.onsubmit = function () {
+        var button = document.getElementById("submit_button");
+        button.innerHTML = button.getAttribute("data-processing");
+        button.disabled = true;
+    }
+
+    button.onclick = function () {
         var form = document.getElementById("f");
         form.submit();
         return true;

--- a/modules/core/public/assets/js/loginuserpass.js
+++ b/modules/core/public/assets/js/loginuserpass.js
@@ -1,12 +1,11 @@
 ready(function () {
-    var button = document.getElementById("submit_button");
-
     window.onpageshow  = function () {
         var button = document.getElementById("submit_button");
         button.innerHTML = button.getAttribute('data-default');
         button.disabled = false;
     }
 
+    var form = document.getElementById("f");
     form.onsubmit = function () {
         var button = document.getElementById("submit_button");
         button.innerHTML = button.getAttribute("data-processing");

--- a/modules/core/templates/loginuserpass.twig
+++ b/modules/core/templates/loginuserpass.twig
@@ -92,8 +92,8 @@
                     {% if rememberOrganizationEnabled is defined -%}
                     <div class="pure-controls">
                         <label for="remember_organization" class="pure-checkbox">
- 	                    <input type="checkbox" id="remember_organization" tabindex="5" name="remember_organization" value="Yes"
-                                {{ rememberOrganizationChecked ? 'checked="checked"' }} >
+                            <input type="checkbox" id="remember_organization" tabindex="5" name="remember_organization"
+                                value="Yes" {{ rememberOrganizationChecked ? 'checked="checked"' }} >
                             <small>{{ 'Remember my organization'|trans }}</small>
                         </label>
                     </div>
@@ -103,7 +103,8 @@
 
             <div class="pure-control-group center login-form-submit">
                 <button class="pure-button pure-button-red pure-input-1-2 pure-input-sm-1-1 right" id="submit_button"
-                        type="submit" tabindex="6" data-processing="{% trans %}Processing...{% endtrans %}">
+                        type="submit" tabindex="6" data-default="{% trans %}Login{% endtrans %}"
+                        data-processing="{% trans %}Processing...{% endtrans %}">
                 {% trans %}Login{% endtrans %}
                 </button>
             </div>

--- a/src/SimpleSAML/Auth/Simple.php
+++ b/src/SimpleSAML/Auth/Simple.php
@@ -153,8 +153,12 @@ class Simple
             $errorURL = null;
         }
 
-
-        if (!isset($params[State::RESTART]) && is_string($returnTo)) {
+        $as = $this->getAuthSource();
+        if (
+            $as instanceof Module\saml\Auth\Source\SP
+            && !isset($params[State::RESTART])
+            && is_string($returnTo)
+        ) {
             /*
              * A URL to restart the authentication, in case the user bookmarks
              * something, e.g. the discovery service page.
@@ -163,7 +167,6 @@ class Simple
             $params[State::RESTART] = $restartURL;
         }
 
-        $as = $this->getAuthSource();
         $as->initLogin($returnTo, $errorURL, $params);
         Assert::true(false);
     }


### PR DESCRIPTION
This PR fixes two issues with the back-button;

The JavaScript-part makes sure the submit-button becomes enabled again.
Now after fixing this, a new problem arised; the restart-url would be triggered to restart the authentication, but we used `getLoginURL` to generate it, which was recently limited to only work for SP-authsources. The second fix is therefor to properly set a restart-url that works for non-SP authsources.

Closes #1720