### PR TITLE
Make error codes easier to extend

### DIFF
--- a/docs/simplesamlphp-authproc.md
+++ b/docs/simplesamlphp-authproc.md
@@ -31,15 +31,15 @@ The configuration of *Auth Proc Filters* is a list of filters with priority as *
 ```php
 'authproc.idp' => [
     10 => [
-        'class' => 'core:AttributeMap', 
+        'class' => 'core:AttributeMap',
         'addurnprefix'
     ],
     20 => 'core:TargetedID',
     50 => 'core:AttributeLimit',
     90 => [
-        'class' => 'consent:Consent', 
-        'store' => 'consent:Cookie', 
-        'focus' => 'yes', 
+        'class' => 'consent:Consent',
+        'store' => 'consent:Cookie',
+        'focus' => 'yes',
         'checked' => true
     ],
 ],
@@ -69,13 +69,13 @@ This is analogous to:
 ],
 ```
 
-Some *Auth Proc Filters* have optional or required *parameters*. To send parameters to *Auth Proc Filters*, you need to choose the second of the two alernatives above. Here is an example of provided parameters to the consent module:
+Some *Auth Proc Filters* have optional or required *parameters*. To send parameters to *Auth Proc Filters*, you need to choose the second of the two alternatives above. Here is an example of provided parameters to the consent module:
 
 ```php
 90 => [
-    'class' => 'consent:Consent', 
-    'store' => 'consent:Cookie', 
-    'focus' => 'yes', 
+    'class' => 'consent:Consent',
+    'store' => 'consent:Cookie',
+    'focus' => 'yes',
     'checked' => true,
 ],
 ```

--- a/docs/simplesamlphp-authsource.md
+++ b/docs/simplesamlphp-authsource.md
@@ -37,7 +37,7 @@ The only function you need to implement is the `login($username, $password)`-fun
 This function receives the username and password the user entered, and is expected to return the attributes of that user.
 If the username or password is incorrect, it should throw an error saying so:
 
-    throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+    throw new \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS);
 
 "[Implementing custom username/password authentication](./simplesamlphp-customauth)" describes how to implement username/password authentication using that base class.
 

--- a/docs/simplesamlphp-customauth.md
+++ b/docs/simplesamlphp-customauth.md
@@ -44,7 +44,7 @@ class MyAuth extends \SimpleSAML\Module\core\Auth\UserPassBase
     protected function login($username, $password)
     {
         if ($username !== 'theusername' || $password !== 'thepassword') {
-            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            throw new \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS);
         }
 
         return [
@@ -206,7 +206,7 @@ class MyAuth extends \SimpleSAML\Module\core\Auth\UserPassBase
     protected function login($username, $password)
     {
         if ($username !== $this->username || $password !== $this->password) {
-            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            throw new \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS);
         }
 
         return [
@@ -357,14 +357,14 @@ class MyAuth extends \SimpleSAML\Module\core\Auth\UserPassBase
         if (!$row) {
             /* User not found. */
             SimpleSAML\Logger::warning('MyAuth: Could not find user ' . var_export($username, true) . '.');
-            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            throw new \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS);
         }
 
         /* Check the password. */
         if (!$this->checkPassword($row['password_hash'], $password)) {
             /* Invalid password. */
             SimpleSAML\Logger::warning('MyAuth: Wrong password for user ' . var_export($username, true) . '.');
-            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            throw new \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS);
         }
 
         /* Create the attribute array of the user. */

--- a/docs/simplesamlphp-googleapps.md
+++ b/docs/simplesamlphp-googleapps.md
@@ -141,9 +141,9 @@ $metadata['https://www.google.com/a/g.feide.no'] => [
     'simplesaml.attributes' => false,
     'authproc' => [
         1 => [
-          'saml:AttributeNameID',
+          'class' => 'saml:AttributeNameID',
           'identifyingAttribute' => 'mail',
-          'format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+          'Format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
         ],
     ],
 ];

--- a/docs/simplesamlphp-googleapps.md
+++ b/docs/simplesamlphp-googleapps.md
@@ -37,7 +37,7 @@ Here is an example of typical user input when creating a certificate request:
 Country Name (2 letter code) [AU]:NO
 State or Province Name (full name) [Some-State]:Trondheim
 Locality Name (eg, city) []:Trondheim
-Organization Name (eg, company) [Internet Widgits Pty Ltd]:UNINETT
+Organization Name (eg, company) [Internet Widgets Pty Ltd]:UNINETT
 Organizational Unit Name (eg, section) []:
 Common Name (eg, YOUR name) []:dev2.andreas.feide.no
 Email Address []:

--- a/modules/core/src/Auth/Process/StatisticsWithAttribute.php
+++ b/modules/core/src/Auth/Process/StatisticsWithAttribute.php
@@ -47,17 +47,17 @@ class StatisticsWithAttribute extends Auth\ProcessingFilter
         parent::__construct($config, $reserved);
 
         if (array_key_exists('attributename', $config)) {
-            $this->attribute = $config['attributename'];
             if (!is_string($this->attribute)) {
                 throw new Exception('Invalid attribute name given to core:StatisticsWithAttribute filter.');
             }
+            $this->attribute = $config['attributename'];
         }
 
         if (array_key_exists('type', $config)) {
-            $this->typeTag = $config['type'];
             if (!is_string($this->typeTag)) {
                 throw new Exception('Invalid typeTag given to core:StatisticsWithAttribute filter.');
             }
+            $this->typeTag = $config['type'];
         }
 
         if (array_key_exists('skipPassive', $config)) {

--- a/modules/core/src/Auth/Process/TargetedID.php
+++ b/modules/core/src/Auth/Process/TargetedID.php
@@ -76,10 +76,10 @@ class TargetedID extends Auth\ProcessingFilter
         $this->identifyingAttribute = $config['identifyingAttribute'];
 
         if (array_key_exists('nameId', $config)) {
-            $this->generateNameId = $config['nameId'];
             if (!is_bool($this->generateNameId)) {
                 throw new Exception('Invalid value of \'nameId\'-option to core:TargetedID filter.');
             }
+            $this->generateNameId = $config['nameId'];
         }
 
         $this->configUtils = new Utils\Config();

--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -37,7 +37,7 @@ class AdminPassword extends UserPassBase
      *
      * On a successful login, this function should return the users attributes. On failure,
      * it should throw an exception. If the error was caused by the user entering the wrong
-     * username or password, a \SimpleSAML\Error\Error('WRONGUSERPASS') should be thrown.
+     * username or password, a \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS) should be thrown.
      *
      * Note that both the username and the password are UTF-8 encoded.
      *
@@ -51,16 +51,16 @@ class AdminPassword extends UserPassBase
         $adminPassword = $config->getString('auth.adminpassword');
         if ($adminPassword === '123') {
             // We require that the user changes the password
-            throw new Error\Error('NOTSET');
+            throw new Error\Error(Error\ErrorCodes::NOTSET);
         }
 
         if ($username !== "admin") {
-            throw new Error\Error('WRONGUSERPASS');
+            throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
         }
 
         $cryptoUtils = new Utils\Crypto();
         if (!$cryptoUtils->pwValid($adminPassword, $password)) {
-            throw new Error\Error('WRONGUSERPASS');
+            throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
         }
         return ['user' => ['admin']];
     }

--- a/modules/core/src/Auth/UserPassBase.php
+++ b/modules/core/src/Auth/UserPassBase.php
@@ -219,7 +219,7 @@ abstract class UserPassBase extends Auth\Source
             if (!isset($_SERVER['PHP_AUTH_USER']) || !isset($_SERVER['PHP_AUTH_PW'])) {
                 Logger::error("ECP AuthnRequest did not contain Basic Authentication header");
                 // TODO Return a SOAP fault instead of using the current binding?
-                throw new Error\Error("WRONGUSERPASS");
+                throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
             }
 
             $username = $_SERVER['PHP_AUTH_USER'];
@@ -255,7 +255,7 @@ abstract class UserPassBase extends Auth\Source
      *
      * On a successful login, this function should return the users attributes. On failure,
      * it should throw an exception/error. If the error was caused by the user entering the wrong
-     * username or password, a \SimpleSAML\Error\Error('WRONGUSERPASS') should be thrown.
+     * username or password, a \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS) should be thrown.
      *
      * Note that both the username and the password are UTF-8 encoded.
      *

--- a/modules/core/src/Auth/UserPassOrgBase.php
+++ b/modules/core/src/Auth/UserPassOrgBase.php
@@ -229,7 +229,7 @@ abstract class UserPassOrgBase extends Auth\Source
      *
      * On a successful login, this function should return the users attributes. On failure,
      * it should throw an exception/error. If the error was caused by the user entering the wrong
-     * username or password, a \SimpleSAML\Error\Error('WRONGUSERPASS') should be thrown.
+     * username or password, a \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS) should be thrown.
      *
      * Note that both the username and the password are UTF-8 encoded.
      *
@@ -293,7 +293,7 @@ abstract class UserPassOrgBase extends Auth\Source
             } else {
                 if ($orgMethod === 'force') {
                     /* The organization should be a part of the username, but isn't. */
-                    throw new Error\Error('WRONGUSERPASS');
+                    throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
                 }
             }
         }

--- a/modules/core/src/Controller/ErrorReport.php
+++ b/modules/core/src/Controller/ErrorReport.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Controller;
 
-use Exception;
+use Exception as BuiltinException;
 use FILTER_REQUIRE_SCALAR;
 use FILTER_VALIDATE_EMAIL;
 use SimpleSAML\{Configuration, Error, Logger, Session, Utils};
@@ -64,7 +64,7 @@ class ErrorReport
 
         try {
             $data = $this->session->getData('core:errorreport', $reportId);
-        } catch (Exception $e) {
+        } catch (BuiltinException $e) {
             $data = null;
             Logger::error('Error loading error report data: ' . var_export($e->getMessage(), true));
         }

