### PR TITLE
Only filter attributes if there is actually a list of allowed values to filter on

### DIFF
--- a/modules/core/src/Auth/Process/AttributeLimit.php
+++ b/modules/core/src/Auth/Process/AttributeLimit.php
@@ -176,10 +176,12 @@ class AttributeLimit extends Auth\ProcessingFilter
                         continue;
                     }
                 } elseif (($regexpMatch = self::matchAnyRegex($name, $allowedAttributeRegex)) !== null) {
-                    $attributes[$name] = $this->filterAttributeValues(
-                        $attributes[$name],
-                        $allowedAttributeRegex[$regexpMatch]
-                    );
+                    if (array_key_exists($regexpMatch, $allowedAttributeRegex)) {
+                        $attributes[$name] = $this->filterAttributeValues(
+                            $attributes[$name],
+                            $allowedAttributeRegex[$regexpMatch]
+                        );
+                    }
                     if (!empty($attributes[$name])) {
                         continue;
                     }


### PR DESCRIPTION
Fixes https://github.com/simplesamlphp/simplesamlphp/actions/runs/9028875799/job/24810192242#step:11:19 as referenced in https://github.com/simplesamlphp/simplesamlphp/pull/1971#issuecomment-2104356390

```
Warning: PHP Warning:  Undefined array key "/^mail$/" in /home/runner/work/simplesamlphp/simplesamlphp/modules/core/src/Auth/Process/AttributeLimit.php on line 181
Warning: PHP Warning:  Undefined array key "/^mail$/" in /home/runner/work/simplesamlphp/simplesamlphp/modules/core/src/Auth/Process/AttributeLimit.php on line 181
```

The issue the warning is complaining about is handled in the first line of the `filterAttributeValues()` function anyway (it handles the second argument being null), so the warning this PR fixes was harmless and condition already handled. In any case, this PR removes the noise of the warning, but should have no other impact, as the behaviour is unchanged.

In the tests, the condition occurs when using SP metadata (ie. `$config = ['default' => true, ... ];`), as `$allowedAttributeRegex` is a simple list, whereas when coming out of config files it's a key/value map.
