### PR TITLE
Fixes to the custom username/password auth docs

### DIFF
--- a/docs/simplesamlphp-customauth.md
+++ b/docs/simplesamlphp-customauth.md
@@ -21,7 +21,6 @@ cd modules
 mkdir mymodule
 ```
 
-Since this is a custom module, it should always be enabled in the configuration.
 Now that we have our own module, we can move on to creating an authentication source.
 
 Creating a basic authentication source
@@ -41,7 +40,7 @@ namespace SimpleSAML\Module\mymodule\Auth\Source;
 
 class MyAuth extends \SimpleSAML\Module\core\Auth\UserPassBase
 {
-    protected function login($username, $password)
+    protected function login(string $username, string $password): array
     {
         if ($username !== 'theusername' || $password !== 'thepassword') {
             throw new \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS);
@@ -76,7 +75,7 @@ Configuring our authentication source
 -------------------------------------
 
 Before we can test our authentication source, we must add an entry for it in `config/authsources.php`.
-`config/authsources.php` contains an list of enabled authentication sources.
+`config/authsources.php` contains a list of enabled authentication sources.
 
 The entry looks like this:
 
@@ -105,6 +104,18 @@ The instance name is used to refer to this authentication source in other config
 
 The first element of the configuration of the authentication source must be `'mymodule:MyAuth'`.
 This tells SimpleSAMLphp to look for the `\SimpleSAML\Module\mymodule\Auth\Source\MyAuth` class.
+
+We also need to enable our new module in `config/config.php`.
+`config/config.php` contains a list of enabled modules.
+
+We want to add our new module to the list of other enabled modules.  We can add it to the beginning of the list, so the enabled modules section looks something like this:
+
+```php
+'module.enable' => [
+    'mymodule' => true,
+    /* Other enabled modules follow. */
+],
+```
 
 Testing our authentication source
 ---------------------------------
@@ -203,7 +214,7 @@ class MyAuth extends \SimpleSAML\Module\core\Auth\UserPassBase
         $this->password = $config['password'];
     }
 
-    protected function login($username, $password)
+    protected function login(string $username, string $password): array
     {
         if ($username !== $this->username || $password !== $this->password) {
             throw new \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS);
@@ -332,7 +343,7 @@ class MyAuth extends \SimpleSAML\Module\core\Auth\UserPassBase
         return $digest === $checkDigest;
     }
 
-    protected function login($username, $password)
+    protected function login(string $username, string $password): array
     {
         /* Connect to the database. */
         $db = new PDO($this->dsn, $this->username, $this->password, $this->options);
@@ -380,7 +391,7 @@ class MyAuth extends \SimpleSAML\Module\core\Auth\UserPassBase
 }
 ```
 
-And configured in `config/authsources.php`:
+Configured in `config/authsources.php`:
 
 ```php
 'myauthinstance' => [
@@ -388,5 +399,14 @@ And configured in `config/authsources.php`:
     'dsn' => 'mysql:host=sql.example.org;dbname=userdatabase',
     'username' => 'db_username',
     'password' => 'secret_db_password',
+],
+```
+
+And enabled in `config/config.php`:
+
+```php
+'module.enable' => [
+    'mymodule' => true,
+    /* Other enabled modules follow. */
 ],
 ```


### PR DESCRIPTION
When getting started with SimpleSAMLphp and creating my first custom authentication module, following [the docs](https://simplesamlphp.org/docs/devel/simplesamlphp-customauth.html), I hit a couple of minor issues where the docs seem to be slightly outdated when running against version 2.2.1:

**Outdated method signature for login method:**
The existing docs suggest creating a method with signature `protected function login($username, $password)`.  Doing so will result in the following error when attempting to test or use the module:

```
SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
Backtrace:
3 src/SimpleSAML/Error/ExceptionHandler.php:35 (SimpleSAML\Error\ExceptionHandler::customExceptionHandler)
2 vendor/symfony/error-handler/ErrorHandler.php:535 (Symfony\Component\ErrorHandler\ErrorHandler::handleException)
1 vendor/symfony/error-handler/ErrorHandler.php:627 (Symfony\Component\ErrorHandler\ErrorHandler::handleFatalError)
0 [builtin] (N/A)
Caused by: Symfony\Component\ErrorHandler\Error\FatalError: Compile Error: Declaration of SimpleSAML\Module\mymodule\Auth\Source\MyAuth::login($username, $password) must be compatible with SimpleSAML\Module\core\Auth\UserPassBase::login(string $username, string $password): array
Backtrace:
0 modules/mymodule/src/Auth/Source/MyAuth.php:7 (N/A)
```

I have updated the docs to use the current method signature, `protected function login(string $username, string $password): array`, and confirmed this resolves the issue.

**Required steps to enable the module are missing:**
The existing docs suggest that there is no explicit action needed to enable the module, stating:

> Since this is a custom module, it should always be enabled in the configuration.

However, this no longer appears to be the case, possibly due to changes in version 2.0?  Without explicitly enabling the new module, the following error occurs when attempting to test or use the module:

```
SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
Backtrace:
2 src/SimpleSAML/Error/ExceptionHandler.php:32 (SimpleSAML\Error\ExceptionHandler::customExceptionHandler)
1 vendor/symfony/error-handler/ErrorHandler.php:535 (Symfony\Component\ErrorHandler\ErrorHandler::handleException)
0 [builtin] (N/A)
Caused by: Exception: The module 'mymodule' is not enabled.
Backtrace:
8 src/SimpleSAML/Module.php:449 (SimpleSAML\Module::resolveClass)
7 src/SimpleSAML/Auth/Source.php:313 (SimpleSAML\Auth\Source::parseAuthSource)
6 src/SimpleSAML/Auth/Source.php:356 (SimpleSAML\Auth\Source::getById)
5 src/SimpleSAML/Auth/Simple.php:62 (SimpleSAML\Auth\Simple::getAuthSource)
4 src/SimpleSAML/Auth/Simple.php:151 (SimpleSAML\Auth\Simple::login)
3 [builtin] (call_user_func_array)
2 src/SimpleSAML/HTTP/RunnableResponse.php:68 (SimpleSAML\HTTP\RunnableResponse::sendContent)
1 vendor/symfony/http-foundation/Response.php:423 (Symfony\Component\HttpFoundation\Response::send)
0 public/module.php:24 (N/A)
```

I have updated the docs to include the requirement to enable the new module after creating it.