### PR TITLE
Fix static call for non-static method in bin/importPdoMetadata.php

### DIFF
--- a/bin/importPdoMetadata.php
+++ b/bin/importPdoMetadata.php
@@ -4,9 +4,7 @@
 declare(strict_types=1);
 
 $baseDir = dirname(__FILE__, 2);
-
 require_once $baseDir . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . '_autoload.php';
-//require_once \SimpleSAML\Utils\Config::getConfigDir() . DIRECTORY_SEPARATOR . 'config.php';
 
 // This is the config dir of the SimpleSAMLphp installation
 $configDir = (new \SimpleSAML\Utils\Config())->getConfigDir();


### PR DESCRIPTION
This commit refactors the PHP script. The changes include:

- Using the 'configDir' variable consistently for the configuration directory.
