### PR TITLE
Update authsources.php.dist

### DIFF
--- a/config/authsources.php.dist
+++ b/config/authsources.php.dist
@@ -196,68 +196,51 @@ $config = [
     'example-ldap' => [
         'ldap:Ldap',
 
-        /**
-         * The connection string for the LDAP-server.
-         * You can add multiple by separating them with a space.
-         */
+        // The connection string for the LDAP-server.
+        // You can add multiple by separating them with a space.
         'connection_string' => 'ldap.example.org',
 
-        /**
-         * Whether SSL/TLS should be used when contacting the LDAP server.
-         * Possible values are 'ssl', 'tls' or 'none'
-         */
+        // Whether SSL/TLS should be used when contacting the LDAP server.
+        // Possible values are 'ssl', 'tls' or 'none'
         'encryption' => 'ssl',
 
-        /**
-         * The LDAP version to use when interfacing the LDAP-server.
-         * Defaults to 3
-         */
+        // The LDAP version to use when interfacing the LDAP-server.
+        // Defaults to 3
         'version' => 3,
 
-        /**
-         * Set to TRUE to enable LDAP debug level. Passed to the LDAP connector class.
-         *
-         * Default: FALSE
-         * Required: No
-         */
+        // Set to TRUE to enable LDAP debug level. Passed to the LDAP connector class.
+        //
+        // Default: FALSE
+        // Required: No
         'ldap.debug' => false,
 
-        /**
-         * The LDAP-options to pass when setting up a connection
-         * See [Symfony documentation][1]
-         */
+        // The LDAP-options to pass when setting up a connection
+        // See [Symfony documentation][1]
         'options' => [
-            /**
-             * Set whether to follow referrals.
-             * AD Controllers may require 0x00 to function.
-             * Possible values are 0x00 (NEVER), 0x01 (SEARCHING),
-             *   0x02 (FINDING) or 0x03 (ALWAYS).
-             */
+
+            // Set whether to follow referrals.
+            // AD Controllers may require 0x00 to function.
+            // Possible values are 0x00 (NEVER), 0x01 (SEARCHING),
+            //   0x02 (FINDING) or 0x03 (ALWAYS).
             'referrals' => 0x00,
 
             'network_timeout' => 3,
         ],
 
-        /**
-         * The connector to use.
-         * Defaults to '\SimpleSAML\Module\ldap\Connector\Ldap', but can be set
-         * to '\SimpleSAML\Module\ldap\Connector\ActiveDirectory' when
-         * authenticating against Microsoft Active Directory. This will
-         * provide you with more specific error messages.
-         */
+        // The connector to use.
+        // Defaults to '\SimpleSAML\Module\ldap\Connector\Ldap', but can be set
+        // to '\SimpleSAML\Module\ldap\Connector\ActiveDirectory' when
+        // authenticating against Microsoft Active Directory. This will
+        // provide you with more specific error messages.
         'connector' => '\SimpleSAML\Module\ldap\Connector\Ldap',
 
-        /**
-         * Which attributes should be retrieved from the LDAP server.
-         * This can be an array of attribute names, or NULL, in which case
-         * all attributes are fetched.
-         */
+        // Which attributes should be retrieved from the LDAP server.
+        // This can be an array of attribute names, or NULL, in which case
+        // all attributes are fetched.
         'attributes' => null,
 
-        /**
-         * Which attributes should be base64 encoded after retrieval from
-         * the LDAP server.
-         */
+         // Which attributes should be base64 encoded after retrieval from
+         // the LDAP server.
         'attributes.binary' => [
             'jpegPhoto',
             'objectGUID',
@@ -265,58 +248,44 @@ $config = [
             'mS-DS-ConsistencyGuid'
         ],
 
-        /**
-         * The pattern which should be used to create the user's DN given
-         * the username. %username% in this pattern will be replaced with
-         * the user's username.
-         *
-         * This option is not used if the search.enable option is set to TRUE.
-         */
+        // The pattern which should be used to create the user's DN given
+        // the username. %username% in this pattern will be replaced with
+        // the user's username.
+        //
+        // This option is not used if the search.enable option is set to TRUE.
         'dnpattern' => 'uid=%username%,ou=people,dc=example,dc=org',
 
-        /**
-         * As an alternative to specifying a pattern for the users DN, it is
-         * possible to search for the username in a set of attributes. This is
-         * enabled by this option.
-         */
+        // As an alternative to specifying a pattern for the users DN, it is
+        // possible to search for the username in a set of attributes. This is
+        // enabled by this option.
         'search.enable' => false,
 
-        /**
-         * An array on DNs which will be used as a base for the search. In
-         * case of multiple strings, they will be searched in the order given.
-         */
+        // An array on DNs which will be used as a base for the search. In
+        // case of multiple strings, they will be searched in the order given.
         'search.base' => [
             'ou=people,dc=example,dc=org',
         ],
 
-        /**
-         * The scope of the search. Valid values are 'sub' and 'one' and
-         * 'base', first one being the default if no value is set.
-         */
+        // The scope of the search. Valid values are 'sub' and 'one' and
+        // 'base', first one being the default if no value is set.
         'search.scope' => 'sub',
 
-        /**
-         * The attribute(s) the username should match against.
-         *
-         * This is an array with one or more attribute names. Any of the
-         * attributes in the array may match the value the username.
-         */
+        // The attribute(s) the username should match against.
+        //
+        // This is an array with one or more attribute names. Any of the
+        // attributes in the array may match the value the username.
         'search.attributes' => ['uid', 'mail'],
 
-        /**
-         * Additional filters that must match for the entire LDAP search to
-         * be true.
-         *
-         * This should be a single string conforming to [RFC 1960][2]
-         * and [RFC 2544][3]. The string is appended to the search attributes
-         */
+        // Additional filters that must match for the entire LDAP search to
+        // be true.
+        //
+        // This should be a single string conforming to [RFC 1960][2]
+        // and [RFC 2544][3]. The string is appended to the search attributes
         'search.filter' => '(&(objectClass=Person)(|(sn=Doe)(cn=John *)))',
 
-        /**
-         * The username & password where SimpleSAMLphp should bind to before
-         * searching. If this is left NULL, no bind will be performed before
-         * searching.
-         */
+        // The username & password where SimpleSAMLphp should bind to before
+        // searching. If this is left NULL, no bind will be performed before
+        // searching.
         'search.username' => null,
         'search.password' => null,
     ],
@@ -327,50 +296,42 @@ $config = [
     'example-ldapmulti' => [
         'ldap:LdapMulti',
 
-        /*
-         * The way the organization as part of the username should be handled.
-         * Three possible values:
-         * - 'none':   No handling of the organization. Allows '@' to be part
-         *             of the username.
-         * - 'allow':  Will allow users to type 'username@organization'.
-         * - 'force':  Force users to type 'username@organization'. The dropdown
-         *             list will be hidden.
-         *
-         * The default is 'none'.
-         */
+         // The way the organization as part of the username should be handled.
+         // Three possible values:
+         // - 'none':   No handling of the organization. Allows '@' to be part
+         //             of the username.
+         // - 'allow':  Will allow users to type 'username@organization'.
+         // - 'force':  Force users to type 'username@organization'. The dropdown
+         //             list will be hidden.
+         //
+         // The default is 'none'.
         'username_organization_method' => 'none',
 
-        /*
-         * Whether the organization should be included as part of the username
-         * when authenticating. If this is set to TRUE, the username will be on
-         * the form <username>@<organization identifier>. If this is FALSE, the
-         * username will be used as the user enters it.
-         *
-         * The default is FALSE.
-         */
+        // Whether the organization should be included as part of the username
+        // when authenticating. If this is set to TRUE, the username will be on
+        // the form <username>@<organization identifier>. If this is FALSE, the
+        // username will be used as the user enters it.
+        //
+        // The default is FALSE.
         'include_organization_in_username' => false,
 
-        /*
-         * A list of available LDAP servers.
-         *
-         * The index is an identifier for the organization/group. When
-         * 'username_organization_method' is set to something other than 'none',
-         * the organization-part of the username is matched against the index.
-         *
-         * The value of each element is an array in the same format as an LDAP
-         * authentication source.
-         */
+        // A list of available LDAP servers.
+        //
+        // The index is an identifier for the organization/group. When
+        // 'username_organization_method' is set to something other than 'none',
+        // the organization-part of the username is matched against the index.
+        //
+        // The value of each element is an array in the same format as an LDAP
+        // authentication source.
         'mapping' => [
             'employees' => [
-                /**
-                 * A short name/description for this group. Will be shown in a
-                 * dropdown list when the user logs on.
-                 *
-                 * This option can be a string or an array with
-                 * language => text mappings.
-                 */
+                // A short name/description for this group. Will be shown in a
+                // dropdown list when the user logs on.
+                //
+                // This option can be a string or an array with
+                // language => text mappings.
                 'description' => 'Employees',
-                'authsource' => ''example-ldap,
+                'authsource' => 'example-ldap',
             ],
 
             'students' => [


### PR DESCRIPTION
The multi-line comments break the 'dist' version of authsources.php file.

This prevent to access to the '/admin' location if one simply copy/paste/rename it, because he meets the error:

```php
SimpleSAML\Error\ConfigurationError: The configuration (/var/simplesamlphp/config/authsources.php) is invalid: syntax error, unexpected token ","
Backtrace:
9 src/SimpleSAML/Configuration.php:140 (SimpleSAML\Configuration::loadFromFile)
8 src/SimpleSAML/Configuration.php:264 (SimpleSAML\Configuration::getConfig)
7 src/SimpleSAML/Auth/Source.php:345 (SimpleSAML\Auth\Source::getById)
6 src/SimpleSAML/Utils/Auth.php:63 (SimpleSAML\Utils\Auth::requireAdmin)
5 modules/admin/src/Controller/Config.php:117 (SimpleSAML\Module\admin\Controller\Config::main)
4 /var/simplesamlphp/vendor/symfony/http-kernel/HttpKernel.php:163 (Symfony\Component\HttpKernel\HttpKernel::handleRaw)
3 /var/simplesamlphp/vendor/symfony/http-kernel/HttpKernel.php:75 (Symfony\Component\HttpKernel\HttpKernel::handle)
2 /var/simplesamlphp/vendor/symfony/http-kernel/Kernel.php:202 (Symfony\Component\HttpKernel\Kernel::handle)
1 src/SimpleSAML/Module.php:234 (SimpleSAML\Module::process)
0 public/module.php:14 (N/A)
```
The provided commit fixes this issue.