--- a/modules/core/src/Controller/Exception.php
+++ b/modules/core/src/Controller/Exception.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Controller;
 
-use DATE_W3C;
+use DateTimeInterface;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\{Auth, Configuration, Error, Logger, Module, Session, Utils};
 use SimpleSAML\XHTML\Template;
@@ -66,7 +66,7 @@ class Exception
 
         if ($ts !== 'ERRORURL_TS') {
             Assert::integerish($ts);
-            $ts = date(DATE_W3C, intval($ts));
+            $ts = date(DateTimeInterface::W3C, intval($ts));
         } else {
             $ts = null;
         }

--- a/modules/core/src/Controller/Login.php
+++ b/modules/core/src/Controller/Login.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Controller;
 
-use Exception;
+use Exception as BuiltinException;
 use SimpleSAML\{Auth, Configuration, Error, Module, Utils};
 use SimpleSAML\Module\core\Auth\{UserPassBase, UserPassOrgBase};
 use SimpleSAML\XHTML\Template;
@@ -106,7 +106,7 @@ class Login
         /** @var \SimpleSAML\Module\core\Auth\UserPassBase|null $source */
         $source = $this->authSource::getById($state[UserPassBase::AUTHID]);
         if ($source === null) {
-            throw new Exception(
+            throw new BuiltinException(
                 'Could not find authentication source with id ' . $state[UserPassBase::AUTHID]
             );
         }
@@ -324,7 +324,7 @@ class Login
         /** @var \SimpleSAML\Module\core\Auth\UserPassOrgBase $source */
         $source = $this->authSource::getById($state[UserPassOrgBase::AUTHID]);
         if ($source === null) {
-            throw new Exception(
+            throw new BuiltinException(
                 'Could not find authentication source with id ' . $state[UserPassOrgBase::AUTHID]
             );
         }

--- a/modules/core/src/Controller/Logout.php
+++ b/modules/core/src/Controller/Logout.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Controller;
 
-use Exception;
+use Exception as BuiltinException;
 use SimpleSAML\{Auth, Configuration, Error, IdP, Logger, Stats, Utils};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\saml\Message;
@@ -319,7 +319,7 @@ class Logout
                 $assocIdP = IdP::getByState($this->config, $sp);
                 $url = call_user_func([$sp['Handler'], 'getLogoutURL'], $assocIdP, $sp, null);
                 $sp['core:Logout-IFrame:URL'] = $url;
-            } catch (Exception $e) {
+            } catch (BuiltinException $e) {
                 $sp['core:Logout-IFrame:State'] = 'failed';
             }
         }

--- a/modules/exampleauth/src/Auth/Source/UserPass.php
+++ b/modules/exampleauth/src/Auth/Source/UserPass.php
@@ -82,7 +82,7 @@ class UserPass extends UserPassBase
      *
      * On a successful login, this function should return the users attributes. On failure,
      * it should throw an exception. If the error was caused by the user entering the wrong
-     * username or password, a \SimpleSAML\Error\Error('WRONGUSERPASS') should be thrown.
+     * username or password, a \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS) should be thrown.
      *
      * Note that both the username and the password are UTF-8 encoded.
      *
@@ -94,7 +94,7 @@ class UserPass extends UserPassBase
     {
         $userpass = $username . ':' . $password;
         if (!array_key_exists($userpass, $this->users)) {
-            throw new Error\Error('WRONGUSERPASS');
+            throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
         }
 
         return $this->users[$userpass];

--- a/modules/saml/src/Controller/Metadata.php
+++ b/modules/saml/src/Controller/Metadata.php
@@ -69,7 +69,7 @@ class Metadata
     public function metadata(Request $request): Response
     {
         if ($this->config->getBoolean('enable.saml20-idp') === false || !Module::isModuleEnabled('saml')) {
-            throw new Error\Error('NOACCESS', null, 403);
+            throw new Error\Error(Error\ErrorCodes::NOACCESS, null, 403);
         }
 
         // check if valid local session exists
@@ -109,7 +109,7 @@ class Metadata
 
             return $response;
         } catch (Exception $exception) {
-            throw new Error\Error('METADATA', $exception);
+            throw new Error\Error(Error\ErrorCodes::METADATA, $exception);
         }
     }
 }

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -189,7 +189,7 @@ class ServiceProvider
         try {
             $b = Binding::getCurrentBinding($psrRequest);
         } catch (UnsupportedBindingException $e) {
-            throw new Error\Error('ACSPARAMS', $e, 400);
+            throw new Error\Error(Error\ErrorCodes::ACSPARAMS, $e, 400);
         }
 
         if ($b instanceof HTTPArtifact) {
@@ -466,7 +466,7 @@ class ServiceProvider
         try {
             $binding = Binding::getCurrentBinding($psrRequest);
         } catch (UnsupportedBindingException $e) {
-            throw new Error\Error('SLOSERVICEPARAMS', $e, 400);
+            throw new Error\Error(Error\ErrorCodes::SLOSERVICEPARAMS, $e, 400);
         }
         $message = $binding->receive($psrRequest);
 

--- a/modules/saml/src/Controller/SingleLogout.php
+++ b/modules/saml/src/Controller/SingleLogout.php
@@ -76,7 +76,7 @@ class SingleLogout
         Logger::info('SAML2.0 - IdP.SingleLogoutService: Accessing SAML 2.0 IdP endpoint SingleLogoutService');
 
         if ($this->config->getBoolean('enable.saml20-idp') === false || !Module::isModuleEnabled('saml')) {
-            throw new Error\Error('NOACCESS', null, 403);
+            throw new Error\Error(Error\ErrorCodes::NOACCESS, null, 403);
         }
 
         $httpUtils = new Utils\HTTP();
@@ -96,7 +96,7 @@ class SingleLogout
         try {
             return Module\saml\IdP\SAML2::receiveLogoutMessage($request, $idp);
         } catch (UnsupportedBindingException $e) {
-            throw new Error\Error('SLOSERVICEPARAMS', $e, 400);
+            throw new Error\Error(Error\ErrorCodes::SLOSERVICEPARAMS, $e, 400);
         }
     }
 
@@ -111,14 +111,14 @@ class SingleLogout
         Logger::info('SAML2.0 - IdP.initSLO: Accessing SAML 2.0 IdP endpoint init Single Logout');
 
         if ($this->config->getBoolean('enable.saml20-idp') === false || !Module::isModuleEnabled('saml')) {
-            throw new Error\Error('NOACCESS', null, 403);
+            throw new Error\Error(Error\ErrorCodes::NOACCESS, null, 403);
         }
 
         $idpEntityId = $this->mdHandler->getMetaDataCurrentEntityID('saml20-idp-hosted');
         $idp = $this->idp::getById($this->config, 'saml2:' . $idpEntityId);
 
         if (!$request->query->has('RelayState')) {
-            throw new Error\Error('NORELAYSTATE');
+            throw new Error\Error(Error\ErrorCodes::NORELAYSTATE);
         }
 
         $httpUtils = new Utils\HTTP();

--- a/modules/saml/src/Controller/WebBrowserSingleSignOn.php
+++ b/modules/saml/src/Controller/WebBrowserSingleSignOn.php
@@ -47,7 +47,7 @@ class WebBrowserSingleSignOn
     public function artifactResolutionService(Request $request): Response
     {
         if ($this->config->getBoolean('enable.saml20-idp') === false || !Module::isModuleEnabled('saml')) {
-            throw new Error\Error('NOACCESS', null, 403);
+            throw new Error\Error(Error\ErrorCodes::NOACCESS, null, 403);
         }
 
         $metadata = Metadata\MetaDataStorageHandler::getMetadataHandler($this->config);
@@ -55,7 +55,7 @@ class WebBrowserSingleSignOn
         $idpMetadata = $metadata->getMetaDataConfig($idpEntityId, 'saml20-idp-hosted');
 
         if (!$idpMetadata->getOptionalBoolean('saml20.sendartifact', false)) {
-            throw new Error\Error('NOACCESS');
+            throw new Error\Error(Error\ErrorCodes::NOACCESS);
         }
 
         $storeType = $this->config->getOptionalString('store.type', 'phpsession');
@@ -72,7 +72,7 @@ class WebBrowserSingleSignOn
         try {
             $request = $binding->receive($psrRequest);
         } catch (UnsupportedBindingException $e) {
-            throw new Error\Error('ARSPARAMS', $e, 400);
+            throw new Error\Error(Error\ErrorCodes::ARSPARAMS, $e, 400);
         }
 
         if (!($request instanceof ArtifactResolve)) {
@@ -119,7 +119,7 @@ class WebBrowserSingleSignOn
         Logger::info('SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService');
 
         if ($this->config->getBoolean('enable.saml20-idp') === false || !Module::isModuleEnabled('saml')) {
-            throw new Error\Error('NOACCESS', null, 403);
+            throw new Error\Error(Error\ErrorCodes::NOACCESS, null, 403);
         }
 
         $metadata = Metadata\MetaDataStorageHandler::getMetadataHandler($this->config);
@@ -129,7 +129,7 @@ class WebBrowserSingleSignOn
         try {
             return Module\saml\IdP\SAML2::receiveAuthnRequest($request, $idp);
         } catch (UnsupportedBindingException $e) {
-            throw new Error\Error('SSOPARAMS', $e, 400);
+            throw new Error\Error(Error\ErrorCodes::SSOPARAMS, $e, 400);
         }
     }
 }

