### PR TITLE
add support for TLS configuration for Redis Store

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -1227,6 +1227,28 @@ $config = [
     'store.redis.password' => '',
 
     /*
+     * Communicate with Redis over a secure connection instead of plain TCP.
+     *
+     * This setting affects both single host connections as
+     * well as Sentinel mode.
+     */
+    'store.redis.tls' => false,
+
+    /*
+     * Verify the Redis server certificate.
+     */
+    'store.redis.insecure' => false,
+
+    /*
+     * Files related to secure communication with Redis.
+     *
+     * Files are searched in the 'certdir' when using relative paths.
+     */
+    'store.redis.ca_certificate' => null,
+    'store.redis.certificate' => null,
+    'store.redis.privatekey' => null,
+
+    /*
      * The prefix we should use on our Redis datastore.
      */
     'store.redis.prefix' => 'SimpleSAMLphp',
@@ -1244,6 +1266,9 @@ $config = [
      *     'tcp://[yoursentinel2]:[port]',
      *     'tcp://[yoursentinel3]:[port]
      * ],
+     *
+     * Use 'tls' instead of 'tcp' in order to make use of the additional
+     * TLS settings.
      */
     'store.redis.sentinels' => [],
 

--- a/src/SimpleSAML/Store/RedisStore.php
+++ b/src/SimpleSAML/Store/RedisStore.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Store;
 
 use Predis\Client;
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\{Configuration, Error};
+use SimpleSAML\{Configuration, Error, Utils};
 
 use function class_exists;
 use function serialize;
@@ -45,17 +45,44 @@ class RedisStore implements StoreInterface
             $password = $config->getOptionalString('store.redis.password', null);
             $username = $config->getOptionalString('store.redis.username', null);
             $database = $config->getOptionalInteger('store.redis.database', 0);
+            $tls = $config->getOptionalBoolean('store.redis.tls', false);
+            $scheme = $tls ? 'tls' : 'tcp';
+            $ssl = [];
 
             $sentinels = $config->getOptionalArray('store.redis.sentinels', []);
+
+            if ($tls) {
+                $configUtils = new Utils\Config();
+
+                if ($config->getOptionalBoolean('store.redis.insecure', false)) {
+                    $ssl['verify_peer'] = false;
+                    $ssl['verify_peer_name'] = false;
+                } else {
+                    $ca = $config->getOptionalString('store.redis.ca_certificate', null);
+
+                    if ($ca !== null) {
+                        $ssl['cafile'] = $configUtils->getCertPath($ca);
+                    }
+                }
+
+                $cert = $config->getOptionalString('store.redis.certificate', null);
+                $key = $config->getOptionalString('store.redis.privatekey', null);
+
+                if ($cert !== null && $key !== null) {
+                    $ssl['local_cert'] = $configUtils->getCertPath($cert);
+                    $ssl['local_pk'] = $configUtils->getCertPath($key);
+                }
+            }
 
             if (empty($sentinels)) {
                 $redis = new Client(
                     [
-                        'scheme' => 'tcp',
+                        'scheme' => $scheme,
                         'host' => $host,
                         'port' => $port,
                         'database' => $database,
                     ]
+                    + (!empty($ssl) ? ['ssl' => $ssl] : [])
                     + (!empty($username) ? ['username' => $username] : [])
                     + (!empty($password) ? ['password' => $password] : []),
                     [
@@ -73,6 +100,7 @@ class RedisStore implements StoreInterface
                         'parameters' => [
                             'database' => $database,
                         ]
+                        + (!empty($ssl) ? ['ssl' => $ssl] : [])
                         + (!empty($username) ? ['username' => $username] : [])
                         + (!empty($password) ? ['password' => $password] : []),
                     ]

--- a/tests/src/SimpleSAML/Store/RedisStoreTest.php
+++ b/tests/src/SimpleSAML/Store/RedisStoreTest.php
@@ -113,6 +113,37 @@ class RedisStoreTest extends TestCase
         $this->assertInstanceOf(Store\RedisStore::class, $this->store);
     }
 
+    /**
+     * @test
+     */
+    public function testRedisInstanceWithInsecureTLS(): void
+    {
+        $config = Configuration::loadFromArray([
+            'store.type' => 'redis',
+            'store.redis.prefix' => 'phpunit_',
+            'store.redis.tls' => true,
+            'store.redis.insecure' => true,
+        ], '[ARRAY]', 'simplesaml');
+
+        $this->assertInstanceOf(Store\RedisStore::class, $this->store);
+    }
+
+    /**
+     * @test
+     */
+    public function testRedisInstanceWithSecureTLS(): void
+    {
+        $config = Configuration::loadFromArray([
+            'store.type' => 'redis',
+            'store.redis.prefix' => 'phpunit_',
+            'store.redis.tls' => true,
+            'store.redis.ca_certificate' => '/tmp/ssl/pki_roots.crt.pem',
+            'store.redis.certificate' => '/tmp/ssl/phpunit.crt.pem',
+            'store.redis.privatekey' => '/tmp/ssl/phpunit.key.pem',
+        ], '[ARRAY]', 'simplesaml');
+
+        $this->assertInstanceOf(Store\RedisStore::class, $this->store);
+    }
 
     /**
      * @test


### PR DESCRIPTION
generate selected SSL context options for the Predis client.

see https://www.php.net/manual/en/context.ssl.php

closes #1804