### PR TITLE
Fix atomically writing to a file

### DIFF
--- a/src/SimpleSAML/Utils/System.php
+++ b/src/SimpleSAML/Utils/System.php
@@ -187,7 +187,7 @@ class System
      */
     public function writeFile(string $filename, string $data, int $mode = 0600): void
     {
-        $tmpFile = $this->getTempDir() . DIRECTORY_SEPARATOR . rand();
+        $tmpFile = $filename . '.' . bin2hex(random_bytes(4));
 
         $res = @file_put_contents($tmpFile, $data);
         if ($res === false) {


### PR DESCRIPTION
For the trick to work, the file needs to be on the same filesystem. The tempdir is likely not on the same filesystem so the rename will not be instantaneous. This probably worked in the past when the tempdir was expected to be a subdir of the SimpleSAMLphp installation.

Fix it by writing a file to the same directory as the target file, which will always be on the same FS. Also do not just use a `rand()` number but something more random as we do in other places in the code.