### PR TITLE
Default for entity nameformat when not set should be uri

### DIFF
--- a/src/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/src/SimpleSAML/Metadata/SAMLBuilder.php
@@ -186,7 +186,7 @@ class SAMLBuilder
                 } else {
                     $attr[] = new Attribute(
                         name: $attributeName,
-                        nameFormat: C::NAMEFORMAT_UNSPECIFIED,
+                        nameFormat: C::NAMEFORMAT_URI,
                         attributeValue: $attrValues,
                     );
                 }


### PR DESCRIPTION
This matches both the code, and the code comments, [the documentation](https://simplesamlphp.org/docs/stable/simplesamlphp-metadata-extensions-attributes.html) and the behaviour of 1.19 so it seems to be a bug due to refactoring that it was changed to Unspecified in 2.x.