### PR TITLE
Handle AuthnContextClassRef changes when proxying

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -13,6 +13,8 @@ Released TBD
 * Fix legacy endpoints to not send response twice
 * Fix exception when using iframe-logout (#1936)
 * Look for the schema files in the right place (#1929)
+* Fixed file logging handler to not fail on the first write after file-creation (#1877)
+* Fixed a warning in the RequestedAuthnContextSelector
 
 `core`
 
@@ -44,7 +46,6 @@ Released 2023-10-30
 * Update vulnerable composer (CVE-2023-43655; not affected)
 * Fixed a potential XSS-through-DOM (3x; not affected)
 * Fixed a warning in the RequestedAuthnContextSelector
-* Fixed file logging handler to not fail on the first write after file-creation (#1877)
 
 ## Version 2.0.6
 

--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -862,6 +862,30 @@ class SP extends \SimpleSAML\Auth\Source
             $state['saml:sp:AuthId'] = $this->authId;
             self::askForIdPChange($state);
         }
+
+        /*
+         * When proxying AuthnContextClassRef, we also need to check if the
+         * original IdP used a compatible AuthnContext. If not, we may need
+         * need to do step-up authentication (e.g. for requesting MFA). At
+         * the moment this only handles exact comparisons, since handling
+         * better/minimum/maximum would require a prioritised list.
+         */
+        if (
+            $this->passAuthnContextClassRef
+            && isset($state['saml:RequestedAuthnContext'])
+            && $state['saml:RequestedAuthnContext']['Comparison'] == Constants::COMPARISON_EXACT
+            && isset($data['saml:sp:AuthnContext'])
+            && $state['saml:RequestedAuthnContext']['AuthnContextClassRef'][0] != $data['saml:sp:AuthnContext']
+        ) {
+            Logger::warning(sprintf(
+                "Reauthentication requires change in AuthnContext from '%s' to '%s'.",
+                $data['saml:sp:AuthnContext'],
+                $state['saml:RequestedAuthnContext']['AuthnContextClassRef'][0]
+            ));
+            $state['saml:idp'] = $data['saml:sp:IdP'];
+            $state['saml:sp:AuthId'] = $this->authId;
+            self::tryStepUpAuth($state);
+        }
     }
 
 
@@ -904,6 +928,37 @@ class SP extends \SimpleSAML\Auth\Source
 
         $httpUtils = new Utils\HTTP();
         $httpUtils->redirectTrustedURL($url, ['AuthState' => $id]);
+        Assert::true(false);
+    }
+
+
+    /**
+     * Attempt to re-authenticate using the same identity provider, perhaps
+     * with different requirements (e.g. AuthnContext). Note that this method
+     * is intended for instances of SimpleSAMLphp running as a SAML proxy,
+     * and therefore acting as both an SP and an IdP at the same time.
+     *
+     * @param array The state array
+     * The following keys must be defined:
+     * - 'saml:idp': the IdP to re-authenticate with
+     * - 'saml:sp:AuthId': the identifier of the current authentication source.
+     * @throws \SAML2\Exception\Protocol\NoPassiveException In case the authentication request was passive.
+     */
+    public static function tryStepUpAuth(array &$state): void
+    {
+        Assert::keyExists($state, 'saml:idp');
+        Assert::keyExists($state, 'saml:sp:AuthId');
+
+        if (isset($state['isPassive']) && (bool) $state['isPassive']) {
+            // passive request, we cannot authenticate the user
+            throw new NoPassiveException(
+                Constants::STATUS_REQUESTER . ':  Reauthentication required'
+            );
+        }
+
+        /** @var \SimpleSAML\Module\saml\Auth\Source\SP $as */
+        $as = new Auth\Simple($state['saml:sp:AuthId']);
+        $as->login($state);
         Assert::true(false);
     }
 

--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -873,9 +873,9 @@ class SP extends \SimpleSAML\Auth\Source
         if (
             $this->passAuthnContextClassRef
             && isset($state['saml:RequestedAuthnContext'])
-            && $state['saml:RequestedAuthnContext']['Comparison'] == Constants::COMPARISON_EXACT
+            && $state['saml:RequestedAuthnContext']['Comparison'] === Constants::COMPARISON_EXACT
             && isset($data['saml:sp:AuthnContext'])
-            && $state['saml:RequestedAuthnContext']['AuthnContextClassRef'][0] != $data['saml:sp:AuthnContext']
+            && $state['saml:RequestedAuthnContext']['AuthnContextClassRef'][0] !== $data['saml:sp:AuthnContext']
         ) {
             Logger::warning(sprintf(
                 "Reauthentication requires change in AuthnContext from '%s' to '%s'.",


### PR DESCRIPTION
We introduced the ability to proxy RequestedAuthnContext in #833. However, if we're doing that, we must also consider what happens during authentication when the RequestedAuthnContext doesn't match the AuthnContext we have in a cached session.

If we don't compare what we have against what's requested, we may miss a request to step up authentication (e.g. when MFA is required by a specific service). This results in a poor user experience where they've got an IdP behind the proxy that is capable of meeting the request, but have to log out/terminate their SSO session to trigger it.

This patch tries to fix that by comparing whats in our session with what was requested, and triggering authentication again if they don't match. It only uses an exact comparison since we've no way of comparing relative weights of different AuthnContextClassRefs without also maintaining a lookup table. However, the exact match should be good enough for the majority of use cases.

This patch was written for 2.0.x but should apply cleanly to 2.1.x. It'll need refactoring for master.