### PR TITLE
Allow authprocs to be used with exampleauth UserPass

### DIFF
--- a/modules/exampleauth/src/Auth/Source/UserPass.php
+++ b/modules/exampleauth/src/Auth/Source/UserPass.php
@@ -48,6 +48,8 @@ class UserPass extends UserPassBase
                 throw new Exception(
                     'Invalid <username>:<password> for authentication source ' . $this->authId . ': ' . $userpass
                 );
+            } elseif ($userpass === 'authproc') {
+                continue;
             }
 
             $userpass = explode(':', $userpass, 2);


### PR DESCRIPTION
Combining exampleauth with authprocs is a good way to test an authproc whilst developing, and for users to be able to experiment with a chain of authprocs in a test environment before applying to a production environment.

Currently, if you try to use authprocs with exampleauth you'll get a stacktrace:

```
SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
Backtrace:
2 src/SimpleSAML/Error/ExceptionHandler.php:32 (SimpleSAML\Error\ExceptionHandler::customExceptionHandler)
1 vendor/symfony/error-handler/ErrorHandler.php:531 (Symfony\Component\ErrorHandler\ErrorHandler::handleException)
0 [builtin] (N/A)
Caused by: Exception: Invalid <username>:<password> for authentication source example-userpass: authproc
Backtrace:
10 modules/exampleauth/src/Auth/Source/UserPass.php:57 (SimpleSAML\Module\exampleauth\Auth\Source\UserPass::__construct)
9 src/SimpleSAML/Auth/Source.php:314 (SimpleSAML\Auth\Source::parseAuthSource)
8 src/SimpleSAML/Auth/Source.php:356 (SimpleSAML\Auth\Source::getById)
7 src/SimpleSAML/IdP.php:108 (SimpleSAML\IdP::__construct)
6 src/SimpleSAML/IdP.php:140 (SimpleSAML\IdP::getById)
5 modules/saml/src/Controller/WebBrowserSingleSignOn.php:128 (SimpleSAML\Module\saml\Controller\WebBrowserSingleSignOn::singleSignOnService)
4 vendor/symfony/http-kernel/HttpKernel.php:181 (Symfony\Component\HttpKernel\HttpKernel::handleRaw)
3 vendor/symfony/http-kernel/HttpKernel.php:76 (Symfony\Component\HttpKernel\HttpKernel::handle)
2 vendor/symfony/http-kernel/Kernel.php:197 (Symfony\Component\HttpKernel\Kernel::handle)
1 src/SimpleSAML/Module.php:234 (SimpleSAML\Module::process)
0 public/module.php:17 (N/A)
```

This PR corrects this oversight. I've created it against the SimpleSAMLphp 2.2 branch, as Issue #1986 is preventing testing on master. However, it should work so I suggest forward porting to master as well.