### PR TITLE
Fix invalid session error

### DIFF
--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -912,7 +912,7 @@ class SP extends Auth\Source
 
         // save the state WITHOUT a restart URL, so that we don't try an IdP-initiated login if something goes wrong
         $id = Auth\State::saveState($state, 'saml:proxy:invalid_idp', true);
-        $url = Module::getModuleURL('saml/proxy/invalid_session.php');
+        $url = Module::getModuleURL('saml/proxy/invalidSession');
 
         $httpUtils = new Utils\HTTP();
         return $httpUtils->redirectTrustedURL($url, ['AuthState' => $id]);

--- a/modules/saml/templates/proxy/invalid_session.twig
+++ b/modules/saml/templates/proxy/invalid_session.twig
@@ -4,9 +4,9 @@
 {% block content %}
     <h2>{{ 'Invalid Identity Provider'|trans }}</h2>
     <p>{{ 'You already have a valid session with an identity provider (<em>%IDP%</em>) that is not accepted by <em>%SP%</em>. Would you like to log out from your existing session and log in again with another identity provider?'|trans({"%IDP%": entity_idp|entityDisplayName, "%SP%": entity_sp|entityDisplayName}, "app")|raw }}</p>
-    <form method="post" action="?">
+    <form class="pure-form" method="post" action="?">
         <input type="hidden" name="AuthState" value="{{ AuthState|escape('html') }}">
-        <input type="submit" name="continue" value="{{ 'Yes, continue'|trans }}">
-        <input type="submit" name="cancel" value="{{ 'No, cancel'|trans }}">
+        <input type="submit" class="pure-button pure-button-red" name="continue" value="{{ 'Yes, continue'|trans }}">
+        <input type="submit" class="pure-button" name="cancel" value="{{ 'No, cancel'|trans }}">
     </form>
 {% endblock %}


### PR DESCRIPTION
The invalid session handler currently generates a redirect to a legacy URL (saml/proxy/invalid_session.php) whereas routing has been updated to locate this at a new URL (saml/proxy/invalidSession)

To reproduce the current bug:
* have the saml:SP module set up to support multiple IdPs
* log in with one IdP
* try to log in with a second IdP while the first session is still valid

This patch fixes that bug, and also adds pure styling to the twig template so that the buttons appear consistent with the rest of the new UI.

I've not tried to preserve the legacy URL as nothing outside the current SSP instance should point to it.
