### PR TITLE
i18n: when loading from po file the domain from the file has to be wiped

### DIFF
--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -244,6 +244,7 @@ class Localization
             $file = new File($langPath . $domain . '.po', false);
             if ($file->getRealPath() !== false && $file->isReadable()) {
                 $translations = (new PoLoader())->loadFile($file->getRealPath());
+                $translations->setDomain('');
                 $arrayGenerator = new ArrayGenerator();
                 $this->translator->addTranslations(
                     $arrayGenerator->generateArray($translations)


### PR DESCRIPTION
Loading from po files is slightly different than the existing path for mo files. The domain from the po file has to be removed in order for the loaded translation to be found by SSP.

This relates to https://github.com/simplesamlphp/simplesamlphp/issues/2009.