### PR TITLE
allow again admin module login with raw password stored in config.php

### DIFF
--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -59,6 +59,9 @@ class AdminPassword extends UserPassBase
             throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
         }
 
+        if( $password === $adminPassword ) {
+            return ['user' => ['admin']];
+        }
         $hasher = new NativePasswordHasher();
         if (!$hasher->verify($adminPassword, $password)) {
             throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);

--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -59,7 +59,7 @@ class AdminPassword extends UserPassBase
             throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
         }
 
-        if( $password === $adminPassword ) {
+        if ($password === $adminPassword) {
             return ['user' => ['admin']];
         }
         $hasher = new NativePasswordHasher();


### PR DESCRIPTION
The old pwValid method would fall back to a direct `===` compare if the `password_verify()` failed. 

https://github.com/simplesamlphp/simplesamlphp/blob/e2cd10b10e8cab40d534f938058911e94b32d66b/src/SimpleSAML/Utils/Crypto.php#L379

If we want to allow login as admin to the admin module again without storing the bin/pwgen for the admin password in the config we need to also check if the stored admin password is exactly what was supplied and allow that again.
