### PR TITLE
when migrating from an old saml to a new one the session sometimes desn't deserialize, and it should just be thrown away at that point

### DIFF
--- a/src/SimpleSAML/SessionHandlerPHP.php
+++ b/src/SimpleSAML/SessionHandlerPHP.php
@@ -246,8 +246,11 @@ class SessionHandlerPHP extends SessionHandler
         $session = $_SESSION['SimpleSAMLphp_SESSION'];
         Assert::string($session);
 
-        $session = unserialize($session);
-
+        try {
+            $session = unserialize($session);
+        } catch (\Throwable $e) {
+            $session = null;  # sometimes deserializing fails, so we throw it away
+        }
         return ($session !== false) ? $session : null;
     }
 


### PR DESCRIPTION
pretty obvious I hope.