### PR TITLE
update of pull/1984 against 2.3 (A new MetaDataStorageHandlerDirectory class to load metadata from subdirectories)

### DIFF
--- a/docs/simplesamlphp-maintenance.md
+++ b/docs/simplesamlphp-maintenance.md
@@ -198,7 +198,7 @@ Configure your master group by setting `store.redis.mastergroup` (`mymaster` by 
 
 ## Metadata storage
 
-Several metadata storage backends are available by default, including `flatfile`, `serialize`, `mdq` and
+Several metadata storage backends are available by default, including `flatfile`, `directory`, `serialize`, `mdq` and
 [`pdo`](https://simplesamlphp.org/docs/stable/simplesamlphp-metadata-pdostoragehandler). Here you have an
 example configuration of different metadata sources in use at the same time:
 
@@ -207,8 +207,17 @@ example configuration of different metadata sources in use at the same time:
     ['type' => 'flatfile'],
     ['type' => 'flatfile', 'directory' => 'metadata/metarefresh-kalmar'],
     ['type' => 'serialize', 'directory' => 'metadata/metarefresh-ukaccess'],
+    ['type' => 'directory'],
+    ['type' => 'directory', 'directory' => 'metadata/somewhere-else'],
 ],
 ```
+
+The directory type storage backend will look in subdirectories such as
+saml20-idp-hosted.d and saml20-sp-remote.d in the given directory (or
+the 'metadatadir' configuration option in 'config.php' by default).
+All xml and php files found in those subdirectories will be loaded. It is
+currently an error to have subdirectories inside the
+saml20-sp-remote.d directories.
 
 You may also implement your own metadata storage handler, in a very similar way to how you would implement
 your own session handler. Your class **must** extend the `\SimpleSAML\Metadata\MetaDataStorageSource` class

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerDirectory.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerDirectory.php
@@ -7,19 +7,21 @@ namespace SimpleSAML\Metadata;
 use Exception;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Configuration;
+use SimpleSAML\Logger;
 
 use function array_key_exists;
 use function is_array;
 
 /**
- * This file defines a flat file metadata source.
+ * A directory that contains metadata files.
  * Instantiation of session handler objects should be done through
  * the class method getMetadataHandler().
  *
  * @package SimpleSAMLphp
+ * This was created based on the MetaDataStorageHandlerFlatFile.php source in February 2024.
  */
 
-class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
+class MetaDataStorageHandlerDirectory extends MetaDataStorageSource
 {
     /**
      * This is the directory we will load metadata files from. The path will always end
@@ -29,13 +31,6 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
      */
     private string $directory = '/';
 
-
-    /**
-     * Optional explicit file path to load metadata from
-     *
-     * @var string
-     */
-    private ?string $file = null;
 
     /**
      * This is an associative array which stores the different metadata sets we have loaded.
@@ -51,7 +46,6 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
      * possible elements:
      * - 'directory': The directory we should load metadata from. The default directory is
      *                set in the 'metadatadir' configuration option in 'config.php'.
-     * - 'file': full path to load metadata from. This is used by the MetaDataStorageHandlerDirectory class.
      *
      * @param array $config An associative array with the configuration for this handler.
      */
@@ -69,10 +63,6 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
             $this->directory = $globalConfig->getOptionalString('metadatadir', 'metadata/');
         }
 
-        if (array_key_exists('file', $config)) {
-            $this->file = $globalConfig->resolvePath($config['file']);
-        }
-
         /* Resolve this directory relative to the SimpleSAMLphp directory (unless it is
          * an absolute path).
          */
@@ -84,7 +74,7 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
 
 
     /**
-     * This function loads the given set of metadata from a file our metadata directory.
+     * This function loads the given set of metadata files in the metadata directory.
      * This function returns null if it is unable to locate the given set in the metadata directory.
      *
      * @param string $set The set of metadata we are loading.
@@ -95,24 +85,58 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
      */
     private function load(string $set): ?array
     {
-        $metadatasetfile = $this->directory . $set . '.php';
-        if ($this->file) {
-            $metadatasetfile = $this->file;
-        }
+        $metadatasetdir = $this->directory . $set . '.d';
 
-        if (!$this->fileSystem->exists($metadatasetfile)) {
+        if (!$this->fileSystem->exists($metadatasetdir)) {
             return null;
         }
 
         /** @psalm-var mixed $metadata   We cannot be sure what the include below will do with this var */
         $metadata = [];
 
-        include($metadatasetfile);
+        $dh = @opendir($metadatasetdir);
+        if ($dh === false) {
+            Logger::warning(
+                'Directory metadata handler: Unable to open directory: ' . var_export($metadatasetdir, true)
+            );
+            return $metadata;
+        }
+
+        while (($entry = readdir($dh)) !== false) {
+            if ($entry[0] === '.') {
+                // skip '..', '.' and hidden files
+                continue;
+            }
+
+            $path = $metadatasetdir . DIRECTORY_SEPARATOR . $entry;
+            if (is_dir($path)) {
+                Logger::warning(
+                    'Directory metadata handler: Metadata directory contained a directory where only files should ' .
+                    'exist: ' . var_export($path, true)
+                );
+                 continue;
+            }
+
+            if (str_ends_with($path, '.php') || str_ends_with($path, '.xml')) {
+                $type = 'flatfile';
+                if (str_ends_with($path, '.xml')) {
+                    $type = 'xml';
+                }
+                Logger::info("loading set $set metadata file at $path");
+
+                $config = [ 'type' => $type, 'file' => $path ];
+                $source = MetaDataStorageSource::getSource($config);
+                $md = $source->getMetadataSet($set);
+                $metadata = array_merge($metadata, $md);
+            }
+        }
+
+
+
 
         if (!is_array($metadata)) {
             throw new Exception('Could not load metadata set [' . $set . '] from file: ' . $metadatasetfile);
         }
-
         return $metadata;
     }
 

--- a/src/SimpleSAML/Metadata/MetaDataStorageSource.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageSource.php
@@ -95,6 +95,8 @@ abstract class MetaDataStorageSource
                 return new Sources\MDQ($sourceConfig);
             case 'pdo':
                 return new MetaDataStorageHandlerPdo($sourceConfig);
+            case 'directory':
+                return new MetaDataStorageHandlerDirectory($sourceConfig);
             default:
                 // metadata store from module
                 try {


### PR DESCRIPTION
A new MetaDataStorageHandlerDirectory class to load metadata from subdirectories

This is a retarget of the original PR https://github.com/simplesamlphp/simplesamlphp/pull/1984 from simplesamlphp-2.1 to simplesamlphp-2.3.

This is another attempt at loading metadata from a subdirectory containing either php or xml files (or both). This specifically allows SP files to be broken out into one file per SP if there are a number of SPs and you wish to maintain a list using one file per SP. 

It seems from the below links that the feature is desirable for a few users and having an implementation based on simplesamlphp-2.1 may allow a merge and closing of a long standing issue and long standing PR.

To be generic this also adds a `file` property to the config of the MetaDataStorageHandlerFlatFile class so it can be used to load the file instead of directly including it in the new MetaDataStorageHandlerDirectory class. This has the added advantage of a single code path to load those php files so other checks etc in the future can be all in one place.

I have tested with various php and xml files in /opt/sspdev/metadata/saml20-sp-remote.d and other metadata directories and inspected the results in the admin/federation page.

This relates to https://github.com/simplesamlphp/simplesamlphp/pull/1292 and https://github.com/simplesamlphp/simplesamlphp/issues/1368.