### PR TITLE
23: if the auth.adminpassword is not hashed provide some insight

### DIFF
--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -63,7 +63,7 @@ class AdminPassword extends UserPassBase
         if (!$pwinfo['algo']) {
             throw new Error\Error(Error\ErrorCodes::ADMINNOTHASHED);
         }
-        
+
         $hasher = new NativePasswordHasher();
         if (!$hasher->verify($adminPassword, $password)) {
             throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);

--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -60,7 +60,7 @@ class AdminPassword extends UserPassBase
         }
 
         $pwinfo = password_get_info($adminPassword);
-        if (!$pwinfo['algo']) {
+        if ($pwinfo['algo'] === null) {
             throw new Error\Error(Error\ErrorCodes::ADMINNOTHASHED);
         }
 

--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -59,6 +59,11 @@ class AdminPassword extends UserPassBase
             throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
         }
 
+        $pwinfo = password_get_info($adminPassword);
+        if (!$pwinfo['algo']) {
+            throw new Error\Error(Error\ErrorCodes::ADMINNOTHASHED);
+        }
+        
         $hasher = new NativePasswordHasher();
         if (!$hasher->verify($adminPassword, $password)) {
             throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -241,7 +241,11 @@ class ErrorCodes
                 "from the default value. Please edit the configuration file."),
             self::ADMINNOTHASHED => Translate::noop("" .
                 "The password in the configuration (auth.adminpassword) is not a hashed value. " .
-                "Full details on how to fix this are supplied at https://github.com/simplesamlphp/simplesamlphp/wiki/Frequently-Asked-Questions-(FAQ)#failed-to-login-to-the-admin-page-with-and-error-message-admin-password-not-set-to-a-hashed-value"),
+                "Full details on how to fix this are supplied at " .
+                "https://github.com/simplesamlphp/simplesamlphp/wiki/" .
+                "Frequently-Asked-Questions-(FAQ)#failed-to-login-to-the-" .
+                "admin-page-with-and-error-message-admin-password-" .
+                "not-set-to-a-hashed-value"),
             self::NOTVALIDCERT => Translate::noop('You did not present a valid certificate.'),
             self::PROCESSASSERTION => Translate::noop('We did not accept the response sent from the Identity Provider.'),
             self::PROCESSAUTHNREQUEST => Translate::noop("" .

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -39,6 +39,7 @@ class ErrorCodes
     public const NOTFOUND = 'NOTFOUND';
     public const NOTFOUNDREASON = 'NOTFOUNDREASON';
     public const NOTSET = 'NOTSET';
+    public const ADMINNOTHASHED = 'ADMINNOTHASHED';
     public const NOTVALIDCERT = 'NOTVALIDCERT';
     public const PROCESSASSERTION = 'PROCESSASSERTION';
     public const PROCESSAUTHNREQUEST = 'PROCESSAUTHNREQUEST';
@@ -89,6 +90,7 @@ class ErrorCodes
             self::NOTFOUND => Translate::noop('Page not found'),
             self::NOTFOUNDREASON => Translate::noop('Page not found'),
             self::NOTSET => Translate::noop('Password not set'),
+            self::ADMINNOTHASHED => Translate::noop('Admin password not set to a hashed value'),
             self::NOTVALIDCERT => Translate::noop('Invalid certificate'),
             self::PROCESSASSERTION => Translate::noop('Error processing response from Identity Provider'),
             self::PROCESSAUTHNREQUEST => Translate::noop('Error processing request from Service Provider'),
@@ -237,6 +239,9 @@ class ErrorCodes
             self::NOTSET => Translate::noop("" .
                 "The password in the configuration (auth.adminpassword) is not changed " .
                 "from the default value. Please edit the configuration file."),
+            self::ADMINNOTHASHED => Translate::noop("" .
+                "The password in the configuration (auth.adminpassword) is not a hashed value. " .
+                "Full details on how to fix this are supplied at https://github.com/simplesamlphp/simplesamlphp/wiki/Frequently-Asked-Questions-(FAQ)#failed-to-login-to-the-admin-page-with-and-error-message-admin-password-not-set-to-a-hashed-value"),
             self::NOTVALIDCERT => Translate::noop('You did not present a valid certificate.'),
             self::PROCESSASSERTION => Translate::noop('We did not accept the response sent from the Identity Provider.'),
             self::PROCESSAUTHNREQUEST => Translate::noop("" .


### PR DESCRIPTION
In 2.3 and above non hashed admin passwords are not accepted any more. This warns the user and provides some insight to what went wrong and a link with more detail on the exact steps to fix it.

This is the opposite to https://github.com/simplesamlphp/simplesamlphp/pull/2110

This references https://github.com/simplesamlphp/simplesamlphp/wiki/Frequently-Asked-Questions-(FAQ)#failed-to-login-to-the-admin-page-with-and-error-message-admin-password-not-set-to-a-hashed-value for the solution so we can potentially make it more interesting if need be.
