### PR TITLE
Duplicate use statement for Request class.

### DIFF
--- a/public/saml2/idp/SingleLogoutService.php
+++ b/public/saml2/idp/SingleLogoutService.php
@@ -13,7 +13,6 @@ require_once('../../_include.php');
 use SimpleSAML\Configuration;
 use SimpleSAML\Module\saml\Controller;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Request;
 
 $request = Request::createFromGlobals();
 $config = Configuration::getInstance();


### PR DESCRIPTION
> Fatal Error: Cannot use 'Request' because the name is already in use.

I know that is already fixed in main branch, but the Drupal module "Simplesamlphp Auth" will be use the next release 2.1 in their code as dependency, so it would be nice if this bug could be fixed.

See: [Drupal Simplesamlphp Auth issue](https://www.drupal.org/project/simplesamlphp_auth/issues/3349278)