--- a/src/SimpleSAML/Error/AuthSource.php
+++ b/src/SimpleSAML/Error/AuthSource.php
@@ -32,7 +32,7 @@ class AuthSource extends Error
         $this->reason = $reason;
         parent::__construct(
             [
-                'AUTHSOURCEERROR',
+                ErrorCodes::AUTHSOURCEERROR,
                 '%AUTHSOURCE%' => $this->authsource,
                 '%REASON%' => $this->reason,
             ],

--- a/src/SimpleSAML/Error/BadRequest.php
+++ b/src/SimpleSAML/Error/BadRequest.php
@@ -25,7 +25,7 @@ class BadRequest extends Error
     public function __construct(
         protected string $reason
     ) {
-        parent::__construct(['BADREQUEST', '%REASON%' => $reason], null, 400);
+        parent::__construct([ErrorCodes::BADREQUEST, '%REASON%' => $reason], null, 400);
     }
 
 

--- a/src/SimpleSAML/Error/ConfigurationError.php
+++ b/src/SimpleSAML/Error/ConfigurationError.php
@@ -41,7 +41,7 @@ class ConfigurationError extends Error
     {
         $file_str = '';
         $reason_str = '.';
-        $params = ['CONFIG'];
+        $params = [ErrorCodes::CONFIG];
         if ($file !== null) {
             $params['%FILE%'] = $file;
             $basepath = dirname(__FILE__, 4) . '/';

--- a/src/SimpleSAML/Error/Error.php
+++ b/src/SimpleSAML/Error/Error.php
@@ -87,9 +87,9 @@ class Error extends Exception
      * The error can either be given as a string, or as an array. If it is an array, the first element in the array
      * (with index 0), is the error code, while the other elements are replacements for the error text.
      *
-     * @param string|array $errorCode One of the error codes defined in the errors dictionary.
-     * @param \Throwable   $cause The exception which caused this fatal error (if any). Optional.
-     * @param int|null     $httpCode The HTTP response code to use. Optional.
+     * @param string|array     $errorCode One of the error codes defined in the errors dictionary.
+     * @param Throwable|null   $cause The exception which caused this fatal error (if any). Optional.
+     * @param int|null         $httpCode The HTTP response code to use. Optional.
      */
     public function __construct(string|array $errorCode, Throwable $cause = null, ?int $httpCode = null)
     {
@@ -106,8 +106,9 @@ class Error extends Exception
             $this->httpCode = $httpCode;
         }
 
-        $this->dictTitle = ErrorCodes::getErrorCodeTitle($this->errorCode);
-        $this->dictDescr = ErrorCodes::getErrorCodeDescription($this->errorCode);
+        $errorCodes = $this->getErrorCodes();
+        $this->dictTitle = $errorCodes::getErrorCodeTitle($this->errorCode);
+        $this->dictDescr = $errorCodes::getErrorCodeDescription($this->errorCode);
 
         if (!empty($this->parameters)) {
             $msg = $this->errorCode . '(';
@@ -123,6 +124,18 @@ class Error extends Exception
             $msg = $this->errorCode;
         }
         parent::__construct($msg, -1, $cause);
+    }
+
+    /**
+     * Retrieve the ErrorCodes instance to use for resolving dictionary title and description tags.
+     *
+     * Extend this to use custom ErrorCodes instance (with custom error codes and their title / description tags).
+     *
+     * @return ErrorCodes
+     */
+    protected function getErrorCodes(): ErrorCodes
+    {
+        return new ErrorCodes();
     }
 
 

--- a/src/SimpleSAML/Error/Error.php
+++ b/src/SimpleSAML/Error/Error.php
@@ -91,8 +91,12 @@ class Error extends Exception
      * @param Throwable|null   $cause The exception which caused this fatal error (if any). Optional.
      * @param int|null         $httpCode The HTTP response code to use. Optional.
      */
-    public function __construct(string|array $errorCode, Throwable $cause = null, ?int $httpCode = null)
-    {
+    public function __construct(
+        string|array $errorCode,
+        Throwable $cause = null,
+        ?int $httpCode = null,
+        ErrorCodes $errorCodes = null
+    ) {
         if (is_array($errorCode)) {
             $this->parameters = $errorCode;
             unset($this->parameters[0]);
@@ -106,9 +110,9 @@ class Error extends Exception
             $this->httpCode = $httpCode;
         }
 
-        $errorCodes = $this->getErrorCodes();
-        $this->dictTitle = $errorCodes::getErrorCodeTitle($this->errorCode);
-        $this->dictDescr = $errorCodes::getErrorCodeDescription($this->errorCode);
+        $errorCodes = $errorCodes ?? $this->getErrorCodes();
+        $this->dictTitle = $errorCodes->getTitle($this->errorCode);
+        $this->dictDescr = $errorCodes->getDescription($this->errorCode);
 
         if (!empty($this->parameters)) {
             $msg = $this->errorCode . '(';

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Error;
 use SimpleSAML\Locale\Translate;
 
 use function array_key_exists;
+use function array_merge;
 
 /**
  * Class that maps SimpleSAMLphp error codes to translateable strings.

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -12,11 +12,45 @@ use function array_key_exists;
  * Class that maps SimpleSAMLphp error codes to translateable strings.
  *
  * @package SimpleSAMLphp
- *
- * TODO Consider moving to constants for error code keys.
  */
 class ErrorCodes
 {
+    // TODO PHPv8.1 - Consider moving to final consts for these default error codes to prevent overrides.
+    public const ACSPARAMS = 'ACSPARAMS';
+    public const ARSPARAMS = 'ARSPARAMS';
+    public const AUTHSOURCEERROR = 'AUTHSOURCEERROR';
+    public const BADREQUEST = 'BADREQUEST';
+    public const CASERROR = 'CASERROR';
+    public const CONFIG = 'CONFIG';
+    public const CREATEREQUEST = 'CREATEREQUEST';
+    public const DISCOPARAMS = 'DISCOPARAMS';
+    public const GENERATEAUTHNRESPONSE = 'GENERATEAUTHNRESPONSE';
+    public const INVALIDCERT = 'INVALIDCERT';
+    public const LDAPERROR = 'LDAPERROR';
+    public const LOGOUTINFOLOST = 'LOGOUTINFOLOST';
+    public const LOGOUTREQUEST = 'LOGOUTREQUEST';
+    public const MEMCACHEDOWN = 'MEMCACHEDOWN';
+    public const METADATA = 'METADATA';
+    public const METADATANOTFOUND = 'METADATANOTFOUND';
+    public const NOACCESS = 'NOACCESS';
+    public const NOCERT = 'NOCERT';
+    public const NORELAYSTATE = 'NORELAYSTATE';
+    public const NOSTATE = 'NOSTATE';
+    public const NOTFOUND = 'NOTFOUND';
+    public const NOTFOUNDREASON = 'NOTFOUNDREASON';
+    public const NOTSET = 'NOTSET';
+    public const NOTVALIDCERT = 'NOTVALIDCERT';
+    public const PROCESSASSERTION = 'PROCESSASSERTION';
+    public const PROCESSAUTHNREQUEST = 'PROCESSAUTHNREQUEST';
+    public const RESPONSESTATUSNOSUCCESS = 'RESPONSESTATUSNOSUCCESS';
+    public const SLOSERVICEPARAMS = 'SLOSERVICEPARAMS';
+    public const SSOPARAMS = 'SSOPARAMS';
+    public const UNHANDLEDEXCEPTION = 'UNHANDLEDEXCEPTION';
+    public const UNKNOWNCERT = 'UNKNOWNCERT';
+    public const USERABORTED = 'USERABORTED';
+    public const WRONGUSERPASS = 'WRONGUSERPASS';
+
+
     /**
      * Fetch all default translation strings for error code titles.
      *
@@ -25,39 +59,39 @@ class ErrorCodes
     final public static function defaultGetAllErrorCodeTitles(): array
     {
         return [
-            'ACSPARAMS' => Translate::noop('No SAML response provided'),
-            'ARSPARAMS' => Translate::noop('No SAML message provided'),
-            'AUTHSOURCEERROR' => Translate::noop('Authentication source error'),
-            'BADREQUEST' => Translate::noop('Bad request received'),
-            'CASERROR' => Translate::noop('CAS Error'),
-            'CONFIG' => Translate::noop('Configuration error'),
-            'CREATEREQUEST' => Translate::noop('Error creating request'),
-            'DISCOPARAMS' => Translate::noop('Bad request to discovery service'),
-            'GENERATEAUTHNRESPONSE' => Translate::noop('Could not create authentication response'),
-            'INVALIDCERT' => Translate::noop('Invalid certificate'),
-            'LDAPERROR' => Translate::noop('LDAP Error'),
-            'LOGOUTINFOLOST' => Translate::noop('Logout information lost'),
-            'LOGOUTREQUEST' => Translate::noop('Error processing the Logout Request'),
-            'MEMCACHEDOWN' => Translate::noop('Cannot retrieve session data'),
-            'METADATA' => Translate::noop('Error loading metadata'),
-            'METADATANOTFOUND' => Translate::noop('Metadata not found'),
-            'NOACCESS' => Translate::noop('No access'),
-            'NOCERT' => Translate::noop('No certificate'),
-            'NORELAYSTATE' => Translate::noop('No RelayState'),
-            'NOSTATE' => Translate::noop('State information lost'),
-            'NOTFOUND' => Translate::noop('Page not found'),
-            'NOTFOUNDREASON' => Translate::noop('Page not found'),
-            'NOTSET' => Translate::noop('Password not set'),
-            'NOTVALIDCERT' => Translate::noop('Invalid certificate'),
-            'PROCESSASSERTION' => Translate::noop('Error processing response from Identity Provider'),
-            'PROCESSAUTHNREQUEST' => Translate::noop('Error processing request from Service Provider'),
-            'RESPONSESTATUSNOSUCCESS' => Translate::noop('Error received from Identity Provider'),
-            'SLOSERVICEPARAMS' => Translate::noop('No SAML message provided'),
-            'SSOPARAMS' => Translate::noop('No SAML request provided'),
-            'UNHANDLEDEXCEPTION' => Translate::noop('Unhandled exception'),
-            'UNKNOWNCERT' => Translate::noop('Unknown certificate'),
-            'USERABORTED' => Translate::noop('Authentication aborted'),
-            'WRONGUSERPASS' => Translate::noop('Incorrect username or password'),
+            self::ACSPARAMS => Translate::noop('No SAML response provided'),
+            self::ARSPARAMS => Translate::noop('No SAML message provided'),
+            self::AUTHSOURCEERROR => Translate::noop('Authentication source error'),
+            self::BADREQUEST => Translate::noop('Bad request received'),
+            self::CASERROR => Translate::noop('CAS Error'),
+            self::CONFIG => Translate::noop('Configuration error'),
+            self::CREATEREQUEST => Translate::noop('Error creating request'),
+            self::DISCOPARAMS => Translate::noop('Bad request to discovery service'),
+            self::GENERATEAUTHNRESPONSE => Translate::noop('Could not create authentication response'),
+            self::INVALIDCERT => Translate::noop('Invalid certificate'),
+            self::LDAPERROR => Translate::noop('LDAP Error'),
+            self::LOGOUTINFOLOST => Translate::noop('Logout information lost'),
+            self::LOGOUTREQUEST => Translate::noop('Error processing the Logout Request'),
+            self::MEMCACHEDOWN => Translate::noop('Cannot retrieve session data'),
+            self::METADATA => Translate::noop('Error loading metadata'),
+            self::METADATANOTFOUND => Translate::noop('Metadata not found'),
+            self::NOACCESS => Translate::noop('No access'),
+            self::NOCERT => Translate::noop('No certificate'),
+            self::NORELAYSTATE => Translate::noop('No RelayState'),
+            self::NOSTATE => Translate::noop('State information lost'),
+            self::NOTFOUND => Translate::noop('Page not found'),
+            self::NOTFOUNDREASON => Translate::noop('Page not found'),
+            self::NOTSET => Translate::noop('Password not set'),
+            self::NOTVALIDCERT => Translate::noop('Invalid certificate'),
+            self::PROCESSASSERTION => Translate::noop('Error processing response from Identity Provider'),
+            self::PROCESSAUTHNREQUEST => Translate::noop('Error processing request from Service Provider'),
+            self::RESPONSESTATUSNOSUCCESS => Translate::noop('Error received from Identity Provider'),
+            self::SLOSERVICEPARAMS => Translate::noop('No SAML message provided'),
+            self::SSOPARAMS => Translate::noop('No SAML request provided'),
+            self::UNHANDLEDEXCEPTION => Translate::noop('Unhandled exception'),
+            self::UNKNOWNCERT => Translate::noop('Unknown certificate'),
+            self::USERABORTED => Translate::noop('Authentication aborted'),
+            self::WRONGUSERPASS => Translate::noop('Incorrect username or password'),
         ];
     }
 
@@ -83,33 +117,33 @@ class ErrorCodes
     final public static function defaultGetAllErrorCodeDescriptions(): array
     {
         return [
-            'ACSPARAMS' => Translate::noop("" .
+            self::ACSPARAMS => Translate::noop("" .
                 "You accessed the Assertion Consumer Service interface, but did not " .
                 "provide a SAML Authentication Response. Please note that this endpoint is" .
                 " not intended to be accessed directly."),
-            'ARSPARAMS' => Translate::noop("" .
+            self::ARSPARAMS => Translate::noop("" .
                 "You accessed the Artifact Resolution Service interface, but did not " .
                 "provide a SAML ArtifactResolve message. Please note that this endpoint is" .
                 " not intended to be accessed directly."),
-            'AUTHSOURCEERROR' => Translate::noop("" .
+            self::AUTHSOURCEERROR => Translate::noop("" .
                 'Authentication error in source %AUTHSOURCE%. The reason was: %REASON%'),
-            'BADREQUEST' => Translate::noop('There is an error in the request to this page. The reason was: %REASON%'),
-            'CASERROR' => Translate::noop('Error when communicating with the CAS server.'),
-            'CONFIG' => Translate::noop('SimpleSAMLphp appears to be misconfigured.'),
-            'CREATEREQUEST' => Translate::noop("An error occurred when trying to create the SAML request."),
-            'DISCOPARAMS' => Translate::noop("" .
+            self::BADREQUEST => Translate::noop('There is an error in the request to this page. The reason was: %REASON%'),
+            self::CASERROR => Translate::noop('Error when communicating with the CAS server.'),
+            self::CONFIG => Translate::noop('SimpleSAMLphp appears to be misconfigured.'),
+            self::CREATEREQUEST => Translate::noop("An error occurred when trying to create the SAML request."),
+            self::DISCOPARAMS => Translate::noop("" .
                 "The parameters sent to the discovery service were not according to " .
                 "specifications."),
-            'GENERATEAUTHNRESPONSE' => Translate::noop("" .
+            self::GENERATEAUTHNRESPONSE => Translate::noop("" .
                 "When this identity provider tried to create an authentication response, " .
                 "an error occurred."),
-            'INVALIDCERT' => Translate::noop("" .
+            self::INVALIDCERT => Translate::noop("" .
                 "Authentication failed: the certificate your browser sent is invalid or " .
                 "cannot be read"),
-            'LDAPERROR' => Translate::noop("" .
+            self::LDAPERROR => Translate::noop("" .
                 "LDAP is the user database, and when you try to login, we need to contact " .
                 "an LDAP database. An error occurred when we tried it this time."),
-            'LOGOUTINFOLOST' => Translate::noop("" .
+            self::LOGOUTINFOLOST => Translate::noop("" .
                 "The information about the current logout operation has been lost. You " .
                 "should return to the service you were trying to log out from and try to " .
                 "log out again. This error can be caused by the logout information " .
@@ -118,49 +152,49 @@ class ErrorCodes
                 "operation should take, so this error may indicate some other error with " .
                 "the configuration. If the problem persists, contact your service " .
                 "provider."),
-            'LOGOUTREQUEST' => Translate::noop('An error occurred when trying to process the Logout Request.'),
-            'MEMCACHEDOWN' => Translate::noop("" .
+            self::LOGOUTREQUEST => Translate::noop('An error occurred when trying to process the Logout Request.'),
+            self::MEMCACHEDOWN => Translate::noop("" .
                 "Your session data cannot be retrieved right now due to technical " .
                 "difficulties. Please try again in a few minutes."),
-            'METADATA' => Translate::noop("" .
+            self::METADATA => Translate::noop("" .
                 "There is some misconfiguration of your SimpleSAMLphp installation. If you" .
                 " are the administrator of this service, you should make sure your " .
                 "metadata configuration is correctly setup."),
-            'METADATANOTFOUND' => Translate::noop('Unable to locate metadata for %ENTITYID%'),
-            'NOACCESS' => Translate::noop("" .
+            self::METADATANOTFOUND => Translate::noop('Unable to locate metadata for %ENTITYID%'),
+            self::NOACCESS => Translate::noop("" .
                 "This endpoint is not enabled. Check the enable options in your " .
                 "configuration of SimpleSAMLphp."),
-            'NOCERT' => Translate::noop('Authentication failed: your browser did not send any certificate'),
-            'NORELAYSTATE' => Translate::noop("" .
+            self::NOCERT => Translate::noop('Authentication failed: your browser did not send any certificate'),
+            self::NORELAYSTATE => Translate::noop("" .
                 "The initiator of this request did not provide a RelayState parameter " .
                 "indicating where to go next."),
-            'NOSTATE' => Translate::noop('State information lost, and no way to restart the request'),
-            'NOTFOUND' => Translate::noop('The given page was not found. The URL was: %URL%'),
-            'NOTFOUNDREASON' => Translate::noop("" .
+            self::NOSTATE => Translate::noop('State information lost, and no way to restart the request'),
+            self::NOTFOUND => Translate::noop('The given page was not found. The URL was: %URL%'),
+            self::NOTFOUNDREASON => Translate::noop("" .
                 "The given page was not found. The reason was: %REASON%  The URL was: %URL%"),
-            'NOTSET' => Translate::noop("" .
+            self::NOTSET => Translate::noop("" .
                 "The password in the configuration (auth.adminpassword) is not changed " .
                 "from the default value. Please edit the configuration file."),
-            'NOTVALIDCERT' => Translate::noop('You did not present a valid certificate.'),
-            'PROCESSASSERTION' => Translate::noop('We did not accept the response sent from the Identity Provider.'),
-            'PROCESSAUTHNREQUEST' => Translate::noop("" .
+            self::NOTVALIDCERT => Translate::noop('You did not present a valid certificate.'),
+            self::PROCESSASSERTION => Translate::noop('We did not accept the response sent from the Identity Provider.'),
+            self::PROCESSAUTHNREQUEST => Translate::noop("" .
                 "This Identity Provider received an Authentication Request from a Service " .
                 "Provider, but an error occurred when trying to process the request."),
-            'RESPONSESTATUSNOSUCCESS' => Translate::noop("" .
+            self::RESPONSESTATUSNOSUCCESS => Translate::noop("" .
                 "The Identity Provider responded with an error. (The status code in the " .
                 "SAML Response was not success)"),
-            'SLOSERVICEPARAMS' => Translate::noop("" .
+            self::SLOSERVICEPARAMS => Translate::noop("" .
                 "You accessed the SingleLogoutService interface, but did not provide a " .
                 "SAML LogoutRequest or LogoutResponse. Please note that this endpoint is " .
                 "not intended to be accessed directly."),
-            'SSOPARAMS' => Translate::noop("" .
+            self::SSOPARAMS => Translate::noop("" .
                 "You accessed the Single Sign On Service interface, but did not provide a " .
                 "SAML Authentication Request. Please note that this endpoint is not " .
                 "intended to be accessed directly."),
-            'UNHANDLEDEXCEPTION' => Translate::noop('An unhandled exception was thrown.'),
-            'UNKNOWNCERT' => Translate::noop('Authentication failed: the certificate your browser sent is unknown'),
-            'USERABORTED' => Translate::noop('The authentication was aborted by the user'),
-            'WRONGUSERPASS' => Translate::noop("" .
+            self::UNHANDLEDEXCEPTION => Translate::noop('An unhandled exception was thrown.'),
+            self::UNKNOWNCERT => Translate::noop('Authentication failed: the certificate your browser sent is unknown'),
+            self::USERABORTED => Translate::noop('The authentication was aborted by the user'),
+            self::WRONGUSERPASS => Translate::noop("" .
                 "Either no user with the given username could be found, or the password " .
                 "you gave was wrong. Please check the username and try again."),
         ];

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -58,6 +58,10 @@ class ErrorCodes
      * Fetch all default translation strings for error code titles.
      *
      * @return array A map from error code to error code title
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getDefaultTitles()
+     * TODO NextMajorRelease Move content to substitute method and remove.
      */
     final public static function defaultGetAllErrorCodeTitles(): array
     {
@@ -99,13 +103,40 @@ class ErrorCodes
     }
 
     /**
+     * Fetch all default translation strings for error code titles.
+     *
+     * @return array A map from error code to error code title
+     */
+    final public function getDefaultTitles(): array
+    {
+        // TODO NextMajorRelease Move content from self::defaultGetAllErrorCodeTitles() to this method.
+        return self::defaultGetAllErrorCodeTitles();
+    }
+
+    /**
+     * Fetch all title translation strings for custom error codes.
+     *
+     * Extend this to define custom error codes and their title translations.
+     *
+     * @return array A map from custom error code to error code title
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getCustomTitles()
+     * TODO NextMajorRelease Remove this method.
+     */
+    public static function getCustomErrorCodeTitles(): array
+    {
+        return [];
+    }
+
+    /**
      * Fetch all title translation strings for custom error codes.
      *
      * Extend this to define custom error codes and their title translations.
      *
      * @return array A map from custom error code to error code title
      */
-    public static function getCustomErrorCodeTitles(): array
+    public function getCustomTitles(): array
     {
         return [];
     }
@@ -115,10 +146,24 @@ class ErrorCodes
      * Fetch all translation strings for error code titles.
      *
      * @return array A map from error code to error code title
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getAllTitles()
+     * TODO NextMajorRelease Remove this method.
      */
     public static function getAllErrorCodeTitles(): array
     {
         return array_merge(self::defaultGetAllErrorCodeTitles(), static::getCustomErrorCodeTitles());
+    }
+
+    /**
+     * Fetch all translation strings for error code titles.
+     *
+     * @return array A map from error code to error code title
+     */
+    public function getAllTitles(): array
+    {
+        return array_merge($this->getDefaultTitles(), $this->getCustomTitles());
     }
 
 
@@ -126,6 +171,10 @@ class ErrorCodes
      * Fetch all default translation strings for error code descriptions.
      *
      * @return array A map from error code to error code description
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getDefaultDescriptions()
+     * TODO NextMajorRelease Move content to substitute method and remove.
      */
     final public static function defaultGetAllErrorCodeDescriptions(): array
     {
@@ -214,13 +263,40 @@ class ErrorCodes
     }
 
     /**
+     * Fetch all default translation strings for error code descriptions.
+     *
+     * @return array A map from error code to error code description
+     */
+    final public function getDefaultDescriptions(): array
+    {
+        // TODO NextMajorRelease Move content from self::defaultGetAllErrorCodeDescriptions() to this method.
+        return self::defaultGetAllErrorCodeDescriptions();
+    }
+
+    /**
+     * Fetch all description translation strings for custom error codes.
+     *
+     * Extend this to define custom error codes and their description translations.
+     *
+     * @return array A map from error code to error code description
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getCustomDescriptions()
+     * TODO NextMajorRelease Remove this method.
+     */
+    public static function getCustomErrorCodeDescriptions(): array
+    {
+        return [];
+    }
+
+    /**
      * Fetch all description translation strings for custom error codes.
      *
      * Extend this to define custom error codes and their description translations.
      *
      * @return array A map from error code to error code description
      */
-    public static function getCustomErrorCodeDescriptions(): array
+    public function getCustomDescriptions(): array
     {
         return [];
     }
@@ -229,10 +305,19 @@ class ErrorCodes
      * Fetch all translation strings for error code descriptions.
      *
      * @return array A map from error code to error code description
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getAllDescriptions()
+     * TODO NextMajorRelease Remove this method.
      */
     public static function getAllErrorCodeDescriptions(): array
     {
         return array_merge(self::defaultGetAllErrorCodeDescriptions(), static::getCustomErrorCodeDescriptions());
+    }
+
+    public function getAllDescriptions(): array
+    {
+        return array_merge($this->getDefaultDescriptions(), $this->getCustomDescriptions());
     }
 
 
@@ -242,12 +327,30 @@ class ErrorCodes
      * Convenience-method for template-callers
      *
      * @return array An array containing both errorcode maps.
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getAllMessages()
+     * TODO NextMajorRelease Remove this method.
      */
     public static function getAllErrorCodeMessages(): array
     {
         return [
             self::KEY_TITLE => self::getAllErrorCodeTitles(),
             self::KEY_DESCRIPTION => self::getAllErrorCodeDescriptions(),
+        ];
+    }
+
+    /**
+     * Get a map of both errorcode titles and descriptions
+     *
+     * Convenience-method for template-callers
+     *
+     * @return array An array containing both errorcode maps.
+     */
+    public function getAllMessages(): array
+    {
+        return [
+            self::KEY_TITLE => $this->getAllTitles(),
+            self::KEY_DESCRIPTION => $this->getAllDescriptions(),
         ];
     }
 
@@ -258,6 +361,10 @@ class ErrorCodes
      * @param string $errorCode The error code to look up
      *
      * @return string A string to translate
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getTitle()
+     * TODO NextMajorRelease Remove this method.
      */
     public static function getErrorCodeTitle(string $errorCode): string
     {
@@ -269,6 +376,17 @@ class ErrorCodes
         }
     }
 
+    /**
+     * Fetch a translation string for a title for a given error code.
+     *
+     * @param string $errorCode The error code to look up
+     *
+     * @return string A string to translate
+     */
+    public function getTitle(string $errorCode): string
+    {
+        return (string)($this->getAllTitles()[$errorCode] ?? Translate::addTagPrefix($errorCode, 'title_'));
+    }
 
     /**
      * Fetch a translation string for a description for a given error code.
@@ -276,6 +394,10 @@ class ErrorCodes
      * @param string $errorCode The error code to look up
      *
      * @return string A string to translate
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getDescription()
+     * TODO NextMajorRelease Remove this method.
      */
     public static function getErrorCodeDescription(string $errorCode): string
     {
@@ -287,6 +409,38 @@ class ErrorCodes
         }
     }
 
+    /**
+     * Fetch a translation string for a description for a given error code.
+     *
+     * @param string $errorCode The error code to look up
+     *
+     * @return string A string to translate
+     */
+    public function getDescription(string $errorCode): string
+    {
+        return (string)($this->getAllDescriptions()[$errorCode] ?? Translate::addTagPrefix($errorCode, 'descr_'));
+    }
+
+    /**
+     * Get both title and description for a specific error code
+     *
+     * Convenience-method for template-callers
+     *
+     * @param string $errorCode The error code to look up
+     *
+     * @return array An array containing both errorcode strings.
+     *
+     * @deprecated Static method access is deprecated. Move to instance method.
+     * @see self::getMessage()
+     * TODO NextMajorRelease Remove this method.
+     */
+    public static function getErrorCodeMessage(string $errorCode): array
+    {
+        return [
+            self::KEY_TITLE => self::getErrorCodeTitle($errorCode),
+            self::KEY_DESCRIPTION => self::getErrorCodeDescription($errorCode),
+        ];
+    }
 
     /**
      * Get both title and description for a specific error code
@@ -297,11 +451,11 @@ class ErrorCodes
      *
      * @return array An array containing both errorcode strings.
      */
-    public static function getErrorCodeMessage(string $errorCode): array
+    public function getMessage(string $errorCode): array
     {
         return [
-            self::KEY_TITLE => self::getErrorCodeTitle($errorCode),
-            self::KEY_DESCRIPTION => self::getErrorCodeDescription($errorCode),
+            self::KEY_TITLE => $this->getTitle($errorCode),
+            self::KEY_DESCRIPTION => $this->getDescription($errorCode),
         ];
     }
 }

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -50,6 +50,9 @@ class ErrorCodes
     public const USERABORTED = 'USERABORTED';
     public const WRONGUSERPASS = 'WRONGUSERPASS';
 
+    public const KEY_TITLE = 'title';
+    public const KEY_DESCRIPTION = 'descr';
+
 
     /**
      * Fetch all default translation strings for error code titles.
@@ -95,17 +98,27 @@ class ErrorCodes
         ];
     }
 
+    /**
+     * Fetch all title translation strings for custom error codes.
+     *
+     * Extend this to define custom error codes and their title translations.
+     *
+     * @return array A map from custom error code to error code title
+     */
+    public static function getCustomErrorCodeTitles(): array
+    {
+        return [];
+    }
+
 
     /**
      * Fetch all translation strings for error code titles.
-     *
-     * Extend this to add error codes.
      *
      * @return array A map from error code to error code title
      */
     public static function getAllErrorCodeTitles(): array
     {
-        return self::defaultGetAllErrorCodeTitles();
+        return array_merge(self::defaultGetAllErrorCodeTitles(), static::getCustomErrorCodeTitles());
     }
 
 
@@ -201,15 +214,25 @@ class ErrorCodes
     }
 
     /**
-     * Fetch all translation strings for error code descriptions.
+     * Fetch all description translation strings for custom error codes.
      *
-     * Extend this to add error codes.
+     * Extend this to define custom error codes and their description translations.
+     *
+     * @return array A map from error code to error code description
+     */
+    public static function getCustomErrorCodeDescriptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * Fetch all translation strings for error code descriptions.
      *
      * @return array A map from error code to error code description
      */
     public static function getAllErrorCodeDescriptions(): array
     {
-        return self::defaultGetAllErrorCodeDescriptions();
+        return array_merge(self::defaultGetAllErrorCodeDescriptions(), static::getCustomErrorCodeDescriptions());
     }
 
 
@@ -223,8 +246,8 @@ class ErrorCodes
     public static function getAllErrorCodeMessages(): array
     {
         return [
-            'title' => self::getAllErrorCodeTitles(),
-            'descr' => self::getAllErrorCodeDescriptions(),
+            self::KEY_TITLE => self::getAllErrorCodeTitles(),
+            self::KEY_DESCRIPTION => self::getAllErrorCodeDescriptions(),
         ];
     }
 
@@ -277,8 +300,8 @@ class ErrorCodes
     public static function getErrorCodeMessage(string $errorCode): array
     {
         return [
-            'title' => self::getErrorCodeTitle($errorCode),
-            'descr' => self::getErrorCodeDescription($errorCode),
+            self::KEY_TITLE => self::getErrorCodeTitle($errorCode),
+            self::KEY_DESCRIPTION => self::getErrorCodeDescription($errorCode),
         ];
     }
 }

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -12,6 +12,8 @@ use function array_key_exists;
  * Class that maps SimpleSAMLphp error codes to translateable strings.
  *
  * @package SimpleSAMLphp
+ *
+ * TODO Consider moving to constants for error code keys.
  */
 class ErrorCodes
 {
@@ -220,7 +222,7 @@ class ErrorCodes
      */
     public static function getErrorCodeDescription(string $errorCode): string
     {
-        if (array_key_exists($errorCode, self::getAllErrorCodeTitles())) {
+        if (array_key_exists($errorCode, self::getAllErrorCodeDescriptions())) {
             $errorCodeDescriptions = self::getAllErrorCodeDescriptions();
             return $errorCodeDescriptions[$errorCode];
         } else {

--- a/src/SimpleSAML/Error/ExceptionHandler.php
+++ b/src/SimpleSAML/Error/ExceptionHandler.php
@@ -29,10 +29,10 @@ class ExceptionHandler
         if ($exception instanceof Error) {
             $exception->show();
         } elseif ($exception instanceof BuiltinException) {
-            $e = new Error('UNHANDLEDEXCEPTION', $exception);
+            $e = new Error(ErrorCodes::UNHANDLEDEXCEPTION, $exception);
             $e->show();
         } elseif (class_exists('Error') && $exception instanceof BuiltinError) {
-            $e = new Error('UNHANDLEDEXCEPTION', $exception);
+            $e = new Error(ErrorCodes::UNHANDLEDEXCEPTION, $exception);
             $e->show();
         }
     }

--- a/src/SimpleSAML/Error/MetadataNotFound.php
+++ b/src/SimpleSAML/Error/MetadataNotFound.php
@@ -23,7 +23,7 @@ class MetadataNotFound extends Error
     {
         $this->includeTemplate = 'core:no_metadata.twig';
         parent::__construct([
-                'METADATANOTFOUND',
+                ErrorCodes::METADATANOTFOUND,
                 '%ENTITYID%' => $entityId
         ]);
     }

--- a/src/SimpleSAML/Error/NoState.php
+++ b/src/SimpleSAML/Error/NoState.php
@@ -19,6 +19,6 @@ class NoState extends Error
     public function __construct()
     {
         $this->includeTemplate = 'core:no_state.twig';
-        parent::__construct('NOSTATE');
+        parent::__construct(ErrorCodes::NOSTATE);
     }
 }

--- a/src/SimpleSAML/Error/NotFound.php
+++ b/src/SimpleSAML/Error/NotFound.php
@@ -30,10 +30,10 @@ class NotFound extends Error
         $url = $httpUtils->getSelfURL();
 
         if ($reason === null) {
-            parent::__construct(['NOTFOUND', '%URL%' => $url], null, 404);
+            parent::__construct([ErrorCodes::NOTFOUND, '%URL%' => $url], null, 404);
             $this->message = "The requested page '$url' could not be found.";
         } else {
-            parent::__construct(['NOTFOUNDREASON', '%URL%' => $url, '%REASON%' => $reason], null, 404);
+            parent::__construct([ErrorCodes::NOTFOUNDREASON, '%URL%' => $url, '%REASON%' => $reason], null, 404);
             $this->message = "The requested page '$url' could not be found. " . $reason;
         }
     }

--- a/src/SimpleSAML/Error/UserAborted.php
+++ b/src/SimpleSAML/Error/UserAborted.php
@@ -21,6 +21,6 @@ class UserAborted extends Error
      */
     public function __construct(Throwable $cause = null)
     {
-        parent::__construct('USERABORTED', $cause);
+        parent::__construct(ErrorCodes::USERABORTED, $cause);
     }
 }

--- a/src/SimpleSAML/Memcache.php
+++ b/src/SimpleSAML/Memcache.php
@@ -6,6 +6,7 @@ namespace SimpleSAML;
 
 use Exception;
 use Memcached;
+use SimpleSAML\Error\ErrorCodes;
 use SimpleSAML\Utils;
 
 use function array_key_exists;
@@ -133,7 +134,7 @@ class Memcache
         if ($latestData === null) {
             if ($allDown) {
                 // all servers are down, panic!
-                $e = new Error\Error('MEMCACHEDOWN', null, 503);
+                $e = new Error\Error(ErrorCodes::MEMCACHEDOWN, null, 503);
                 throw new Error\Exception('All memcache servers are down', 503, $e);
             }
             // we didn't find any data matching the key

--- a/tests/modules/admin/src/Controller/TestTest.php
+++ b/tests/modules/admin/src/Controller/TestTest.php
@@ -146,7 +146,7 @@ class TestTest extends TestCase
         });
 
         $this->expectException(Error\NoState::class);
