### PR TITLE
The setNameIdPolicy method requires the NameIDPolicy class parameter, but it passed an array.

### DIFF
--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -14,6 +14,7 @@ use SimpleSAML\SAML2\Exception\ArrayValidationException;
 use SimpleSAML\SAML2\Exception\Protocol\{NoAvailableIDPException, NoPassiveException, NoSupportedIDPException};
 use SimpleSAML\SAML2\XML\md\ContactPerson;
 use SimpleSAML\SAML2\XML\saml\NameID;
+use SimpleSAML\SAML2\XML\samlp\NameIDPolicy;
 use SimpleSAML\Store\StoreFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
@@ -561,7 +562,7 @@ class SP extends Auth\Source
         }
 
         if (!empty($state['saml:NameIDPolicy'])) {
-            $ar->setNameIdPolicy($state['saml:NameIDPolicy']);
+            $ar->setNameIdPolicy(NameIDPolicy::fromArray($state['saml:NameIDPolicy']));
         }
 
         $requesterID = [];

--- a/modules/saml/src/Message.php
+++ b/modules/saml/src/Message.php
@@ -12,6 +12,7 @@ use SimpleSAML\SAML2\{Assertion, EncryptedAssertion}; // Assertions
 use SimpleSAML\SAML2\{AuthnRequest, LogoutRequest, LogoutResponse, Response, StatusResponse}; // Messages
 use SimpleSAML\SAML2\{Constants as C, SignedElement};
 use SimpleSAML\SAML2\XML\saml\Issuer;
+use SimpleSAML\SAML2\XML\samlp\NameIDPolicy;
 use SimpleSAML\XMLSecurity\XML\ds\{KeyInfo, X509Certificate, X509Data};
 
 use function array_key_exists;
@@ -487,7 +488,7 @@ class Message
         $policy = Utils\Config\Metadata::parseNameIdPolicy($nameIdPolicy);
         // empty array signals not to set any NameIdPolicy element
         if ($policy !== []) {
-            $ar->setNameIdPolicy($policy);
+            $ar->setNameIdPolicy(NameIDPolicy::fromArray($policy));
         }
 
         $ar->setForceAuthn($spMetadata->getOptionalBoolean('ForceAuthn', false));


### PR DESCRIPTION
The fromArray static method applies to pass the setNameIdPolicy method.