### PR TITLE
respect the gettext domain for modules

### DIFF
--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -26,6 +26,7 @@ class Localization
      * @var string
      */
     public const DEFAULT_DOMAIN = 'messages';
+    public const CORE_DOMAIN = 'core';
 
     /**
      * The default locale directory
@@ -132,7 +133,11 @@ class Localization
         $this->addDomain($localeDir, $domain ?? $module);
     }
 
-
+    public function defaultDomain(string $domain): self
+    {
+        $this->translator->defaultDomain($domain);
+        return $this;
+    }
     /**
      * Add a new translation domain
      * (We're assuming that each domain only exists in one place)
@@ -244,7 +249,6 @@ class Localization
             $file = new File($langPath . $domain . '.po', false);
             if ($file->getRealPath() !== false && $file->isReadable()) {
                 $translations = (new PoLoader())->loadFile($file->getRealPath());
-                $translations->setDomain('');
                 $arrayGenerator = new ArrayGenerator();
                 $this->translator->addTranslations(
                     $arrayGenerator->generateArray($translations)
@@ -269,6 +273,9 @@ class Localization
         $this->setupTranslator();
         // setup default domain
         $this->addDomain($this->localeDir, self::DEFAULT_DOMAIN);
+        // There are not many "core" translations and we would like them to be
+        // loaded along with the messages.po and available to all.
+        $this->addModuleDomain(self::CORE_DOMAIN, null, self::CORE_DOMAIN);
     }
 
 

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -72,7 +72,12 @@ class Translate
         $original = $original ?? 'undefined variable';
 
         $text = TranslatorFunctions::getTranslator()->gettext($original);
-
+        if ($text === $original) {
+            $text = TranslatorFunctions::getTranslator()->dgettext("core", $original);
+            if ($text === $original) {
+                $text = TranslatorFunctions::getTranslator()->dgettext("messages", $original);
+            }
+        }
         if (func_num_args() === 1) {
             return $text;
         }

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -76,6 +76,10 @@ class Translate
             $text = TranslatorFunctions::getTranslator()->dgettext("core", $original);
             if ($text === $original) {
                 $text = TranslatorFunctions::getTranslator()->dgettext("messages", $original);
+                // try attributes.po
+                if ($text === $original) {
+                    $text = TranslatorFunctions::getTranslator()->dgettext("", $original);
+                }
             }
         }
         if (func_num_args() === 1) {

--- a/src/SimpleSAML/XHTML/Template.php
+++ b/src/SimpleSAML/XHTML/Template.php
@@ -301,9 +301,11 @@ class Template extends Response
         // load extra i18n domains
         if ($this->module) {
             $this->localization->addModuleDomain($this->module);
+            $this->localization->defaultDomain($this->module);
         }
         if ($this->theme['module'] !== null && $this->theme['module'] !== $this->module) {
             $this->localization->addModuleDomain($this->theme['module']);
+            $this->localization->defaultDomain($this->theme['module']);
         }
 
         // set up translation

--- a/tests/modules/core/src/Controller/ExceptionTest.php
+++ b/tests/modules/core/src/Controller/ExceptionTest.php
@@ -82,7 +82,7 @@ class ExceptionTest extends TestCase
         Logger::setCaptureLog(false);
 
         $log = Logger::getCapturedLog();
-        self::assertCount(5, $log);
+        self::assertCount(7, $log);
 
         self::assertStringContainsString(
             "A Service Provider reported the following error during authentication:  "


### PR DESCRIPTION
This is a cleaned up version of the rough code to solve https://github.com/simplesamlphp/simplesamlphp/issues/2013.

The core module has only a few translations (25 ish) and seems like it should be available to all modules for translation. The current fallback translation ordering is module, core, then messages. I have been tinkering with the code at https://github.com/monkeyiq/simplesamlphp/tree/2024/march/i18n-domains2 which includes some translations in each of admin, core, and messages and an explicit callout to these in the federaion admin twig page. That let me see the three files are reachable from that page.
