### PR TITLE
IdP logout fix case sensitive key in logout

### DIFF
--- a/modules/saml/src/Message.php
+++ b/modules/saml/src/Message.php
@@ -534,7 +534,7 @@ class Message
     ): LogoutRequest {
         $lr = new LogoutRequest();
         $issuer = new Issuer();
-        $issuer->setValue($srcMetadata->getString('entityID'));
+        $issuer->setValue($srcMetadata->getString('entityid'));
         $issuer->setFormat(Constants::NAMEID_ENTITY);
         $lr->setIssuer($issuer);
 


### PR DESCRIPTION
In my opinion there should be **entityid** in lower case.  Here is inititated with lower case: https://github.com/simplesamlphp/simplesamlphp/blob/master/src/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php#L127

Without this change I got "Unable to initialize logout to " in logs. And was logouted only from SP, where I click on Logout not from next SPs.

With this change I am logouted from all SPs without problems.