### PR TITLE
change adfs SSO from baseurl to prp endpoint

### DIFF
--- a/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
@@ -9,6 +9,7 @@ use SimpleSAML\{Configuration, Error, Logger, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\Utils\ClearableState;
+use SimpleSAML\Module;
 
 use function array_key_exists;
 use function array_merge;
@@ -130,15 +131,16 @@ class MetaDataStorageHandler implements ClearableState
                     return C::BINDING_HTTP_REDIRECT;
             }
         } elseif ($set == 'adfs-idp-hosted') {
+            $endpoint = Module::getModuleURL('adfs/idp/prp.php');
             switch ($property) {
                 case 'SingleSignOnService':
-                    return $baseurl;
+                    return $endpoint;
 
                 case 'SingleSignOnServiceBinding':
                     return C::BINDING_HTTP_REDIRECT;
 
                 case 'SingleLogoutService':
-                    return $baseurl;
+                    return $endpoint;
 
                 case 'SingleLogoutServiceBinding':
                     return C::BINDING_HTTP_REDIRECT;


### PR DESCRIPTION
As mentioned last week [1] the SSO link is updated from baseurl to the prp-endpoint from the adfs-module.

The next move is to shift this code out to the ADFS module with the goal of removing the need for explicit adfs references in SSP itself.

[1] https://github.com/simplesamlphp/simplesamlphp/pull/2067/files/444c9f9e45ec943b1723698d6fa2c85be614f4a2#r1583601248