### PR TITLE
Use unique exception message to avoid confusion

### DIFF
--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -122,7 +122,7 @@ class SP extends Auth\Source
         Assert::notEq(
             $entityId,
             'https://myapp.example.org/',
-            'Please set a valid and unique entityID',
+            'Please set a valid and unique SP entityID',
         );
 
         $this->config = Configuration::getInstance();


### PR DESCRIPTION
Same message exists in `src/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php`.