-        $this->expectExceptionMessage('NOSTATE');
+        $this->expectExceptionMessage(Error\ErrorCodes::NOSTATE);
         $c->main($request, 'admin');
     }
 

--- a/tests/modules/core/src/Auth/UserPassBaseTest.php
+++ b/tests/modules/core/src/Auth/UserPassBaseTest.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Test\Module\core\Auth;
 
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Error\Error as SspError;
+use SimpleSAML\Error\ErrorCodes;
 use SimpleSAML\Module\core\Auth\UserPassBase;
 use SimpleSAML\SAML2\Constants as C;
 use Symfony\Component\HttpFoundation\Request;
@@ -50,7 +51,7 @@ class UserPassBaseTest extends TestCase
     public function testAuthenticateECPMissingUsername(): void
     {
         $this->expectException(SspError::class);
-        $this->expectExceptionMessage('WRONGUSERPASS');
+        $this->expectExceptionMessage(ErrorCodes::WRONGUSERPASS);
 
         $state = [
             'saml:Binding' => C::BINDING_PAOS,
@@ -74,7 +75,7 @@ class UserPassBaseTest extends TestCase
     public function testAuthenticateECPMissingPassword(): void
     {
         $this->expectException(SspError::class);
-        $this->expectExceptionMessage('WRONGUSERPASS');
+        $this->expectExceptionMessage(ErrorCodes::WRONGUSERPASS);
 
         $state = [
             'saml:Binding' => C::BINDING_PAOS,

--- a/tests/modules/saml/src/Controller/MetadataTest.php
+++ b/tests/modules/saml/src/Controller/MetadataTest.php
@@ -196,8 +196,8 @@ class MetadataTest extends TestCase
 
         $c = new Controller\Metadata($config);
 
-        $this->expectException(\SimpleSAML\Error\Error::class);
-        $this->expectExceptionMessage('NOACCESS');
+        $this->expectException(Error\Error::class);
+        $this->expectExceptionMessage(Error\ErrorCodes::NOACCESS);
         $result = $c->metadata($request);
     }
 
@@ -214,8 +214,8 @@ class MetadataTest extends TestCase
         $c = new Controller\Metadata($this->config);
         $c->setMetadataStorageHandler($this->mdh);
 
-        $this->expectException(\SimpleSAML\Error\Error::class);
-        $this->expectExceptionMessage('METADATA');
+        $this->expectException(Error\Error::class);
+        $this->expectExceptionMessage(Error\ErrorCodes::METADATA);
         $result = $c->metadata($request);
     }
 

--- a/tests/modules/saml/src/Controller/ServiceProviderTest.php
+++ b/tests/modules/saml/src/Controller/ServiceProviderTest.php
@@ -349,7 +349,7 @@ class ServiceProviderTest extends TestCase
         $c = new Controller\ServiceProvider($this->config, $this->session);
 
         $this->expectException(Error\Error::class);
-        $this->expectExceptionMessage('ACSPARAMS');
+        $this->expectExceptionMessage(Error\ErrorCodes::ACSPARAMS);
 
         $c->assertionConsumerService($request, 'phpunit');
     }
@@ -441,7 +441,7 @@ class ServiceProviderTest extends TestCase
         $c = new Controller\ServiceProvider($this->config, $this->session);
 
         $this->expectException(Error\Error::class);
-        $this->expectExceptionMessage('SLOSERVICEPARAMS');
+        $this->expectExceptionMessage(Error\ErrorCodes::SLOSERVICEPARAMS);
 
         $c->singleLogoutService($request, 'phpunit');
     }

