### PR TITLE
Fix static call for non-static method in bin/initMDSPdo.php

### DIFF
--- a/bin/initMDSPdo.php
+++ b/bin/initMDSPdo.php
@@ -8,7 +8,7 @@ $baseDir = dirname(__FILE__, 2);
 
 // Add library autoloader and configuration
 require_once $baseDir . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . '_autoload.php';
-require_once \SimpleSAML\Utils\Config::getConfigDir() . DIRECTORY_SEPARATOR . 'config.php';
+require_once (new \SimpleSAML\Utils\Config())->getConfigDir() . DIRECTORY_SEPARATOR . 'config.php';
 
 echo "Initializing Metadata Database..." . PHP_EOL;
 

--- a/bin/initMDSPdo.php
+++ b/bin/initMDSPdo.php
@@ -8,7 +8,11 @@ $baseDir = dirname(__FILE__, 2);
 
 // Add library autoloader and configuration
 require_once $baseDir . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . '_autoload.php';
-require_once (new \SimpleSAML\Utils\Config())->getConfigDir() . DIRECTORY_SEPARATOR . 'config.php';
+
+// This is the config dir of the SimpleSAMLphp installation
+$configDir = (new \SimpleSAML\Utils\Config())->getConfigDir();
+
+require_once $configDir . DIRECTORY_SEPARATOR . 'config.php';
 
 echo "Initializing Metadata Database..." . PHP_EOL;
 


### PR DESCRIPTION
This PR fixes static call for non static method in bin/initMDSPdo.php, which raises fatal error in PHP v8.1.

```bash
www-data@5657578d7e53:~/projects/simplesamlphp/simplesamlphp-2.1$ php bin/initMDSPdo.php
PHP Fatal error:  Uncaught Error: Non-static method SimpleSAML\Utils\Config::getConfigDir() cannot be called statically in /var/www/projects/simplesamlphp/simplesamlphp-2.1/bin/initMDSPdo.php:11
Stack trace:
#0 {main}
  thrown in /var/www/projects/simplesamlphp/simplesamlphp-2.1/bin/initMDSPdo.php on line 11

Fatal error: Uncaught Error: Non-static method SimpleSAML\Utils\Config::getConfigDir() cannot be called statically in /var/www/projects/simplesamlphp/simplesamlphp-2.1/bin/initMDSPdo.php on line 11

Error: Non-static method SimpleSAML\Utils\Config::getConfigDir() cannot be called statically in /var/www/projects/simplesamlphp/simplesamlphp-2.1/bin/initMDSPdo.php on line 11

Call Stack:
    0.0018     394872   1. {main}() /var/www/projects/simplesamlphp/simplesamlphp-2.1/bin/initMDSPdo.php:0

```