### PR TITLE
Configure exampleauth:UserPass credentials in "users" key, not top level config

### DIFF
--- a/config/authsources.php.dist
+++ b/config/authsources.php.dist
@@ -97,13 +97,15 @@ $config = [
         //'remember.username.enabled' => false,
         //'remember.username.checked' => false,
 
-        'student:studentpass' => [
-            'uid' => ['test'],
-            'eduPersonAffiliation' => ['member', 'student'],
-        ],
-        'employee:employeepass' => [
-            'uid' => ['employee'],
-            'eduPersonAffiliation' => ['member', 'employee'],
+        'users' => [
+            'student:studentpass' => [
+                'uid' => ['test'],
+                'eduPersonAffiliation' => ['member', 'student'],
+            ],
+            'employee:employeepass' => [
+                'uid' => ['employee'],
+                'eduPersonAffiliation' => ['member', 'employee'],
+            ],
         ],
     ],
     */

--- a/docs/simplesamlphp-idp.md
+++ b/docs/simplesamlphp-idp.md
@@ -83,13 +83,15 @@ In this setup, this file should contain a single entry:
 $config = [
     'example-userpass' => [
         'exampleauth:UserPass',
-        'student:studentpass' => [
-            'uid' => ['student'],
-            'eduPersonAffiliation' => ['member', 'student'],
-        ],
-        'employee:employeepass' => [
-            'uid' => ['employee'],
-            'eduPersonAffiliation' => ['member', 'employee'],
+        'users' => [
+            'student:studentpass' => [
+                'uid' => ['student'],
+                'eduPersonAffiliation' => ['member', 'student'],
+            ],
+            'employee:employeepass' => [
+                'uid' => ['employee'],
+                'eduPersonAffiliation' => ['member', 'employee'],
+            ],
         ],
     ],
 ];

--- a/modules/exampleauth/src/Auth/Source/UserPass.php
+++ b/modules/exampleauth/src/Auth/Source/UserPass.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Module\exampleauth\Auth\Source;
 
 use Exception;
 use SimpleSAML\Error;
+use SimpleSAML\Logger;
 use SimpleSAML\Module\core\Auth\UserPassBase;
 use SimpleSAML\Utils;
 
@@ -42,8 +43,19 @@ class UserPass extends UserPassBase
 
         $this->users = [];
 
+        // Old version of SimpleSAMLphp had the username:password just be a list in the top level
+        // configuration. We now have them under the "users" key, so that exampleauth can be used
+        // for testing things like core:loginpage_links, etc. that require top level configuration.
+        if (array_key_exists('users', $config)) {
+            $config_users = $config['users'];
+        } else {
+            Logger::warning("Module exampleauth:UserPass configured in legacy mode. Please put your " .
+                "username:password entries under the \"users\" key in your authsource.");
+            $config_users = $config;
+        }
+
         // Validate and parse our configuration
-        foreach ($config as $userpass => $attributes) {
+        foreach ($config_users as $userpass => $attributes) {
             if (!is_string($userpass)) {
                 throw new Exception(
                     'Invalid <username>:<password> for authentication source ' . $this->authId . ': ' . $userpass


### PR DESCRIPTION
I've been using `exampleauth:UserPass` to test functionality without the need to setup more complex authsources. Over the past week or so I've been tripped up a few times by an inconsistency in `exampleauth:UserPass`, where it doesn't allow any additional configuration in `authsources.php` due to assuming all top level keys are `username:password` pairs.

This PR moves those `username:password` strings under the `users` key, such that other configuration can be added / tested. My latest example of the need for this is trying to add `core:loginpage_links` configuration to `exampleauth:UserPass` configuration in `authsources.php`. With this PR, `core:loginpage_links` links are rendered on the login page for `exampleauth:UserPass`, if configured. Prior to this PR, you get an error when trying to use `core:loginpage_links` with `exampleauth:UserPass`:

```
SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
Backtrace:
2 src/SimpleSAML/Error/ExceptionHandler.php:32 (SimpleSAML\Error\ExceptionHandler::customExceptionHandler)
1 vendor/symfony/error-handler/ErrorHandler.php:531 (Symfony\Component\ErrorHandler\ErrorHandler::handleException)
0 [builtin] (N/A)
Caused by: Exception: Invalid attributes for user core in authentication source example-userpass: Invalid attribute name: "0".
Backtrace:
10 modules/exampleauth/src/Auth/Source/UserPass.php:79 (SimpleSAML\Module\exampleauth\Auth\Source\UserPass::__construct)
9 src/SimpleSAML/Auth/Source.php:314 (SimpleSAML\Auth\Source::parseAuthSource)
8 src/SimpleSAML/Auth/Source.php:356 (SimpleSAML\Auth\Source::getById)
7 src/SimpleSAML/IdP.php:108 (SimpleSAML\IdP::__construct)
6 src/SimpleSAML/IdP.php:140 (SimpleSAML\IdP::getById)
5 modules/saml/src/Controller/WebBrowserSingleSignOn.php:128 (SimpleSAML\Module\saml\Controller\WebBrowserSingleSignOn::singleSignOnService)
4 vendor/symfony/http-kernel/HttpKernel.php:181 (Symfony\Component\HttpKernel\HttpKernel::handleRaw)
3 vendor/symfony/http-kernel/HttpKernel.php:76 (Symfony\Component\HttpKernel\HttpKernel::handle)
2 vendor/symfony/http-kernel/Kernel.php:197 (Symfony\Component\HttpKernel\Kernel::handle)
1 src/SimpleSAML/Module.php:234 (SimpleSAML\Module::process)
0 public/module.php:17 (N/A)
```

where it wrongly matches `core:loginpage_links` as a `username:password` pair, and errors that the following configuration is wrong.

This has been implemented to be backwards compatible - if the `users` key doesn't exist in the configuration, it will default back to the old syntax (all entries are assumed to be `username:password` pairs), but put an ugly warning in the logs, asking the user to update their configuration to put `username:password` pairs in the `users` key.

All documentation in the repository referencing the module has also had their examples updated to include the new `users` key.