### PR TITLE
Bugfix for intl-extension

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,7 +50,7 @@ jobs:
           php-version: '8.2'
           tools: composer, composer-require-checker, composer-unused, phpcs, psalm
           # optional performance gain for psalm: opcache
-          extensions: ctype, date, dom, fileinfo, filter, hash, intl, json, mbstring, mysql, \
+          extensions: ctype, date, dom, fileinfo, filter, hash, json, mbstring, mysql, \
             opcache, openssl, pcre, pdo, pdo_sqlite, posix, soap, spl, xml
           coverage: none
 
@@ -80,7 +80,10 @@ jobs:
         run: composer-require-checker check --config-file tools/composer-require-checker.json composer.json
 
       - name: Check code for unused dependencies in composer.json
-        run: composer-unused --excludePackage=simplesamlphp/simplesamlphp-assets-base --excludePackage=ext-intl
+        run: |
+          composer-unused \
+          --excludePackage=simplesamlphp/simplesamlphp-assets-base \
+          --excludePackage=symfony/polyfill-intl-icu
 
       - name: PHP Code Sniffer
         run: phpcs
@@ -122,7 +125,7 @@ jobs:
         with:
           # Should be the lowest supported version
           php-version: '8.0'
-          extensions: ctype, date, dom, hash, fileinfo, filter, intl, json, mbstring, mysql, \
+          extensions: ctype, date, dom, hash, fileinfo, filter, json, mbstring, mysql, \
             openssl, pcre, pdo, pdo_sqlite, posix, soap, spl, xml
           tools: composer
           coverage: none
@@ -170,7 +173,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ctype, date, dom, fileinfo, filter, hash, intl, json, mbstring, mysql, openssl, pcre,\
+          extensions: ctype, date, dom, fileinfo, filter, hash, json, mbstring, mysql, openssl, pcre,\
             pdo, pdo_sqlite, posix, soap, spl, xdebug, xml
           tools: composer
           ini-values: error_reporting=E_ALL, pcov.directory=.
@@ -233,7 +236,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ctype, dom, date, fileinfo, filter, hash, intl, json, mbstring, mysql, openssl, pcre, \
+          extensions: ctype, dom, date, fileinfo, filter, hash, json, mbstring, mysql, openssl, pcre, \
             pdo, pdo_sqlite, posix, soap, spl, xdebug, xml
           tools: composer
           ini-values: error_reporting=E_ALL

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
         "ext-fileinfo": "*",
         "ext-filter": "*",
         "ext-hash": "*",
-        "ext-intl": "*",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
@@ -85,6 +84,7 @@
         "symfony/http-foundation": "^6.0",
         "symfony/http-kernel": "^6.0",
         "symfony/intl": "^6.0",
+        "symfony/polyfill-intl-icu": "^1.28",
         "symfony/psr-http-message-bridge": "^2.3",
         "symfony/routing": "^6.0",
         "symfony/translation-contracts": "^3.0",
@@ -107,6 +107,7 @@
     "suggest": {
         "predis/predis": "Needed if a Redis server is used to store session information",
         "ext-curl": "Needed in order to check for updates automatically",
+        "ext-intl": "Needed if translations for non-English languages are required.",
         "ext-memcached": "Needed if a Memcached server is used to store session information",
         "ext-pdo": "Needed if a database backend is used, either for authentication or to store session information",
         "ext-mysql": "Needed if a MySQL backend is used, either for authentication or to store session information",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bfd24d756adf90c6f98452f6fac3b29",
+    "content-hash": "f3d3ffb293bd5111fe908a9a8e04f77a",
     "packages": [
         {
             "name": "beste/clock",
@@ -2778,6 +2778,93 @@
                 }
             ],
             "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/e46b4da57951a16053cd751f63f4a24292788157",
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance and support of other locales than \"en\""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Icu\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's ICU-related data and classes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "icu",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-21T17:27:24+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -6065,7 +6152,6 @@
         "ext-fileinfo": "*",
         "ext-filter": "*",
         "ext-hash": "*",
-        "ext-intl": "*",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",

--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -16,9 +16,10 @@ repository](simplesamlphp-install-repo).
 * A web server capable of executing PHP scripts.
 * PHP version >= 8.0.0.
 * Support for the following PHP extensions:
-  * Always required: `date`, `dom`, `fileinfo`, `filter`, `hash`, `intl`, `json`, `libxml`, `mbstring`, `openssl`,
+  * Always required: `date`, `dom`, `fileinfo`, `filter`, `hash`, `json`, `libxml`, `mbstring`, `openssl`,
                      `pcre`, `session`, `simplexml`, `sodium`, `SPL` and `zlib`
   * When running on Linux: `posix`
+  * When wanting to use translations for non-English languages: `intl`
   * When automatically checking for latest versions, and used by some modules: `cURL`
   * When authenticating against an LDAP server: `ldap`
   * When authenticating against a RADIUS server: `radius`

--- a/modules/admin/src/Controller/Config.php
+++ b/modules/admin/src/Controller/Config.php
@@ -255,9 +255,9 @@ class Config
                 ]
             ],
             'intl_get_error_code' => [
-                'required' => 'required',
+                'required' => 'optional',
                 'descr' => [
-                    'required' => Translate::noop('PHP intl extension'),
+                    'optional' => Translate::noop('PHP intl extension'),
                 ]
             ],
             'json_decode' => [


### PR DESCRIPTION
We currently require `ext-intl`, however we cannot be sure that people using the tarball have installed it.

This PR installs a polyfill that will ensure English translations will always work, with or without `ext-intl`. The `ext-intl` extension has been downgraded to `optional`; only install for non-English deployments.

This ensures people deploying using the tarball will not run into nasty fatal errors like [this one](https://github.com/simplesamlphp/simplesamlphp/issues/1890#issuecomment-1807524926).

Closes #1890 