### PR TITLE
Clarify enabled by default modules

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -554,10 +554,7 @@ $config = [
      */
 
     'module.enable' => [
-        'exampleauth' => false,
-        'core' => true,
         'admin' => true,
-        'saml' => true
     ],
 
 


### PR DESCRIPTION
Only 'admin' is enabled additionally, 'core' and 'saml' are enabled by default in \SimpleSAML\Module::isModuleEnabled().