### PR TITLE
Fix URL in error page redirection in ExpectedAuthContextClassRef auth…

### DIFF
--- a/modules/saml/src/Auth/Process/ExpectedAuthnContextClassRef.php
+++ b/modules/saml/src/Auth/Process/ExpectedAuthnContextClassRef.php
@@ -103,7 +103,7 @@ class ExpectedAuthnContextClassRef extends Auth\ProcessingFilter
 
         $id = Auth\State::saveState($state, 'saml:ExpectedAuthnContextClassRef:unauthorized');
         $url = Module::getModuleURL(
-            'saml/sp/wrong_authncontextclassref.php'
+            'saml/sp/wrongAuthnContextClassRef'
         );
 
         $httpUtils = new Utils\HTTP();


### PR DESCRIPTION
…proc

ExpectedAuthContextClassRef authproc seems to redirect to an invalid error page. I think this is a bug.

Could not find an issue of PR addressing this.

I hope this fix is correct.
