### PR TITLE
composer: install the deps so that the translation script can run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,7 @@
         "translations:update:binary": "php bin/translations translations:update:binary",
         "translations:update:translatable": "php bin/translations translations:update:translatable",
         "post-install-cmd": [
+            "@composer update",
             "php bin/translations translations:update:binary"
         ],
         "post-update-cmd": [


### PR DESCRIPTION
The `php bin/translations translations:update:binary` command relies on the vendor directory which is not installed at the time the script is called when SSP is installed via composer.  Perhaps we should (or need to) add this to the `post-update-cmd` clause as well. 

I have found this update to work when a composer tree is made (where the script fails) and one then runs the following. 
```
composer run-script post-install-cmd
```

Hopefully with this update the below command will also generate the .mo files during composer installation.
```
composer require simplesamlphp/simplesamlphp
```

This relates to https://github.com/simplesamlphp/simplesamlphp/issues/1914 and is a solution I proposed in https://github.com/simplesamlphp/simplesamlphp/issues/1914#issuecomment-1951475336