### PR TITLE
Changed the UNIQUE key to a PRIMARY key for the tableVersion and saml_Logo…

### DIFF
--- a/modules/saml/src/SP/LogoutStore.php
+++ b/modules/saml/src/SP/LogoutStore.php
@@ -32,7 +32,82 @@ class LogoutStore
     private static function createLogoutTable(Store\SQLStore $store): void
     {
         $tableVer = $store->getTableVersion('saml_LogoutStore');
-        if ($tableVer === 4) {
+        if ($tableVer === 5) {
+            return;
+        } elseif ($tableVer === 4) {
+            // The _authSource index is being changed from UNIQUE to PRIMARY KEY for table version 5.
+            switch ($store->driver) {
+                case 'pgsql':
+                    // Drop old index and add primary key
+                    $update = [
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore DROP CONSTRAINT IF EXISTS ' .
+                          $store->prefix . '_saml_LogoutStore___authSource__nameId__sessionIndex_key',
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore ADD PRIMARY KEY (_authSource, _nameId, _sessionIndex)'
+                    ];
+                    break;
+                case 'sqlsrv':
+                    /**
+                     * Drop old index and add primary key.  
+                     * NOTE: We get the name of the index by looking for the only unique index with a default name.
+                     */
+                    $update = [
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore DROP INDEX IF EXISTS SELECT CONSTRAINT_NAME ' .
+                          'FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME=' . $store->prefix . '_saml_LogoutStore ' .
+                          'AND CONSTRAINT_NAME LIKE \'UQ__%"\'',
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore ADD CONSTRAINT _authSource ' .
+                          'PRIMARY KEY CLUSTERED (_authSource, _nameId, _sessionIndex)'
+                    ];
+                    break;
+                case 'sqlite':
+                    /**
+                     * Because SQLite does not support field alterations, the approach is to:
+                     *     Create a new table with the primary key
+                     *     Copy the current data to the new table
+                     *     Drop the old table
+                     *     Rename the new table correctly
+                     */
+                    $update = [
+                        'CREATE TABLE ' . $store->prefix .
+                          '_saml_LogoutStore_new (_authSource VARCHAR(255) NOT NULL,' .
+                          '_nameId VARCHAR(40) NOT NULL, _sessionIndex VARCHAR(50) NOT NULL, ' .
+                          '_expire TIMESTAMP NOT NULL, _sessionId VARCHAR(50) NOT NULL, PRIMARY KEY' .
+                          '(_authSource, _nameID, _sessionIndex))',
+                        'INSERT INTO ' . $store->prefix . '_saml_LogoutStore_new SELECT * FROM ' .
+                          $store->prefix . '_saml_LogoutStore',
+                        'DROP TABLE ' . $store->prefix . '_saml_LogoutStore',
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore_new RENAME TO ' .
+                          $store->prefix . '_saml_LogoutStore',
+                        'CREATE INDEX ' . $store->prefix . '_saml_LogoutStore_expire ON ' .
+                          $store->prefix . '_saml_LogoutStore (_expire)',
+                        'CREATE INDEX ' . $store->prefix . '_saml_LogoutStore_nameId ON ' .
+                          $store->prefix . '_saml_LogoutStore (_authSource, _nameId)'
+                    ];
+                    break;
+                case 'mysql':
+                    // Drop old index and add primary key
+                    $update = [
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore DROP INDEX _authSource',
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore ADD PRIMARY KEY (_authSource(191), _nameId, _sessionIndex)'
+                    ];
+                    break;
+                default;
+                    // Drop old index and add primary key
+                    $update = [
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore DROP INDEX _authSource',
+                        'ALTER TABLE ' . $store->prefix . '_saml_LogoutStore ADD PRIMARY KEY (_authSource, _nameId, _sessionIndex)'
+                    ];
+                    break;
+            }
+
+            try {
+                foreach ($update as $query) {
+                    $store->pdo->exec($query);
+                }
+            } catch (\Exception $e) {
+                Logger::warning('Database error: ' . var_export($store->pdo->errorInfo(), true));
+                return;
+            }
+            $store->setTableVersion('saml_LogoutStore', 5);
             return;
         } elseif ($tableVer < 4 && $tableVer > 0) {
             throw new Exception(
@@ -47,7 +122,7 @@ class LogoutStore
             _sessionIndex VARCHAR(50) NOT NULL,
             _expire ' . ($store->driver === 'pgsql' ? 'TIMESTAMP' : 'DATETIME') . ' NOT NULL,
             _sessionId VARCHAR(50) NOT NULL,
-            PRIMARY KEY (_authSource' . ($store->driver === 'mysql' ? '(191)' : '') . ', _nameID, _sessionIndex)
+            PRIMARY KEY (_authSource' . ($store->driver === 'mysql' ? '(191)' : '') . ', _nameId, _sessionIndex)
         )';
         $store->pdo->exec($query);
 
@@ -60,7 +135,7 @@ class LogoutStore
         ', _nameId)';
         $store->pdo->exec($query);
 
-        $store->setTableVersion('saml_LogoutStore', 4);
+        $store->setTableVersion('saml_LogoutStore', 5);
     }
 
 

--- a/modules/saml/src/SP/LogoutStore.php
+++ b/modules/saml/src/SP/LogoutStore.php
@@ -47,7 +47,7 @@ class LogoutStore
             _sessionIndex VARCHAR(50) NOT NULL,
             _expire ' . ($store->driver === 'pgsql' ? 'TIMESTAMP' : 'DATETIME') . ' NOT NULL,
             _sessionId VARCHAR(50) NOT NULL,
-            UNIQUE (_authSource' . ($store->driver === 'mysql' ? '(191)' : '') . ', _nameID, _sessionIndex)
+            PRIMARY KEY (_authSource' . ($store->driver === 'mysql' ? '(191)' : '') . ', _nameID, _sessionIndex)
         )';
         $store->pdo->exec($query);
 

--- a/src/SimpleSAML/Store/SQLStore.php
+++ b/src/SimpleSAML/Store/SQLStore.php
@@ -91,14 +91,86 @@ class SQLStore implements StoreInterface
                 'CREATE TABLE ' . $this->prefix .
                 '_tableVersion (_name VARCHAR(30) PRIMARY KEY NOT NULL, _version INTEGER NOT NULL)'
             );
