### PR TITLE
A first attempt at storing generated po files in sorted order. 

### DIFF
--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -32,7 +32,7 @@ use function ksort;
 use function sprintf;
 
 
-function cloneIteratorToTranslations( $ret, $iterator )
+function cloneIteratorToTranslations($ret, $iterator)
 {
     while ($iterator->valid()) {
         $ret->addOrMerge(

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -31,6 +31,22 @@ use function in_array;
 use function ksort;
 use function sprintf;
 
+
+function cloneIteratorToTranslations( $ret, $iterator )
+{
+    while($iterator->valid()) {
+        $ret->addOrMerge(
+            $iterator->current(),
+            Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
+        );
+        
+        $iterator->next();
+    }
+
+    return $ret;
+}
+
+
 class UpdateTranslatableStringsCommand extends Command
 {
     /**
@@ -159,6 +175,15 @@ class UpdateTranslatableStringsCommand extends Command
                         Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
                     );
 
+                    //
+                    // Sort the translations in a predictable way
+                    //
+                    $iter = $merged->getIterator();
+                    $iter->ksort();
+                    $merged = cloneIteratorToTranslations(
+                        Translations::create( $merged->getDomain(), $merged->getLanguage() ),
+                        $iter );
+                    
                     $poGenerator->generateFile($merged, $poFile->getPathName());
                 }
             }

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -34,7 +34,7 @@ use function sprintf;
 
 function cloneIteratorToTranslations( $ret, $iterator )
 {
-    while($iterator->valid()) {
+    while ($iterator->valid()) {
         $ret->addOrMerge(
             $iterator->current(),
             Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
@@ -181,8 +181,9 @@ class UpdateTranslatableStringsCommand extends Command
                     $iter = $merged->getIterator();
                     $iter->ksort();
                     $merged = cloneIteratorToTranslations(
-                        Translations::create( $merged->getDomain(), $merged->getLanguage() ),
-                        $iter );
+                        Translations::create($merged->getDomain(), $merged->getLanguage()),
+                        $iter,
+                    );
                     
                     $poGenerator->generateFile($merged, $poFile->getPathName());
                 }

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -31,8 +31,6 @@ use function in_array;
 use function ksort;
 use function sprintf;
 
-
-
 class UpdateTranslatableStringsCommand extends Command
 {
     /**
@@ -70,25 +68,22 @@ class UpdateTranslatableStringsCommand extends Command
      * Clone the entries from $iterator into the passed Translations object.
      * It is expected that $iterator was made by getIterator() on Translations.
      * This can be useful as the entries are cloned in the iterator order.
-     * 
+     *
      * @param Gettext\Translations $ret
      * @param iterable $iterator
      * @return $ret
-    */
-    protected function cloneIteratorToTranslations( Translations $ret, iterable $iterator): Translations
+     */
+    protected function cloneIteratorToTranslations(Translations $ret,iterable $iterator): Translations
     {
         while ($iterator->valid()) {
             $ret->addOrMerge(
                 $iterator->current(),
                 Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
             );
-            
             $iterator->next();
         }
-        
         return $ret;
     }
-    
 
     /**
      * @param \Symfony\Component\Console\Input\InputInterface $input

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -31,7 +31,6 @@ use function in_array;
 use function ksort;
 use function sprintf;
 
-
 function cloneIteratorToTranslations($ret, $iterator)
 {
     while ($iterator->valid()) {
@@ -39,7 +38,7 @@ function cloneIteratorToTranslations($ret, $iterator)
             $iterator->current(),
             Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
         );
-        
+
         $iterator->next();
     }
 
@@ -184,7 +183,7 @@ class UpdateTranslatableStringsCommand extends Command
                         Translations::create($merged->getDomain(), $merged->getLanguage()),
                         $iter,
                     );
-                    
+
                     $poGenerator->generateFile($merged, $poFile->getPathName());
                 }
             }

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -73,7 +73,7 @@ class UpdateTranslatableStringsCommand extends Command
      * @param iterable $iterator
      * @return $ret
      */
-    protected function cloneIteratorToTranslations(Translations $ret,iterable $iterator): Translations
+    protected function cloneIteratorToTranslations(Translations $ret, iterable $iterator): Translations
     {
         while ($iterator->valid()) {
             $ret->addOrMerge(

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -31,19 +31,6 @@ use function in_array;
 use function ksort;
 use function sprintf;
 
-function cloneIteratorToTranslations($ret, $iterator)
-{
-    while ($iterator->valid()) {
-        $ret->addOrMerge(
-            $iterator->current(),
-            Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
-        );
-
-        $iterator->next();
-    }
-
-    return $ret;
-}
 
 
 class UpdateTranslatableStringsCommand extends Command
@@ -79,6 +66,29 @@ class UpdateTranslatableStringsCommand extends Command
         );
     }
 
+    /**
+     * Clone the entries from $iterator into the passed Translations object.
+     * It is expected that $iterator was made by getIterator() on Translations.
+     * This can be useful as the entries are cloned in the iterator order.
+     * 
+     * @param Gettext\Translations $ret
+     * @param iterable $iterator
+     * @return $ret
+    */
+    protected function cloneIteratorToTranslations( Translations $ret, iterable $iterator): Translations
+    {
+        while ($iterator->valid()) {
+            $ret->addOrMerge(
+                $iterator->current(),
+                Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
+            );
+            
+            $iterator->next();
+        }
+        
+        return $ret;
+    }
+    
 
     /**
      * @param \Symfony\Component\Console\Input\InputInterface $input
@@ -179,7 +189,7 @@ class UpdateTranslatableStringsCommand extends Command
                     //
                     $iter = $merged->getIterator();
                     $iter->ksort();
-                    $merged = cloneIteratorToTranslations(
+                    $merged = $this->cloneIteratorToTranslations(
                         Translations::create($merged->getDomain(), $merged->getLanguage()),
                         $iter,
                     );


### PR DESCRIPTION
This should hopefully minimize the number of changes that git sees when storing these files in a repo

Note that some of the header metadata is not cloned at the moment. If this ordering fixes the issue that was causing git chatter then the metadata clone can be added before merge.

Tested using
```
cd ./bin
./translations translations:update:translatable
vi ../locales/en/LC_MESSAGES/messages.po
```