### PR TITLE
full french translation of admin.po (admin module fr locales)

### DIFF
--- a/modules/admin/locales/fr/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/fr/LC_MESSAGES/admin.po
@@ -24,10 +24,10 @@ msgid "SimpleSAMLphp installation page"
 msgstr "Page d'installation de SimpleSAMLphp"
 
 msgid "SimpleSAMLphp is installed in:"
-msgstr ""
+msgstr "SimpleSAMLphp est installé dans le répertoire:"
 
 msgid "You are running version <kbd>%version%</kbd>."
-msgstr ""
+msgstr "Vous utilisez la version <kbd>%version%</kbd>".
 
 msgid "Configuration"
 msgstr "Configuration"
@@ -36,31 +36,31 @@ msgid "Checking your PHP installation"
 msgstr "Vérification de votre installation de PHP"
 
 msgid "required"
-msgstr ""
+msgstr "requis"
 
 msgid "optional"
-msgstr ""
+msgstr "optionnel"
 
 msgid "SimpleSAMLphp Show Metadata"
-msgstr ""
+msgstr "SimpleSAMLphp Afficher les métadonnées"
 
 msgid "Metadata"
 msgstr "Métadonnées"
 
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "Copier dans le presse-papiers"
 
 msgid "Back"
-msgstr ""
+msgstr "Retour"
 
 msgid "XML metadata"
 msgstr "Métadonnées XML"
 
 msgid "or select a file:"
-msgstr ""
+msgstr "ou sélectionner un fichier:"
 
 msgid "No file selected."
-msgstr ""
+msgstr "Aucun fichier sélectionné."
 
 msgid "Parse"
 msgstr "Analyser"
@@ -69,58 +69,58 @@ msgid "Converted metadata"
 msgstr "Métadonnées converties"
 
 msgid "An error occurred"
-msgstr ""
+msgstr "Une erreur s'est produite"
 
 msgid "Test Authentication Sources"
-msgstr ""
+msgstr "Tester les sources d'authentification"
 
 msgid "Hosted entities"
-msgstr ""
+msgstr "Entités hébergées"
 
 msgid "Trusted entities"
-msgstr ""
+msgstr "Entités de confiance"
 
 msgid "expired"
-msgstr ""
+msgstr "expiré"
 
 msgid "expires"
-msgstr ""
+msgstr "expire"
 
 msgid "Tools"
 msgstr "Outils"
 
 msgid "Look up metadata for entity:"
-msgstr ""
+msgstr "Rechercher les métadonnées de l'entité:"
 
 msgid "EntityID"
-msgstr ""
+msgstr "Entité ID"
 
 msgid "Search"
-msgstr ""
+msgstr "Rechercher"
 
 msgid "Type:"
-msgstr ""
+msgstr "Type:"
 
 msgid "SAML Metadata"
-msgstr ""
+msgstr "Métadonnées SAML"
 
 msgid "You can get the metadata XML on a dedicated URL:"
-msgstr ""
+msgstr "Vous pouvez obtenir les métadonnées XML sur une URL dédiée:"
 
 msgid "In SAML 2.0 Metadata XML format:"
-msgstr "Au format XML de métadonnées SAML 2.0"
+msgstr "Au format XML de métadonnées SAML 2.0:"
 
 msgid "SimpleSAMLphp Metadata"
-msgstr ""
+msgstr "Métadonnées SimpleSAMLphp"
 
 msgid "Use this if you are using a SimpleSAMLphp entity on the other side:"
-msgstr ""
+msgstr "Utilisez cette option si vous utilisez une entité SimpleSAMLphp de l'autre côté:"
 
 msgid "Certificates"
 msgstr "Certificats"
 
 msgid "new"
-msgstr ""
+msgstr "nouveau"
 
 msgid "Diagnostics on hostname, port and protocol"
 msgstr "Diagnostics sur le nom d'hôte, le port et le protocole"
@@ -131,6 +131,8 @@ msgid ""
 "     it lasts until it times out and all the attributes that are attached to "
 "your session."
 msgstr ""