+            $this->setTableVersion('tableVersion', 1);
             return;
         }
 
         while (($row = $fetchTableVersion->fetch(PDO::FETCH_ASSOC)) !== false) {
             $this->tableVersions[$row['_name']] = intval($row['_version']);
         }
-    }
 
+        $tableVer = $this->getTableVersion('tableVersion');
+        if ($tableVer === 1) {
+            return;
+        } else {
+            // The _name index is being changed from UNIQUE to PRIMARY KEY for table version 1.
+            switch ($this->driver) {
+                case 'pgsql':
+                    // Drop old index and add primary key
+                    $update = [
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion DROP CONSTRAINT IF EXISTS ' .
+                          $this->prefix . '_tableVersion__name_key',
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion ADD PRIMARY KEY (_name)'
+                    ];
+                    break;
+                case 'sqlsrv':
+                    /**
+                     * Drop old index and add primary key.  
+                     * NOTE: Because the index has a default name, we need to look it up in the information
+                     *       schema.
+                     */
+                    $update = [
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion DROP INDEX IF EXISTS SELECT CONSTRAINT_NAME ' .
+                          'FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME=' . $this_prefix . '_tableVersion',
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion ADD CONSTRAINT _name PRIMARY KEY CLUSTERED (_name)'
+                    ];
+                    break;
+                case 'sqlite':
+                    /**
+                     * Because SQLite does not support field alterations, the approach is to:
+                     *     Create a new table with the primary key
+                     *     Copy the current data to the new table
+                     *     Drop the old table
+                     *     Rename the new table correctly
+                     */
+                    $update = [
+                        'CREATE TABLE ' . $this->prefix .
+                          '_tableVersion (_name VARCHAR(30) PRIMARY KEY NOT NULL, _version INTEGER NOT NULL)',
+                        'INSERT INTO ' . $this->prefix . '_tableVersion_new SELECT * FROM ' .
+                          $this->prefix . '_tableVersion',
+                        'DROP TABLE ' . $this->prefix . '_tableVersion',
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion_new RENAME TO ' .
+                          $this->prefix . '_tableVersion'
+                    ];
+                    break;
+                case 'mysql':
+                    // Drop old index and add primary key
+                    $update = [
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion DROP INDEX _name',
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion ADD PRIMARY KEY (_name)'
+                    ];
+                    break;
+                default;
+                    // Drop old index and add primary key
+                    $update = [
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion DROP INDEX _name',
+                        'ALTER TABLE ' . $this->prefix . '_tableVersion ADD PRIMARY KEY (_name)'
+                    ];
+                    break;
+            }
+
+            try {
+                foreach ($update as $query) {
+                    $this->pdo->exec($query);
+                }
+            } catch (\Exception $e) {
+                Logger::warning('Database error: ' . var_export($this->pdo->errorInfo(), true));
+                return;
+            }
+            $this->setTableVersion('tableVersion', 1);
+            return;
+        }
+    }
 
     /**
      * Initialize key-value table.

--- a/src/SimpleSAML/Store/SQLStore.php
+++ b/src/SimpleSAML/Store/SQLStore.php
@@ -89,7 +89,7 @@ class SQLStore implements StoreInterface
         } catch (PDOException $e) {
             $this->pdo->exec(
                 'CREATE TABLE ' . $this->prefix .
-                '_tableVersion (_name VARCHAR(30) NOT NULL UNIQUE, _version INTEGER NOT NULL)'
+                '_tableVersion (_name VARCHAR(30) PRIMARY KEY NOT NULL, _version INTEGER NOT NULL)'
             );
             return;
         }


### PR DESCRIPTION
…utStore tables for better compatibility with Drupal.

----

Some of us who are testing simplesamlphp-2.1 for use with Drupal 10 have found that the lack of primary keys for two database tables created by SimpleSAMLphp is causing an error message to be generated by the Drupal site status report function. It is recommended that Drupal website databases have their transaction isolation level set to READ-COMMITTED. When Drupal detects tables without primary keys, it reports that READ-COMMITTED won't work correctly without all tables having primary keys. Because SimpleSAMLphp is using a different database connection, the transaction isolation level is not truly compromised, but the status error could be confusing for website maintainers.

I was able to eliminate this error by changing two UNIQUE keys to PRIMARY keys in the noted tables. These are

Table: <prefix>_saml_LogoutStore
Key fields: _authSource + _nameId + _sessionIndex

Table: <prefix>_tableVersion
Key field: _name

None of the key fields allow for NULL values, so this change should not affect operation, and my testing shows this is the case.