--- a/tests/src/SimpleSAML/Error/ErrorCodesTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorCodesTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\Error;
+
+use SimpleSAML\Error\ErrorCodes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \SimpleSAML\Error\ErrorCodes
+ */
+class ErrorCodesTest extends TestCase
+{
+
+    public function testCanGetFallbackValuesForNonExistentErrorCode(): void
+    {
+        $nonExistentCode = 'nonexistent';
+        $this->assertStringContainsString($nonExistentCode, ErrorCodes::getErrorCodeTitle($nonExistentCode));
+        $this->assertStringContainsString($nonExistentCode, ErrorCodes::getErrorCodeDescription($nonExistentCode));
+    }
+
+    public function testCanGetDefaultErrorCodes(): void
+    {
+        $this->assertSameSize(
+            ErrorCodes::defaultGetAllErrorCodeTitles(),
+            ErrorCodes::defaultGetAllErrorCodeDescriptions(),
+            'Not all error codes have their title / description pair.'
+        );
+
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, ErrorCodes::defaultGetAllErrorCodeTitles());
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, ErrorCodes::defaultGetAllErrorCodeDescriptions());
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, ErrorCodes::getAllErrorCodeDescriptions());
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, ErrorCodes::getAllErrorCodeTitles());
+
+        $this->assertSame(
+            ErrorCodes::defaultGetAllErrorCodeTitles()[ErrorCodes::WRONGUSERPASS],
+            ErrorCodes::getErrorCodeTitle(ErrorCodes::WRONGUSERPASS)
+        );
+        $this->assertSame(
+            ErrorCodes::defaultGetAllErrorCodeDescriptions()[ErrorCodes::WRONGUSERPASS],
+            ErrorCodes::getErrorCodeDescription(ErrorCodes::WRONGUSERPASS)
+        );
+
+        $this->assertSame(
+            ErrorCodes::getAllErrorCodeTitles(),
+            ErrorCodes::getAllErrorCodeMessages()[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            ErrorCodes::getAllErrorCodeDescriptions(),
+            ErrorCodes::getAllErrorCodeMessages()[ErrorCodes::KEY_DESCRIPTION]
+        );
+
+        $this->assertSame(
+            ErrorCodes::getErrorCodeTitle(ErrorCodes::WRONGUSERPASS),
+            ErrorCodes::getErrorCodeMessage(ErrorCodes::WRONGUSERPASS)[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            ErrorCodes::getErrorCodeDescription(ErrorCodes::WRONGUSERPASS),
+            ErrorCodes::getErrorCodeMessage(ErrorCodes::WRONGUSERPASS)[ErrorCodes::KEY_DESCRIPTION]
+        );
+    }
+
+    public function testCanExtendWithCustomErrorCodes(): void
+    {
+        $customErrorCodes = new class extends ErrorCodes
+        {
+            public const CUSTOMCODE = 'CUSTOMCODE';
+            public static string $customTitle = 'customTitle';
+            public static string $customDescription = 'customDescription';
+
+            public static function getCustomErrorCodeTitles(): array
+            {
+                return [self::CUSTOMCODE => self::$customTitle];
+            }
+
+            public static function getCustomErrorCodeDescriptions(): array
+            {
+                return [self::CUSTOMCODE => self::$customDescription];
+            }
+        };
+
+        $this->assertSameSize(
+            ErrorCodes::getCustomErrorCodeTitles(),
+            ErrorCodes::getCustomErrorCodeDescriptions(),
+            'Not all custom error codes have their title / description pair.'
+        );
+
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes::getCustomErrorCodeTitles());
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes::getCustomErrorCodeDescriptions());
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes::getAllErrorCodeDescriptions());
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes::getAllErrorCodeTitles());
+
+        $this->assertSame(
+            $customErrorCodes::getCustomErrorCodeTitles()[$customErrorCodes::CUSTOMCODE],
+            $customErrorCodes::getErrorCodeTitle($customErrorCodes::CUSTOMCODE)
+        );
+        $this->assertSame(
+            $customErrorCodes::getCustomErrorCodeDescriptions()[$customErrorCodes::CUSTOMCODE],
+            $customErrorCodes::getErrorCodeDescription($customErrorCodes::CUSTOMCODE)
+        );
+
+        $this->assertSame(
+            $customErrorCodes::getAllErrorCodeTitles(),
+            $customErrorCodes::getAllErrorCodeMessages()[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            $customErrorCodes::getAllErrorCodeDescriptions(),
+            $customErrorCodes::getAllErrorCodeMessages()[ErrorCodes::KEY_DESCRIPTION]
+        );
+
+        $this->assertSame(
+            $customErrorCodes::getErrorCodeTitle($customErrorCodes::CUSTOMCODE),
+            $customErrorCodes::getErrorCodeMessage($customErrorCodes::CUSTOMCODE)[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            $customErrorCodes::getErrorCodeDescription($customErrorCodes::CUSTOMCODE),
+            $customErrorCodes::getErrorCodeMessage($customErrorCodes::CUSTOMCODE)[ErrorCodes::KEY_DESCRIPTION]
+        );
+    }
+}

