### PR TITLE
log unserialize failures with descriptive message

### DIFF
--- a/src/SimpleSAML/SessionHandlerPHP.php
+++ b/src/SimpleSAML/SessionHandlerPHP.php
@@ -249,6 +249,10 @@ class SessionHandlerPHP extends SessionHandler
         try {
             $session = unserialize($session);
         } catch (\Throwable $e) {
+            Logger::warning('Session load failed using unserialize().'
+                         .  'If you have just upgraded this might be ok. '
+                          . 'If not there might be an issue with your storage. '
+                          . $e->getMessage());
             $session = null;  # sometimes deserializing fails, so we throw it away
         }
         return ($session !== false) ? $session : null;


### PR DESCRIPTION
This is an update to https://github.com/simplesamlphp/simplesamlphp/pull/2065 which logs unsucessful unserialize(). The goal of these two PRs together is to allow SSP to be upgraded without errors appearing while also logging errors so that they can be seen if there is no upgrade and perhaps the storage is degrading or unserialize is failing for another reason.