### PR TITLE
Correct host in generated URLS for IdPs with 'host' config in admin/federation

### DIFF
--- a/modules/admin/src/Controller/Federation.php
+++ b/modules/admin/src/Controller/Federation.php
@@ -198,13 +198,14 @@ class Federation
                 $httpUtils = new Utils\HTTP();
                 $metadataBase = Module::getModuleURL('saml/idp/metadata');
                 if (count($idps) > 1) {
+                    $selfHost = $httpUtils->getSelfHost();
                     foreach ($idps as $index => $idp) {
                         if (isset($idp['host']) && $idp['host'] !== '__DEFAULT__') {
-                            $hostMetadataBase = str_replace('://' . $httpUtils->getSelfHost(), '://' . $idp['host'], $metadataBase);
+                            $mdHostBase = str_replace('://' . $selfHost, '://' . $idp['host'], $metadataBase);
                         } else {
-                            $hostMetadataBase = $metadataBase;
+                            $mdHostBase = $metadataBase;
                         }
-                        $idp['url'] = $hostMetadataBase . '?idpentityid=' . urlencode($idp['entityid']);
+                        $idp['url'] = $mdHostBase . '?idpentityid=' . urlencode($idp['entityid']);
                         $idp['metadata-set'] = 'saml20-idp-hosted';
                         $idp['metadata-index'] = $index;
                         $idp['metadata_array'] = SAML2_IdP::getHostedMetadata($idp['entityid']);

--- a/modules/admin/src/Controller/Federation.php
+++ b/modules/admin/src/Controller/Federation.php
@@ -199,7 +199,12 @@ class Federation
                 $metadataBase = Module::getModuleURL('saml/idp/metadata');
                 if (count($idps) > 1) {
                     foreach ($idps as $index => $idp) {
-                        $idp['url'] = $metadataBase . '?idpentityid=' . urlencode($idp['entityid']);
+                        if (isset($idp['host']) && $idp['host'] !== '__DEFAULT__') {
+                            $hostMetadataBase = str_replace('://' . $httpUtils->getSelfHost(), '://' . $idp['host'], $metadataBase);
+                        } else {
+                            $hostMetadataBase = $metadataBase;
+                        }
+                        $idp['url'] = $hostMetadataBase . '?idpentityid=' . urlencode($idp['entityid']);
                         $idp['metadata-set'] = 'saml20-idp-hosted';
                         $idp['metadata-index'] = $index;
                         $idp['metadata_array'] = SAML2_IdP::getHostedMetadata($idp['entityid']);

--- a/modules/admin/templates/federation.twig
+++ b/modules/admin/templates/federation.twig
@@ -21,7 +21,17 @@
           <dl>
             <dt>{{ set|entityDisplayName }}</dt>
 
-            <dd>EntityID: <code>{{ set.entityid }}</code></dd>
+            <dd>EntityID: <code>{{ set.entityid }}</code>
+            {% if set.type == 'saml20-idp-hosted' and set.host is defined %}
+                (hostname:
+                    {% if set.host == '__DEFAULT__' %}
+                        <em>{{ 'default'|trans }}</em>
+                    {%- else %}
+                        <code>{{ set.host }}</code>
+                    {%- endif -%}
+                )
+            {% endif %}
+            </dd>
             {%- if set.deprecated is defined and set.deprecated %}
 
               <dd><span class="entity-deprecated">{{ 'Deprecated'|trans }}</span></dd>

--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -762,11 +762,14 @@ class SAML2
         }
         $config = $handler->getMetaDataConfig($entityid, 'saml20-idp-hosted');
 
+        $host = $config->getOptionalString('host', null);
+        $host = $host === '__DEFAULT__' ? null : $host;
+
         // configure endpoints
-        $ssob = $handler->getGenerated('SingleSignOnServiceBinding', 'saml20-idp-hosted');
-        $slob = $handler->getGenerated('SingleLogoutServiceBinding', 'saml20-idp-hosted');
-        $ssol = $handler->getGenerated('SingleSignOnService', 'saml20-idp-hosted');
-        $slol = $handler->getGenerated('SingleLogoutService', 'saml20-idp-hosted');
+        $ssob = $handler->getGenerated('SingleSignOnServiceBinding', 'saml20-idp-hosted', $host);
+        $slob = $handler->getGenerated('SingleLogoutServiceBinding', 'saml20-idp-hosted', $host);
+        $ssol = $handler->getGenerated('SingleSignOnService', 'saml20-idp-hosted', $host);
+        $slol = $handler->getGenerated('SingleLogoutService', 'saml20-idp-hosted', $host);
 
         $sso = [];
         if (is_array($ssob)) {

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
@@ -83,11 +83,12 @@ class MetaDataStorageHandler implements ClearableState
      *
      * @param string $property The metadata property which should be auto-generated.
      * @param string $set The set we the property comes from.
+     * @param string $overrideHost Hostname to use in the URLs
      *
      * @return string|array The auto-generated metadata property.
      * @throws \Exception If the metadata cannot be generated automatically.
      */
-    public function getGenerated(string $property, string $set)
+    public function getGenerated(string $property, string $set, string $overrideHost = null)
     {
         // first we check if the user has overridden this property in the metadata
         try {
@@ -101,9 +102,11 @@ class MetaDataStorageHandler implements ClearableState
 
         // get the configuration
         $config = Configuration::getInstance();
-
         $httpUtils = new Utils\HTTP();
         $baseurl = $httpUtils->getSelfURLHost() . $config->getBasePath();
+        if ($overrideHost !== null) {
+            $baseurl = str_replace('://' . $httpUtils->getSelfHost(), '://' . $overrideHost, $baseurl);
+        }
 
         if ($set == 'saml20-sp-hosted') {
             if ($property === 'SingleLogoutServiceBinding') {


### PR DESCRIPTION
It gets quite fiddly to get this right. The actual metadata (hosted on the `host` itself) is alreafy correct because the URL generator uses the 'current' entity metadata and current URL. The admin interface of course presents all entities in one page and hence cannot rely on the current URL. Therefore we need to override the url host for this specific display case.

Closes: #1774