--- a/tests/src/SimpleSAML/Error/ErrorCodesTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorCodesTest.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ErrorCodesTest extends TestCase
 {
-
     public function testCanGetFallbackValuesForNonExistentErrorCode(): void
     {
         $nonExistentCode = 'nonexistent';

--- a/tests/src/SimpleSAML/Error/ErrorCodesTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorCodesTest.php
@@ -12,14 +12,32 @@ use PHPUnit\Framework\TestCase;
  */
 class ErrorCodesTest extends TestCase
 {
-    public function testCanGetFallbackValuesForNonExistentErrorCode(): void
+    protected function instance(): ErrorCodes
+    {
+        return new ErrorCodes();
+    }
+
+    /**
+     * @deprecated
+     */
+    public function testCanStaticallyGetFallbackValuesForNonExistentErrorCode(): void
     {
         $nonExistentCode = 'nonexistent';
         $this->assertStringContainsString($nonExistentCode, ErrorCodes::getErrorCodeTitle($nonExistentCode));
         $this->assertStringContainsString($nonExistentCode, ErrorCodes::getErrorCodeDescription($nonExistentCode));
     }
 
-    public function testCanGetDefaultErrorCodes(): void
+    public function testCanGetFallbackValuesForNonExistentErrorCode(): void
+    {
+        $nonExistentCode = 'nonexistent';
+        $this->assertStringContainsString($nonExistentCode, $this->instance()->getTitle($nonExistentCode));
+        $this->assertStringContainsString($nonExistentCode, $this->instance()->getDescription($nonExistentCode));
+    }
+
+    /**
+     * @deprecated
+     */
+    public function testCanStaticallyGetDefaultErrorCodes(): void
     {
         $this->assertSameSize(
             ErrorCodes::defaultGetAllErrorCodeTitles(),
@@ -60,7 +78,51 @@ class ErrorCodesTest extends TestCase
         );
     }
 
-    public function testCanExtendWithCustomErrorCodes(): void
+    public function testCanGetDefaultErrorCodes(): void
+    {
+        $this->assertSameSize(
+            $this->instance()->getDefaultTitles(),
+            $this->instance()->getDefaultDescriptions(),
+            'Not all error codes have their title / description pair.'
+        );
+
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, $this->instance()->getDefaultTitles());
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, $this->instance()->getDefaultDescriptions());
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, $this->instance()->getAllDescriptions());
+        $this->assertArrayHasKey(ErrorCodes::WRONGUSERPASS, $this->instance()->getAllTitles());
+
+        $this->assertSame(
+            $this->instance()->getDefaultTitles()[ErrorCodes::WRONGUSERPASS],
+            $this->instance()->getTitle(ErrorCodes::WRONGUSERPASS)
+        );
+        $this->assertSame(
+            $this->instance()->getDefaultDescriptions()[ErrorCodes::WRONGUSERPASS],
+            $this->instance()->getDescription(ErrorCodes::WRONGUSERPASS)
+        );
+
+        $this->assertSame(
+            $this->instance()->getAllTitles(),
+            $this->instance()->getAllMessages()[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            $this->instance()->getAllDescriptions(),
+            $this->instance()->getAllMessages()[ErrorCodes::KEY_DESCRIPTION]
+        );
+
+        $this->assertSame(
+            $this->instance()->getTitle(ErrorCodes::WRONGUSERPASS),
+            $this->instance()->getMessage(ErrorCodes::WRONGUSERPASS)[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            $this->instance()->getDescription(ErrorCodes::WRONGUSERPASS),
+            $this->instance()->getMessage(ErrorCodes::WRONGUSERPASS)[ErrorCodes::KEY_DESCRIPTION]
+        );
+    }
+
+    /**
+     * @deprecated
+     */
+    public function testCanStaticallyExtendWithCustomErrorCodes(): void
     {
         $customErrorCodes = new class extends ErrorCodes
         {
@@ -80,8 +142,8 @@ class ErrorCodesTest extends TestCase
         };
 
         $this->assertSameSize(
-            ErrorCodes::getCustomErrorCodeTitles(),
-            ErrorCodes::getCustomErrorCodeDescriptions(),
+            $customErrorCodes::getCustomErrorCodeTitles(),
+            $customErrorCodes::getCustomErrorCodeDescriptions(),
             'Not all custom error codes have their title / description pair.'
         );
 
@@ -115,6 +177,67 @@ class ErrorCodesTest extends TestCase
         $this->assertSame(
             $customErrorCodes::getErrorCodeDescription($customErrorCodes::CUSTOMCODE),
             $customErrorCodes::getErrorCodeMessage($customErrorCodes::CUSTOMCODE)[ErrorCodes::KEY_DESCRIPTION]
+        );
+    }
+
+    /**
+     * @deprecated
+     */
+    public function testCanExtendWithCustomErrorCodes(): void
+    {
+        $customErrorCodes = new class extends ErrorCodes
+        {
+            public const CUSTOMCODE = 'CUSTOMCODE';
+            public static string $customTitle = 'customTitle';
+            public static string $customDescription = 'customDescription';
+
+            public function getCustomTitles(): array
+            {
+                return [self::CUSTOMCODE => self::$customTitle];
+            }
+
+            public function getCustomDescriptions(): array
+            {
+                return [self::CUSTOMCODE => self::$customDescription];
+            }
+        };
+
+        $this->assertSameSize(
+            $customErrorCodes->getCustomTitles(),
+            $customErrorCodes->getCustomDescriptions(),
+            'Not all custom error codes have their title / description pair.'
+        );
+
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes->getCustomTitles());
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes->getCustomDescriptions());
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes->getAllTitles());
+        $this->assertArrayHasKey($customErrorCodes::CUSTOMCODE, $customErrorCodes->getAllDescriptions());
+
+        $this->assertSame(
+            $customErrorCodes->getCustomTitles()[$customErrorCodes::CUSTOMCODE],
+            $customErrorCodes->getTitle($customErrorCodes::CUSTOMCODE)
+        );
+        $this->assertSame(
+            $customErrorCodes->getCustomDescriptions()[$customErrorCodes::CUSTOMCODE],
+            $customErrorCodes->getDescription($customErrorCodes::CUSTOMCODE)
+        );
+
+        $this->assertSame(
+            $customErrorCodes->getAllTitles(),
+            $customErrorCodes->getAllMessages()[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            $customErrorCodes->getAllDescriptions(),
+            $customErrorCodes->getAllMessages()[ErrorCodes::KEY_DESCRIPTION]
+        );
+
+        $this->assertSame(
+            $customErrorCodes->getTitle($customErrorCodes::CUSTOMCODE),
+            $customErrorCodes->getMessage($customErrorCodes::CUSTOMCODE)[ErrorCodes::KEY_TITLE]
+        );
+        $this->assertSame(
+            $customErrorCodes->getDescription($customErrorCodes::CUSTOMCODE),
+            $customErrorCodes->getMessage($customErrorCodes::CUSTOMCODE)[ErrorCodes::KEY_DESCRIPTION]
         );
     }
 }

