### PR TITLE
CI: translations job update to allow fetch/push to complete

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -22,8 +22,6 @@ jobs:
       files_changed: ${{ steps.changes.outputs.files_changed }}
 
     steps:
-      - uses: actions/checkout@v4
-        
       - name: Setup PHP, with composer and extensions
         id: setup-php
         # https://github.com/shivammathur/setup-php

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,4 +1,5 @@
 ---
+
 name: Build translations
 
 on:  # yamllint disable-line rule:truthy
@@ -12,33 +13,17 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
-  quality:
-    name: Quality checks
-    runs-on: ['ubuntu-latest']
-
-    steps:
-      - uses: actions/checkout@v4
-
-      #- uses: actions/setup-python@v4
-      #  with:
-      #    python-version: '3.10'
-
-      #- run: pip install lint-po
-
-      #- name: Lint PO(T) files
-      #  run: |
-      #    lint-po locales/*/LC_MESSAGES/*.po
-      #    lint-po modules/*/locales/*/LC_MESSAGES/*.po
 
   build:
-    name: Build PO-files
+    name: Setup and Build PO-files
     runs-on: ['ubuntu-latest']
-    needs: quality
 
     outputs:
       files_changed: ${{ steps.changes.outputs.files_changed }}
 
     steps:
+      - uses: actions/checkout@v4
+        
       - name: Setup PHP, with composer and extensions
         id: setup-php
         # https://github.com/shivammathur/setup-php
@@ -50,10 +35,12 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          # token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-
+          persist-credentials: false
+          fetch-depth: 0
+        
       - name: Install Composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
@@ -75,7 +62,7 @@ jobs:
           echo "Changed files"
           echo $SourceDiff
 
-          $HasSourceDiff = $SourceDiff.Length -gt 0
+          $HasSourceDiff = $SourceDiff.Length -gt -1
           echo "($($SourceDiff.Length) changes)"
           echo "files_changed=$HasSourceDiff" >> $env:GITHUB_OUTPUT
 
@@ -112,6 +99,9 @@ jobs:
           # The arguments for the `git add` command (see the paragraph below for more info)
           # Default: '.'
           add: "['**/*.po']"
+          fetch: false
+          push: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Determines the way the action fills missing author name and email. Three options are available:
           # - github_actor -> UserName <UserName@users.noreply.github.com>
@@ -132,6 +122,12 @@ jobs:
           # Default: ignore
           pathspec_error_handling: exitImmediately
 
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: ${{ github.ref_name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        
   cleanup:
     name: Cleanup artifacts
     needs: [build, commit]

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -60,7 +60,7 @@ jobs:
           echo "Changed files"
           echo $SourceDiff
 
-          $HasSourceDiff = $SourceDiff.Length -gt -1
+          $HasSourceDiff = $SourceDiff.Length -gt 0
           echo "($($SourceDiff.Length) changes)"
           echo "files_changed=$HasSourceDiff" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
           fetch-depth: 0
-        
+
       - name: Install Composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
@@ -124,7 +124,7 @@ jobs:
         with:
           branch: ${{ github.ref_name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        
+
   cleanup:
     name: Cleanup artifacts
     needs: [build, commit]

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -99,7 +99,6 @@ jobs:
           add: "['**/*.po']"
           fetch: false
           push: false
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Determines the way the action fills missing author name and email. Three options are available:
           # - github_actor -> UserName <UserName@users.noreply.github.com>


### PR DESCRIPTION
These updates allow a Translations workflow to complete. It is a bit annoying trying to make sure the access tokens are right for the checkout and push and this particular combination seems to work on the `monkeyiq/2024/may/ci-translations-test` branch I created for testing in the main git repo.

https://github.com/simplesamlphp/simplesamlphp/actions/runs/9297922087