### PR TITLE
Validators needs to be always accessable

### DIFF
--- a/src/SimpleSAML/Metadata/SAMLParser.php
+++ b/src/SimpleSAML/Metadata/SAMLParser.php
@@ -168,7 +168,8 @@ class SAMLParser
 
         $expireTime = self::getExpireTime($entityElement, $maxExpireTime);
 
-        $validators[] = $entityElement;
+        $this->validators = $validators;
+        $this->validators[] = $entityElement;
 
         // process Extensions element, if it exists
         $ext = self::processExtensions($entityElement, $parentExtensions);


### PR DESCRIPTION
Without this fix the validators are empty in `validateSignature` https://github.com/simplesamlphp/simplesamlphp/blob/2218fa6cfb0014115b34dcb549d46de51fae9800/src/SimpleSAML/Metadata/SAMLParser.php#L1198C20-L1208

causing non validated metadata:
```
Nov 23 10:00:03 simplesamlphp INFO [ab70360658] SAML2.0 - IdP.SSOService: Accessing SAML 2.0 IdP endpoint SSOService
Nov 23 10:00:03 simplesamlphp INFO [ab70360658] SimpleSAML\Metadata\Sources\MDQ: loading metadata entity [https://release-check.qa.swamid.se/shibboleth] from [saml20-sp-remote]
Nov 23 10:00:03 simplesamlphp DEBUG [ab70360658] SimpleSAML\Metadata\Sources\MDQ: reading cache [https://release-check.qa.swamid.se/shibboleth] => [/var/simplesamlphp/mdq-cache/saml20-sp-remote-04c8191b7003f207d19337305d481389b24839c0.cached.xml]
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] SimpleSAML\Metadata\Sources\MDQ: Cached metadata from "/var/simplesamlphp/mdq-cache/saml20-sp-remote-04c8191b7003f207d19337305d481389b24839c0.cached.xml" wasn't an array.
Nov 23 10:00:03 simplesamlphp DEBUG [ab70360658] SimpleSAML\Metadata\Sources\MDQ: downloading metadata for "https://release-check.qa.swamid.se/shibboleth" from [https://mds.swamid.se/qa/entities/https%3A%2F%2Frelease-check.qa.swamid.se%2Fshibboleth]
Nov 23 10:00:03 simplesamlphp DEBUG [ab70360658] SimpleSAML\Metadata\Sources\MDQ: completed parsing of [https://mds.swamid.se/qa/entities/https%3A%2F%2Frelease-check.qa.swamid.se%2Fshibboleth]
Nov 23 10:00:03 simplesamlphp DEBUG [ab70360658] Could not validate signature
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] Backtrace:
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 1 /var/simplesamlphp/src/SimpleSAML/Error/ExceptionHandler.php:32 (SimpleSAML\Error\ExceptionHandler::customExceptionHandler)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 0 [builtin] (N/A)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] Caused by: Exception: SimpleSAML\Metadata\Sources\MDQ: error, could not verify signature for entity: https://release-check.qa.swamid.se/shibboleth".
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] Backtrace:
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 7 /var/simplesamlphp/src/SimpleSAML/Metadata/Sources/MDQ.php:340 (SimpleSAML\Metadata\Sources\MDQ::getMetaData)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 6 /var/simplesamlphp/src/SimpleSAML/Metadata/MetaDataStorageHandler.php:314 (SimpleSAML\Metadata\MetaDataStorageHandler::getMetaData)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 5 /var/simplesamlphp/src/SimpleSAML/Metadata/MetaDataStorageHandler.php:350 (SimpleSAML\Metadata\MetaDataStorageHandler::getMetaDataConfig)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 4 /var/simplesamlphp/modules/saml/src/IdP/SAML2.php:407 (SimpleSAML\Module\saml\IdP\SAML2::receiveAuthnRequest)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 3 [builtin] (call_user_func_array)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 2 /var/simplesamlphp/src/SimpleSAML/HTTP/RunnableResponse.php:68 (SimpleSAML\HTTP\RunnableResponse::sendContent)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 1 /var/simplesamlphp/vendor/symfony/http-foundation/Response.php:373 (Symfony\Component\HttpFoundation\Response::send)
Nov 23 10:00:03 simplesamlphp ERROR [ab70360658] 0 /var/simplesamlphp/public/saml2/idp/SSOService.php:23 (N/A)
```