--- a/tests/src/SimpleSAML/Error/ErrorTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorTest.php
@@ -4,15 +4,44 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Test\Error;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use SimpleSAML\Error\Error;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Error\ErrorCodes;
+use Throwable;
 
 /**
  * @covers \SimpleSAML\Error\Error
+ * @uses \SimpleSAML\Error\ErrorCodes
  */
 class ErrorTest extends TestCase
 {
+    private ErrorCodes $errorCodes;
+    private array|string $errorCodeSample;
+    private ?int $httpCodeSample;
+    private MockObject|Throwable|null $causeMock;
+    private MockObject|ErrorCodes|null $errorCodesMock;
+
+    protected function setUp(): void
+    {
+        $this->errorCodes = new ErrorCodes();
+
+        $this->errorCodeSample = ErrorCodes::WRONGUSERPASS;
+        $this->causeMock = $this->createMock(Throwable::class);
+        $this->httpCodeSample = 500;
+        $this->errorCodesMock = $this->createMock(ErrorCodes::class);
+    }
+
+    protected function mocked(): Error
+    {
+        return new Error(
+            $this->errorCodeSample,
+            $this->causeMock,
+            $this->httpCodeSample,
+            $this->errorCodesMock
+        );
+    }
+
     public function testCanInstantiateWithErrorCodeString(): void
     {
         $error = new Error(ErrorCodes::WRONGUSERPASS);
@@ -23,11 +52,11 @@ class ErrorTest extends TestCase
         $this->assertIsArray($error->getParameters());
         $this->assertArrayNotHasKey('paramKey', $error->getParameters());
         $this->assertSame(
-            ErrorCodes::getErrorCodeTitle(ErrorCodes::WRONGUSERPASS),
+            $this->errorCodes->getTitle(ErrorCodes::WRONGUSERPASS),
             $error->getDictTitle()
         );
         $this->assertSame(
-            ErrorCodes::getErrorCodeDescription(ErrorCodes::WRONGUSERPASS),
+            $this->errorCodes->getDescription(ErrorCodes::WRONGUSERPASS),
             $error->getDictDescr()
         );
     }
@@ -47,13 +76,34 @@ class ErrorTest extends TestCase
         $this->assertIsArray($error->getParameters());
         $this->assertArrayHasKey('paramKey', $error->getParameters());
         $this->assertSame(
-            ErrorCodes::getErrorCodeTitle(ErrorCodes::WRONGUSERPASS),
+            $this->errorCodes->getTitle(ErrorCodes::WRONGUSERPASS),
             $error->getDictTitle()
         );
         $this->assertSame(
-            ErrorCodes::getErrorCodeDescription(ErrorCodes::WRONGUSERPASS),
+            $this->errorCodes->getDescription(ErrorCodes::WRONGUSERPASS),
             $error->getDictDescr()
         );
+    }
+
+    public function testCanUseInjectedMockedErrorCodes(): void
+    {
+        $testTitle = 'testTitle';
+        $testDescription = 'testDescription';
+
+        $this->errorCodesMock->expects($this->once())
+            ->method('getTitle')
+            ->with($this->errorCodeSample)
+            ->willReturn($testTitle);
+
+        $this->errorCodesMock->expects($this->once())
+            ->method('getDescription')
+            ->with($this->errorCodeSample)
+            ->willReturn($testDescription);
+
+        $error = $this->mocked();
+
+        $this->assertSame($testTitle, $error->getDictTitle());
+        $this->assertSame($testDescription, $error->getDictDescr());
     }
 
     public function testCanExtendWithCustomErrorCodes(): void
