### PR TITLE
i18n notice new strings, check hooks, dig deeper in twig dirs

### DIFF
--- a/modules/saml/templates/proxy/invalid_session.twig
+++ b/modules/saml/templates/proxy/invalid_session.twig
@@ -3,7 +3,7 @@
 
 {% block content %}
     <h2>{{ 'Invalid Identity Provider'|trans }}</h2>
-    <p>{{ 'You already have a valid session with an identity provider (<em>%IDP%</em>) that is not accepted by <em>%SP%</em>. Would you like to log out from your existing session and log in again with another identity provider?'|trans({"%IDP%": entity_idp|entityDisplayName, "%SP%": entity_sp|entityDisplayName}, "app")|raw }}</p>
+    <p>{{ 'You already have a valid session with an identity provider (<em>%IDP%</em>) that is not accepted by <em>%SP%</em>. Would you like to log out from your existing session and log in again with another identity provider?'|trans({"%IDP%": entity_idp|entityDisplayName, "%SP%": entity_sp|entityDisplayName})|raw }}</p>
     <form class="pure-form" method="post" action="?">
         <input type="hidden" name="AuthState" value="{{ AuthState|escape('html') }}">
         <input type="submit" class="pure-button pure-button-red" name="continue" value="{{ 'Yes, continue'|trans }}">

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -174,10 +174,16 @@ class UpdateTranslatableStringsCommand extends Command
                 $finder = new Finder();
                 foreach ($finder->files()->in($moduleLocalesDir . '**/LC_MESSAGES/')->name("{$domain}.po") as $poFile) {
                     $current = $loader->loadFile($poFile->getPathName());
+
                     $merged = $template->mergeWith(
                         $current,
-                        Merge::TRANSLATIONS_THEIRS | Merge::COMMENTS_OURS | Merge::HEADERS_OURS | Merge::REFERENCES_OURS,
+                        Merge::TRANSLATIONS_OVERRIDE
+                        | Merge::COMMENTS_OURS
+                        | Merge::HEADERS_OURS
+                        | Merge::REFERENCES_THEIRS
+                        | Merge::EXTRACTED_COMMENTS_OURS
                     );
+                    $merged->setDomain($domain);
 
                     //
                     // Sort the translations in a predictable way

--- a/src/SimpleSAML/Utils/Translate.php
+++ b/src/SimpleSAML/Utils/Translate.php
@@ -35,6 +35,11 @@ class Translate
         foreach ($finder->files()->in($moduleSrcDir)->name('*.php') as $file) {
             $phpScanner->scanFile($file->getPathName());
         }
+        if (is_dir($moduleDir . 'hooks/')) {
+            foreach ($finder->files()->in($moduleDir . 'hooks/')->name('*.php') as $file) {
+                $phpScanner->scanFile($file->getPathName());
+            }
+        }
 
         return $phpScanner;
     }
@@ -48,10 +53,10 @@ class Translate
 
         // Scan Twig-templates
         $finder = new Finder();
-        foreach ($finder->files()->in($moduleTemplateDir)->depth('== 0')->name('*.twig') as $file) {
+        foreach ($finder->files()->in($moduleTemplateDir)->name('*.twig') as $file) {
             $template = new Template(
                 $this->configuration,
-                ($module ? ($module . ':') : '') . $file->getFileName(),
+                ($module ? ($module . ':') : '') . $file->getRelativePathname(),
             );
 
             $catalogue = new MessageCatalogue('en', []);


### PR DESCRIPTION
I identified a number of issues in https://github.com/simplesamlphp/simplesamlphp/issues/2041 after starting a dive because a new string with `|trans` was not being picked up and added by the execution of
```
php bin/translations translations:update:translatable
```

I have played with a few configurations to `mergeWith` and this is the result. This should address the issues from 2041 and leaves a few new items open to further investigation. 

A next logical item is: If a translation was placed in the messages.po originally but is discovered only in the admin or saml modules then the script will want to place a translation into `modules/admin/locales/fr/LC_MESSAGES/admin.po` for example. This gives two locations in the `po` files for the same string. I am thinking about elevating the string only to `locales/fr/LC_MESSAGES/messages.po` and removing it from the module for saml, core, admin, to make it a little less work for translators. Only one string for each translation rather than a duplicate. As this PR is already doing a number of things I have left that update to a subsequent PR.

This is in response to https://github.com/simplesamlphp/simplesamlphp/issues/2041.