### PR TITLE
Harden module.php endpoint against no input

### DIFF
--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -162,7 +162,7 @@ class Module
             $request = Request::createFromGlobals();
         }
 
-        if ($request->server->get('PATH_INFO') === '/') {
+        if ($request->server->get('PATH_INFO') === '/' || $request->server->get('PATH_INFO') === null) {
             throw new Error\NotFound('No PATH_INFO to module.php');
         }
 


### PR DESCRIPTION
![afbeelding](https://github.com/simplesamlphp/simplesamlphp/assets/841045/457c8ad0-f67b-49ae-9c5d-bf97b4e78fd9)

Fixes TypeError. To reproduce visit `/module.php` _without_ any trailing characters, not even a trailing slash.