### PR TITLE
docs: update the upgrade notes for 2.0 with some information from slack about entityIDs

### DIFF
--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -153,10 +153,8 @@ are using for your SP and IdP should be available in
 module.php/core/frontpage_federation.php location on your
 SimpleSAMLphp server.
 
-An EntityID is a unique identifier for your SP or IdP. It has to be
-unique, like an IP-address has to be unique in your network. You might
-like to use your host name and some additional path information for
-the EntityID.
+For a service provider, if it was set as auto-generated in 1.19, it
+will likely have the form of (<https://yourhostname/simplesaml/module.php/saml/sp/metadata.php/default-sp>).
 
 The EntityID is set in two locations, as the property 'entityID' for
 an SP and as the index in the $metadata array for an IdP. Examples of
@@ -192,6 +190,5 @@ $metadata['https://example.com/the-service/'] = [
 ...
 ```
 
-If you are using Azure and if you are configuring a hosted sp in ssp,
-the entityID will be a relying party you added in azure. It will have
-an entityid in azure like <https://your.ssp.hostname/default-sp>.
+If you use SimpleSAMLphp as an SP, the IdP you are using will have
+your correct entityID configured.

--- a/docs/simplesamlphp-upgrade-notes-2.0.md
+++ b/docs/simplesamlphp-upgrade-notes-2.0.md
@@ -21,6 +21,12 @@ composer require simplesamlphp/simplesamlphp-module-ldap --update-no-dev
 
 ## Functional changes
 
+- EntityIDs are no longer auto-generated. Make sure to set something sensible in the array-keys in
+  `metadata/saml20-idp-hosted.php` and for any saml:SP in `config/authsources.php` (or to the existing entityIDs when
+  upgrading an existing installation).
+  If you are using a database to store metadata, make sure to replace any `__DYNAMIC:<n>__` entityID's with
+  a real value manually. Dynamic records are no longer loaded from the database. See the "Upgrading and EntityIDs"
+  section at the end of the document for more information.
 - Modules must be enabled through the `module.enable` option in `config.php`. Modules can no longer be enabled by having
   a file named `enable` or `default-enable` in the module's root directory.
 - The base URL of the SimpleSAMLphp installation no longer provides an admin menu. Instead this is now at the location
@@ -38,11 +44,6 @@ composer require simplesamlphp/simplesamlphp-module-ldap --update-no-dev
 - All support for the Shibboleth 1.3 / SAML 1.1 protocol has been removed.
 - Sessions are no longer backwards compatible with previous versions. Make sure to clear your session cache during
   the upgrade process. How to do this depends on your session backend.
-- EntityIDs are no longer auto-generated. Make sure to set something sensible in the array-keys in
-  `metadata/saml20-idp-hosted.php` and for any saml:SP in `config/authsources.php` (or to the existing entityIDs when
-  upgrading an existing installation).
-  If you are using a database to store metadata, make sure to replace any `__DYNAMIC:<n>__` entityID's with
-  a real value manually. Dynamic records are no longer loaded from the database.
 
 ## Configuration changes
 
@@ -144,3 +145,53 @@ $x = \SimpleSAML\Utils\Arrays::arrayize($someVar)
 
 [1]: https://github.com/simplesamlphp/simplesamlphp/wiki/Migrating-translations-(pre-migration)
 [2]: https://github.com/simplesamlphp/simplesamlphp/wiki/Twig:-Migrating-templates
+
+## Upgrading and EntityIDs
+
+If you still have your 1.x installation available, the entityID you
+are using for your SP and IdP should be available in
+module.php/core/frontpage_federation.php location on your
+SimpleSAMLphp server.
+
+An EntityID is a unique identifier for your SP or IdP. It has to be
+unique, like an IP-address has to be unique in your network. You might
+like to use your host name and some additional path information for
+the EntityID.
+
+The EntityID is set in two locations, as the property 'entityID' for
+an SP and as the index in the $metadata array for an IdP. Examples of
+both are shown below.
+
+For the SP you can set the EntityID as shown in the below fragment of
+authsources.php. In all of the below configuration fragments the
+EntityID is set to (<https://example.com/the-service/>).
+
+```php
+...
+    'default-sp' => [
+        'saml:SP',
+        // The entity ID of this SP.
+        'entityID' => 'https://example.com/the-service/',
+...
+```
+
+One suggestion for forming an EntityID is to use the below scheme.
+
+```php
+$entityid_sp = 'https://'
+   . $_SERVER['HTTP_HOST']
+   . '/simplesaml/module.php/saml/sp/metadata.php/default-sp';
+```
+
+For an IdP you might like to look at saml20-idp-hosted.php where the
+EntityID is used as the key in the metadata array.
+
+```php
+...
+$metadata['https://example.com/the-service/'] = [
+...
+```
+
+If you are using Azure and if you are configuring a hosted sp in ssp,
+the entityID will be a relying party you added in azure. It will have
+an entityid in azure like <https://your.ssp.hostname/default-sp>.


### PR DESCRIPTION
I also moved the entityID point to the top as it seems to be the most common question about upgrading from 1.x to 2.x.

Most of the other information added at the end of document was obtained from slack so might not be 100% the opinion of core developers. Some extra eyes are appreciated, if we can get this info extended and updated in one place that should help everybody.

It also might be useful to mention / link to the 2.0 upgrade notes in the 2.1 upgrade notes. Something like the following: If you are upgrading from a 1.x series release please see the 2.0 upgrade notes (linked) to ensure a smooth transition. 