+"Bonjour, voici la page d'état de SimpleSAMLphp. Ici, vous pouvez voir si votre session\n"
+"est expirée, sa durée de validité et tous les attributs qui y sont attachés."
 
 msgid "Your session is valid for %remaining% seconds from now."
 msgstr "Votre session est encore valide pour %remaining% secondes."
@@ -139,130 +141,133 @@ msgid "Your attributes"
 msgstr "Vos attributs"
 
 msgid "Technical information"
-msgstr ""
+msgstr "Informations techniques"
 
 msgid "SAML Subject"
-msgstr ""
+msgstr "SAML Sujet"
 
 msgid "not set"
-msgstr ""
+msgstr "non défini"
 
 msgid "Format"
-msgstr ""
+msgstr "Format"
 
 msgid "Authentication data"
-msgstr ""
+msgstr "Données d'authentification"
 
 msgid "Logout"
 msgstr "Déconnexion"
 
 msgid "Content of jpegPhoto attribute"
-msgstr ""
+msgstr "Contenu de l'attribut jpegPhoto"
 
 msgid "Log out"
-msgstr ""
+msgstr "Déconnexion"
 
 msgid "Test"
-msgstr ""
+msgstr "Test"
 
 msgid "Federation"
 msgstr "Fédération"
 
 msgid "Information on your PHP installation"
-msgstr ""
+msgstr "Informations sur votre installation PHP"
 
 msgid "PHP %minimum% or newer is needed. You are running: %current%"
-msgstr ""
+msgstr "PHP %minimum% ou plus récent est nécessaire. Vous utilisez : %current%"
 
 msgid "Date/Time Extension"
-msgstr ""
+msgstr "Extension Date/Heure"
 
 msgid "Hashing function"
-msgstr ""
+msgstr "Fonction de hachage"
 
 msgid "ZLib"
-msgstr ""
+msgstr "ZLib"
 
 msgid "OpenSSL"
-msgstr ""
+msgstr "OpenSSL"
 
 msgid "XML DOM"
-msgstr ""
+msgstr "XML DOM"
 
 msgid "Regular expression support"
-msgstr ""
+msgstr "Prise en charge des expressions régulières"
 
 msgid "JSON support"
-msgstr ""
+msgstr "Prise en charge de JSON"
 
 msgid "Standard PHP library (SPL)"
-msgstr ""
+msgstr "Bibliothèque standard de PHP (SPL)"
 
 msgid "Multibyte String extension"
-msgstr ""
+msgstr "Extension de chaîne multioctets"
 
 msgid "cURL (might be required by some modules)"
-msgstr ""
+msgstr "cURL (peut être requis par certains modules)"
 
 msgid ""
 "cURL (required if automatic version checks are used, also by some modules)"
 msgstr ""
+"cURL (nécessaire si des vérifications automatiques de version sont utilisées, également par certains modules)"
 
 msgid "Session extension (required if PHP sessions are used)"
-msgstr ""
+msgstr "Extension de session (nécessaire si des sessions PHP sont utilisées)"
 
 msgid "Session extension"
-msgstr ""
+msgstr "Extension de session"
 
 msgid "PDO Extension (required if a database backend is used)"
-msgstr ""
+msgstr "Extension PDO (nécessaire si une base de données est utilisée)"
 
 msgid "PDO extension"
-msgstr ""
+msgstr "Extension PDO"
 
 msgid "LDAP extension (required if an LDAP backend is used)"
-msgstr ""
+msgstr "Extension LDAP (nécessaire si un backend LDAP est utilisé)"
 
 msgid "LDAP extension"
-msgstr ""
+msgstr "Extension LDAP"
 
 msgid "Radius extension (required if a radius backend is used)"
-msgstr ""
+msgstr "Extension Radius (nécessaire si un backend Radius est utilisé)"
 
 msgid "Radius extension"
-msgstr ""
+msgstr "Extension Radius"
 
 msgid "predis/predis (required if the redis data store is used)"
-msgstr ""
+msgstr "predis/predis (requis si le système de stockage de données redis est utilisé)"
 
 msgid "predis/predis library"
-msgstr ""
+msgstr "Bibliothèque predis/predis"
 
 msgid ""
 "Memcache or Memcached extension (required if the memcache backend is used)"
 msgstr ""
