### PR TITLE
Use DateTime() instead of date()

### DIFF
--- a/src/SimpleSAML/Logger/FileLoggingHandler.php
+++ b/src/SimpleSAML/Logger/FileLoggingHandler.php
@@ -132,7 +132,8 @@ class FileLoggingHandler implements LoggingHandlerInterface
                 }
 
                 $formats[] = $matches[0];
-                $replacements[] = date($format);
+                $date = new \DateTime();
+                $replacements[] = $date->format($format);
             }
 
             if (preg_match('/^php:\/\//', $this->logFile)) {

--- a/src/SimpleSAML/Logger/FileLoggingHandler.php
+++ b/src/SimpleSAML/Logger/FileLoggingHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Logger;
 
+use DateTimeImmutable;
 use SimpleSAML\{Configuration, Logger, Utils};
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\Exception\CannotWriteFileException;
@@ -132,7 +133,7 @@ class FileLoggingHandler implements LoggingHandlerInterface
                 }
 
                 $formats[] = $matches[0];
-                $date = new \DateTime();
+                $date = new DateTimeImmutable();
                 $replacements[] = $date->format($format);
             }
 


### PR DESCRIPTION
`date()` does not support microseconds, but `DateTime` does.
