### PR TITLE
start to allow adfs metadata in the admin ui again

### DIFF
--- a/modules/saml/src/MetadataBuilder.php
+++ b/modules/saml/src/MetadataBuilder.php
@@ -222,10 +222,10 @@ class MetadataBuilder
 //            case 'attributeautority-remote':
 //                $descriptors[] = $this->getAttributeAuthority();
 //                break;
-//            case 'adfs-idp-hosted':
-//                $descriptors[] = $this->getIDPSSODescriptor();
+            case 'adfs-idp-hosted':
+                $descriptors[] = $this->getIDPSSODescriptor();
 //                $descriptors[] = $this->getSecurityTokenService();
-//                break;
+                break;
             default:
                 throw new Exception('Not implemented');
         }

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
@@ -129,6 +129,20 @@ class MetaDataStorageHandler implements ClearableState
                 case 'SingleLogoutServiceBinding':
                     return C::BINDING_HTTP_REDIRECT;
             }
+        } elseif ($set == 'adfs-idp-hosted') {
+            switch ($property) {
+                case 'SingleSignOnService':
+                    return $baseurl;
+
+                case 'SingleSignOnServiceBinding':
+                    return C::BINDING_HTTP_REDIRECT;
+
+                case 'SingleLogoutService':
+                    return $baseurl;
+
+                case 'SingleLogoutServiceBinding':
+                    return C::BINDING_HTTP_REDIRECT;
+            }
         }
 
         throw new Exception('Could not generate metadata property ' . $property . ' for set ' . $set . '.');


### PR DESCRIPTION
This goes hand in hand with https://github.com/simplesamlphp/simplesamlphp-module-adfs/pull/18

With these and https://github.com/simplesamlphp/simplesamlphp-module-adfs/pull/18 I can again see the ADFS metadata in the admin/federation page.

The next logical move is getting `getSecurityTokenService` to work again too. Perhaps phase one might be to directly reach out to it and then move to using a hook to call the function.