@@ -67,11 +117,11 @@ class ErrorTest extends TestCase
                 return new class extends ErrorCodes
                 {
                     public const CUSTOMCODE = 'CUSTOMCODE';
-                    public static function getCustomErrorCodeTitles(): array
+                    public function getCustomTitles(): array
                     {
                         return [self::CUSTOMCODE => 'customCodeTitle'];
                     }
-                    public static function getCustomErrorCodeDescriptions(): array
+                    public function getCustomDescriptions(): array
                     {
                         return [self::CUSTOMCODE => 'customCodeDescription'];
                     }

--- a/tests/src/SimpleSAML/Error/ErrorTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorTest.php
@@ -60,7 +60,7 @@ class ErrorTest extends TestCase
     {
         $customErrorCode = 'CUSTOMCODE';
 
-        $customError = new class($customErrorCode) extends Error
+        $customError = new class ($customErrorCode) extends Error
         {
             protected function getErrorCodes(): ErrorCodes
             {

--- a/tests/src/SimpleSAML/Error/ErrorTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\Error;
+
+use SimpleSAML\Error\Error;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Error\ErrorCodes;
+
+/**
+ * @covers \SimpleSAML\Error\Error
+ */
+class ErrorTest extends TestCase
+{
+    public function testCanInstantiateWithErrorCodeString(): void
+    {
+        $error = new Error(ErrorCodes::WRONGUSERPASS);
+
+        $this->assertInstanceOf(Error::class, $error);
+
+        $this->assertSame(ErrorCodes::WRONGUSERPASS, $error->getErrorCode());
+        $this->assertIsArray($error->getParameters());
+        $this->assertArrayNotHasKey('paramKey', $error->getParameters());
+        $this->assertSame(
+            ErrorCodes::getErrorCodeTitle(ErrorCodes::WRONGUSERPASS),
+            $error->getDictTitle()
+        );
+        $this->assertSame(
+            ErrorCodes::getErrorCodeDescription(ErrorCodes::WRONGUSERPASS),
+            $error->getDictDescr()
+        );
+    }
+
+    public function testCanInstantiateWithErrorCodeParamsArray(): void
+    {
+        $errorCodeParams = [
+            ErrorCodes::WRONGUSERPASS,
+            'paramKey' => 'paramValue',
+        ];
+
+        $error = new Error($errorCodeParams);
+
+        $this->assertInstanceOf(Error::class, $error);
+
+        $this->assertSame(ErrorCodes::WRONGUSERPASS, $error->getErrorCode());
+        $this->assertIsArray($error->getParameters());
+        $this->assertArrayHasKey('paramKey', $error->getParameters());
+        $this->assertSame(
+            ErrorCodes::getErrorCodeTitle(ErrorCodes::WRONGUSERPASS),
+            $error->getDictTitle()
+        );
+        $this->assertSame(
+            ErrorCodes::getErrorCodeDescription(ErrorCodes::WRONGUSERPASS),
+            $error->getDictDescr()
+        );
+    }
+
+    public function testCanExtendWithCustomErrorCodes(): void
+    {
+        $customErrorCode = 'CUSTOMCODE';
+
+        $customError = new class($customErrorCode) extends Error
+        {
+            protected function getErrorCodes(): ErrorCodes
+            {
+                return new class extends ErrorCodes
+                {
+                    public const CUSTOMCODE = 'CUSTOMCODE';
+                    public static function getCustomErrorCodeTitles(): array
+                    {
+                        return [self::CUSTOMCODE => 'customCodeTitle'];
+                    }
+                    public static function getCustomErrorCodeDescriptions(): array
+                    {
+                        return [self::CUSTOMCODE => 'customCodeDescription'];
+                    }
+                };
+            }
+        };
+
+        $this->assertSame('customCodeTitle', $customError->getDictTitle());
+        $this->assertSame('customCodeDescription', $customError->getDictDescr());
+    }
+}


### PR DESCRIPTION
This PR
- makes ErrorCodes easier to extend and to be used in custom Error classes
- introduces unit tests for ErrorCodes and Error classes
- moves to error code constants usage

Closes #1867 