### PR TITLE
i18n: fall back to loading the po file if the mo file is not available

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,8 +23,10 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v6
+        uses: super-linter/super-linter/slim@v6
         env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LOG_LEVEL: NOTICE
           VALIDATE_ALL_CODEBASE: true
           LINTER_RULES_PATH: 'tools/linters'

--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -13,6 +13,7 @@ namespace SimpleSAML\Locale;
 use Exception;
 use Gettext\Generator\ArrayGenerator;
 use Gettext\Loader\MoLoader;
+use Gettext\Loader\PoLoader;
 use Gettext\{Translations, Translator, TranslatorFunctions};
 use SimpleSAML\{Configuration, Logger};
 use Symfony\Component\HttpFoundation\File\File;
@@ -240,12 +241,21 @@ class Localization
                 $arrayGenerator->generateArray($translations)
             );
         } else {
-            Logger::debug(sprintf(
-                "%s - Localization file '%s' not found or not readable in '%s', falling back to default",
-                $_SERVER['PHP_SELF'],
-                $file->getfileName(),
-                $langPath,
-            ));
+            $file = new File($langPath . $domain . '.po', false);
+            if ($file->getRealPath() !== false && $file->isReadable()) {
+                $translations = (new PoLoader())->loadFile($file->getRealPath());
+                $arrayGenerator = new ArrayGenerator();
+                $this->translator->addTranslations(
+                    $arrayGenerator->generateArray($translations)
+                );
+            } else {
+                Logger::debug(sprintf(
+                    "%s - Localization file '%s' not found or not readable in '%s', falling back to default",
+                    $_SERVER['PHP_SELF'],
+                    $file->getfileName(),
+                    $langPath,
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
If there is no `.mo` file available then fall back to loading the `.po` file instead. This should allow installations to still function even if installed with modules that have uncompiled translations and when SSP is installed as a dependency via composer.

Perhaps we should rename `loadGettextGettextFromPO` to `loadGettextForDomain` or something. The caller is not so likely to care if they come from mo or po files or whatnot, that is an implementation detail. 