### PR TITLE
Fix config.php.dist coding standards

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -58,7 +58,7 @@ $config = [
     /*
      * The following settings are *filesystem paths* which define where
      * SimpleSAMLphp can find or write the following things:
-     * - 'cachedir': Where SimpleSAMLphp can write its cache. 
+     * - 'cachedir': Where SimpleSAMLphp can write its cache.
      * - 'loggingdir': Where to write logs. MUST be set to NULL when using a logging
      *                 handler other than `file`.
      * - 'datadir': Storage of general data.
@@ -275,7 +275,16 @@ $config = [
      * Whenever you change any of these headers, make sure to validate your config by running your
      * hostname through a security-test like https://en.internet.nl
     'headers.security' => [
-        'Content-Security-Policy' => "default-src 'none'; frame-ancestors 'self'; object-src 'none'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; base-uri 'none'",
+          'Content-Security-Policy' =>
+            "default-src 'none'; " .
+            "frame-ancestors 'self'; " .
+            "object-src 'none'; " .
+            "script-src 'self'; " .
+            "style-src 'self'; " .
+            "font-src 'self'; " .
+            "connect-src 'self'; " .
+            "img-src 'self' data:; " .
+            "base-uri 'none'",
         'Referrer-Policy' => 'origin-when-cross-origin',
         'X-Content-Type-Options' => 'nosniff',
     ],

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -28,8 +28,6 @@ use function hash;
 use function in_array;
 use function is_null;
 use function sprintf;
-use function strpos;
-use function strrpos;
 use function time;
 use function var_export;
 


### PR DESCRIPTION
2 small fixes to config/config.php.dist so that it complies with PSR12, as defined in phpcs.xml.

1. Comment line 22 of phpcs.xml, to avoid phpcs failure.

2. Run the standards check:
```
phpcs --standard=phpcs.xml --extensions='dist' config/config.php.dist
```

3. Result:
```
-----------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
-----------------------------------------------------------------------------------------
  61 | ERROR | [x] Whitespace found at end of line
 278 | ERROR | [ ] Line exceeds maximum limit of 130 characters; contains 214 characters
-----------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-----------------------------------------------------------------------------------------
```

4. Note: the fix for line 278 is copied from https://github.com/simplesamlphp/simplesamlphp/blob/d6a38f3435bd40d00346a29ee4deb77bffa4842e/src/SimpleSAML/Configuration.php#L55





