### PR TITLE
Fix logout completion for SP

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -10,6 +10,7 @@ See the upgrade notes for specific information about upgrading.
 Released 2023-03-10
 
 * The language-menu on mobile devices was fixed
+* Fix logout completion for SP (#1780) 
 * The `loginpage_links` functionality for authsources was restored and documented (#1773)
 * Several issues regarding the use of the back-button were fixed (#1720)
 * Many fixes in documentation

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -516,7 +516,7 @@ class ServiceProvider
 
             $state = $this->authState::loadState($relayState, 'saml:slosent');
             $state['saml:sp:LogoutStatus'] = $message->getStatus();
-            return new RunnableResponse([Auth\Source::class, 'completeLogout'], [$state]);
+            return new RunnableResponse([Auth\Source::class, 'completeLogout'], [&$state]);
         } elseif ($message instanceof LogoutRequest) {
             Logger::debug('module/saml2/sp/logout: Request from ' . $idpEntityId);
             Logger::stats('saml20-idp-SLO idpinit ' . $spEntityId . ' ' . $idpEntityId);


### PR DESCRIPTION
Reference parameters need to be explicitely marked as such in the arguments array when using call_user_func_array().

Fixes the following exception:
```
SimpleSAML\Error\Exception: Warning - Parameter 1 to SimpleSAML\Auth\Source::completeLogout() expected to be a reference, value given at .../vendor/simplesamlphp/simplesamlphp/src/SimpleSAML/HTTP/RunnableResponse.php:72
Backtrace:
4 .../vendor/simplesamlphp/simplesamlphp/public/_include.php:86 (SimpleSAML_error_handler)
3 [builtin] (call_user_func_array)
2 .../vendor/simplesamlphp/simplesamlphp/src/SimpleSAML/HTTP/RunnableResponse.php:72 (SimpleSAML\HTTP\RunnableResponse::sendContent)
1 .../vendor/symfony/http-foundation/Response.php:394 (Symfony\Component\HttpFoundation\Response::send)
0 .../vendor/simplesamlphp/simplesamlphp/public/module.php:14 (N/A)
```