### PR TITLE
Allow IdP authprocs to be configured in authsources.php

### DIFF
--- a/docs/simplesamlphp-authproc.md
+++ b/docs/simplesamlphp-authproc.md
@@ -23,6 +23,7 @@ Examples of neat things to do using Authentication Processing Filters:
 * On the SP: Specific for only one remote IdP in `saml20-idp-remote`
 * On the IdP: Specific for only one hosted IdP in `saml20-idp-hosted`
 * On the IdP: Specific for only one remote SP in `saml20-sp-remote`
+* On the IDP: Specific for only one IdP authentication source in `authsources.php`
 
 *Note*: An Auth Proc Filter will not work in the "Test authentication sources" option in the web UI of a SimpleSAMLphp IdP. It will only be triggered in conjunction with an actual SP. So you need to set up an IdP *and* and SP when testing your filter.
 

--- a/modules/exampleauth/src/Auth/Source/UserPass.php
+++ b/modules/exampleauth/src/Auth/Source/UserPass.php
@@ -48,6 +48,8 @@ class UserPass extends UserPassBase
                 throw new Exception(
                     'Invalid <username>:<password> for authentication source ' . $this->authId . ': ' . $userpass
                 );
+            } elseif ($userpass === 'authproc') {
+                continue;
             }
 
             $userpass = explode(':', $userpass, 2);

--- a/src/SimpleSAML/Auth/ProcessingChain.php
+++ b/src/SimpleSAML/Auth/ProcessingChain.php
@@ -69,7 +69,7 @@ class ProcessingChain
      * @param array $spMetadata  The metadata for the SP.
      * @param string $mode
      */
-    public function __construct(array $idpMetadata, array $spMetadata, string $mode = 'idp')
+    public function __construct(array $idpMetadata, array $spMetadata, string $mode = 'idp', array $extraAuthprocs = null)
     {
         $config = Configuration::getInstance();
         $configauthproc = $config->getOptionalArray('authproc.' . $mode, null);
@@ -87,6 +87,11 @@ class ProcessingChain
         if (array_key_exists('authproc', $spMetadata)) {
             $spFilters = self::parseFilterList($spMetadata['authproc']);
             self::addFilters($this->filters, $spFilters);
+        }
+
+        if (($extraAuthprocs !== null) && array_key_exists('authproc', $extraAuthprocs)) {
+            $extraFilters = self::parseFilterList($extraAuthprocs['authproc']);
+            self::addFilters($this->filters, $extraFilters);
         }
 
         Logger::debug('Filter config for ' . $idpMetadata['entityid'] . '->' .

--- a/src/SimpleSAML/IdP.php
+++ b/src/SimpleSAML/IdP.php
@@ -317,7 +317,11 @@ class IdP
 
         $idpMetadata = $idp->getConfig()->toArray();
 
-        $pc = new Auth\ProcessingChain($idpMetadata, $spMetadata, 'idp');
+        // Add in authprocs defined in authsources.php
+        $asArray = Configuration::getConfig('authsources.php')->getArray($idp->authSource->getAuthSource()->getAuthId());
+        $asAuthproc = array_key_exists('authproc', $asArray) ? ['authproc' => $asArray['authproc']] : null;
+
+        $pc = new Auth\ProcessingChain($idpMetadata, $spMetadata, 'idp', $asAuthproc);
 
         $state['ReturnCall'] = ['\SimpleSAML\IdP', 'postAuthProc'];
         $state['Destination'] = $spMetadata;


### PR DESCRIPTION
Currently, for SPs you can configure authprocs in metadata, `config.php` or `authsources.php`. However, for an IdP you can only configure in metadata or `config.php`. This PR addresses this, such that regardless of whether you're configuring an IdP or an SP, you can configure in all three places.

The main driver for the desire for `authsources.php` to be supported as an IdP authproc configuration source is when using `multiauth` with multiple different authentication sources. When using multiauth, it would be really handy to be able to apply different authprocs based on which authentication mechanism was delegated to (as defined in `authsources.php`).

- You can't do this in `saml20-sp-remote`, as SP's are likely used by multiple underlying authentication mechanisms, which likely return quite different raw attributes (hence the need for authprocs to make it more transparent to the SP which underlying authenication mechanism was used).
- The only other option currently would be the global `config.php`. Yes, you could do this with pre-conditional filters, but it is nothing like as clean, configuration wise (and more prone to error) as just adding support for `authsources.php` authprocs for IdP.