+"Memcache or Memcached extension (required if the memcache backend is used)"
 
 msgid "Memcache or Memcached extension"
-msgstr ""
+msgstr "Extension Memcache ou Memcached"
 
 msgid ""
 "The <code>technicalcontact_email</code> configuration option should be set"
 msgstr ""
+"L'option de configuration <code>technicalcontact_email</code> doit être définie"
 
 msgid "The auth.adminpassword configuration option must be set"
-msgstr ""
+msgstr "L'option de configuration auth.adminpassword doit être définie"
 
 msgid "Hosted IdP metadata present"
-msgstr ""
+msgstr "Présence de métadonnées IdP hébergées"
 
 msgid "Matching key-pair for signing assertions"
-msgstr ""
+msgstr "Paire de clés correspondante pour la signature des assertions"
 
 msgid "Matching key-pair for signing assertions (rollover key)"
-msgstr ""
+msgstr "Paire de clés correspondante pour la signature des assertions (renouvellement de clé)"
 
 msgid "Matching key-pair for signing metadata"
-msgstr ""
+msgstr "Paire de clés correspondante pour la signature des métadonnées"
 
 msgid ""
 "<strong>You are not using HTTPS</strong> to protect communications with your "
@@ -276,7 +281,7 @@ msgstr ""
 "HTTP pour des tests, mais si vous voulez l'utiliser dans un environnement"
 " de production, vous devriez utiliser HTTPS. [  <a "
 "href=\"https://simplesamlphp.org/docs/stable/simplesamlphp-maintenance"
-"\">En lire plus sur la maintenance de SimpleSAMLphp</a> ]"
+"\">En lire d'avantage sur la maintenance de SimpleSAMLphp</a> ]"
 
 msgid ""
 "<strong>The configuration uses the default secret salt</strong>. Make sure "
@@ -284,28 +289,35 @@ msgid ""
 "configuration in production environments. <a href=\"https://simplesamlphp."
 "org/docs/stable/simplesamlphp-install\">Read more about the maintenance of "
 "SimpleSAMLphp</a>."
-msgstr ""
+msgstr "" 
+"<strong>La configuration utilise le code secret par défaut</strong>. Veillez "
+"à modifier l'option <code>secretsalt</code> dans la configuration de SimpleSAMLphp "
+"dans les environnements de production. <a href=\"https://simplesamlphp."
+"org/docs/stable/simplesamlphp-install\">En lire d'avantage sur la maintenance de "
+"SimpleSAMLphp</a>."
 
 msgid ""
 "The cURL PHP extension is missing. Cannot check for SimpleSAMLphp updates."
-msgstr ""
+msgstr "L'extension PHP cURL est manquante. Impossible de vérifier les mises à jour de SimpleSAMLphp."
 
 msgid ""
 "You are running an outdated version of SimpleSAMLphp. Please update to <a "
 "href=\"%latest%\">the latest version</a> as soon as possible."
-msgstr ""
+msgstr "" 
+"Vous utilisez une version obsolète de SimpleSAMLphp. Veuillez mettre à jour vers <a "
+"href=\"%latest%\">la dernière version</a> dès que possible."
 
 msgid "XML to SimpleSAMLphp metadata converter"
 msgstr "Convertisseur de métadonnées XML vers SimpleSAMLphp"
 
 msgid "SAML 2.0 SP metadata"
-msgstr ""
+msgstr "SAML 2.0 SP métadonnées"
 
 msgid "SAML 2.0 IdP metadata"
-msgstr ""
+msgstr "SAML 2.0 IdP métadonnées"
 
 msgid "ADFS SP metadata"
-msgstr ""
+msgstr "ADFS SP métadonnées"
 
 msgid "ADFS IdP metadata"
-msgstr ""
+msgstr "ADFS IdP métadonnées"


### PR DESCRIPTION
Hi,

While implementing/upgrading to SimpleSamlPHP 2.0.4 i noticed that a lot of translations were missing on modules.

Please find here a full French translation for module Admin ( modules/admin/locales/fr/LC_MESSAGES/admin.po)

Regards,

Ludovic 