### PR TITLE
Update docs to recommend use a tag when installing through git checkout

### DIFF
--- a/docs/simplesamlphp-install-repo.md
+++ b/docs/simplesamlphp-install-repo.md
@@ -3,6 +3,11 @@ Installing SimpleSAMLphp from the repository
 
 These are some notes about running SimpleSAMLphp from the repository.
 
+Prerequisites
+-------------
+
+Review the [prerequisites](../simplesamlphp-install) from the main installation guide.
+
 Installing from git
 -------------------
 
@@ -12,10 +17,13 @@ Go to the directory where you want to install SimpleSAMLphp:
 cd /var
 ```
 
+The `master` branch is not stable and targets the next major release.
+Pick a [tag](https://github.com/simplesamlphp/simplesamlphp/tags) to use.
+
 Then do a git clone:
 
 ```bash
-git clone https://github.com/simplesamlphp/simplesamlphp.git simplesamlphp
+git clone --branch <tag_name> https://github.com/simplesamlphp/simplesamlphp.git simplesamlphp
 ```
 
 Initialize configuration and metadata:


### PR DESCRIPTION
I hope this cuts down on support questions for people checking out master branch for their deploys.
Probably worth apply to SSP 2.1 and 2.2 branches as well, for when those make the next stable documentation.