### PR TITLE
Fix posting the form to the incorrect endpoint when using an authsour…

### DIFF
--- a/modules/core/src/Controller/Login.php
+++ b/modules/core/src/Controller/Login.php
@@ -239,7 +239,6 @@ class Login
         }
 
         $t = new Template($this->config, 'core:loginuserpass.twig');
-        $t->data['AuthState'] = $authStateId;
 
         if ($source instanceof UserPassOrgBase) {
             $t->data['username'] = $username;
@@ -269,6 +268,7 @@ class Login
         }
 
         if ($source instanceof UserPassOrgBase) {
+            $t->data['formURL'] = Module::getModuleURL('core/loginuserpassorg', ['AuthState' => $authStateId]);
             if ($request->request->has($source->getAuthId() . '-username')) {
                 $t->data['rememberUsernameChecked'] = true;
             }
@@ -285,6 +285,7 @@ class Login
                 $t->data['organizations'] = $organizations;
             }
         } else {
+            $t->data['formURL'] = Module::getModuleURL('core/loginuserpass', ['AuthState' => $authStateId]);
             $t->data['loginpage_links'] = $source->getLoginLinks();
         }
 

--- a/modules/core/templates/loginuserpass.twig
+++ b/modules/core/templates/loginuserpass.twig
@@ -37,8 +37,7 @@
 
     <p>{{ 'A service has requested you to authenticate yourself. Please enter your username and password in the form below.'|trans }}</p>
     <div class="center-form login-form-start">
-        <form id="f" class="pure-form pure-form-aligned" action="{{ moduleURL('core/loginuserpass', {'AuthState': AuthState}) }}"
-            method="post" name="f" spellcheck="false">
+        <form id="f" class="pure-form pure-form-aligned" action="{{ formURL }}" method="post" name="f" spellcheck="false">
                 <div class="pure-control-group">
                     <label for="username">{{ 'Username'|trans }}</label>
                     <input id="username" {{ forceUsername ? 'disabled' }} placeholder="{{ username }}" type="text" name="username" class="edge"


### PR DESCRIPTION
…ce based on UserPassOrgBase

This fixes issue reported on Slack causing warnings when trying to extend from UserPassOrgBase:

```
Apr 2 20:45:39 simplesamlphp WARNING [74f10887a4] Wrong stage in state. Was '\SimpleSAML\Module\core\Auth\UserPassOrgBase.state', should be '\SimpleSAML\Module\core\Auth\UserPassBase.state'.
```

We've also seen the same issue when using the [LdapMulti](https://github.com/simplesamlphp/simplesamlphp-module-ldap/issues/50)-authsource.

The issue was introduced in 1.19/2.0 during migration from .tpl.php to .twig.