### PR TITLE
Restore nullable assocId for SLO

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -13,6 +13,7 @@ Released 2023-03-10
 * Fix some issues with logout (#1780, #1785)
 * The `loginpage_links` functionality for authsources was restored and documented (#1770, #1773)
 * Several issues regarding the use of the back-button were fixed (#1720)
+* Fixed IdP-initiated SLO (#1776)
 * Many fixes in documentation
 * Fixed config/authsources.php.dist so you can just rename it for new deployments to get you started (#1771)
 * Fixed UTF-8 encoding for metadata output

--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -10,10 +10,9 @@ See the upgrade notes for specific information about upgrading.
 Released 2023-03-10
 
 * The language-menu on mobile devices was fixed
-* Fix some issues with logout (#1780, #1785)
+* Fix some issues with logout (#1776, #1780, #1785)
 * The `loginpage_links` functionality for authsources was restored and documented (#1770, #1773)
 * Several issues regarding the use of the back-button were fixed (#1720)
-* Fixed IdP-initiated SLO (#1776)
 * Many fixes in documentation
 * Fixed config/authsources.php.dist so you can just rename it for new deployments to get you started (#1771)
 * Fixed UTF-8 encoding for metadata output

--- a/src/SimpleSAML/IdP.php
+++ b/src/SimpleSAML/IdP.php
@@ -437,7 +437,7 @@ class IdP
                 throw new Error\Exception('Unknown logout handler: ' . var_export($logouttype, true));
         }
 
-        /** @var IdP\LogoutHandlerInterface */
+        /** @var \SimpleSAML\IdP\LogoutHandlerInterface */
         return new $handler($this);
     }
 

--- a/src/SimpleSAML/IdP/LogoutHandlerInterface.php
+++ b/src/SimpleSAML/IdP/LogoutHandlerInterface.php
@@ -29,9 +29,9 @@ interface LogoutHandlerInterface
      * This function must never return.
      *
      * @param array &$state The logout state.
-     * @param string $assocId The association that started the logout.
+     * @param string|null $assocId The association that started the logout.
      */
-    public function startLogout(array &$state, string $assocId): void;
+    public function startLogout(array &$state, ?string $assocId): void;
 
 
     /**

--- a/src/SimpleSAML/IdP/TraditionalLogoutHandler.php
+++ b/src/SimpleSAML/IdP/TraditionalLogoutHandler.php
@@ -80,9 +80,9 @@ class TraditionalLogoutHandler implements LogoutHandlerInterface
      * This function never returns.
      *
      * @param array  &$state The logout state.
-     * @param string $assocId The association that started the logout.
+     * @param string|null $assocId The association that started the logout.
      */
-    public function startLogout(array &$state, string $assocId): void
+    public function startLogout(array &$state, /** @scrutinizer ignore-unused */?string $assocId): void
     {
         $state['core:LogoutTraditional:Remaining'] = $this->idp->getAssociations();
 


### PR DESCRIPTION
Closes #1776

The assocId is nullable for IdP-initiated SLO