### PR TITLE
Fix Linter + CI clean job

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -303,7 +303,7 @@ jobs:
     if: |
       always() &&
       needs.coverage.result == 'success' ||
-      (needs.unit-tests-linux == 'success' && needs.coverage == 'skipped')
+      (needs.unit-tests-linux.result == 'success' && needs.coverage.result == 'skipped')
 
     steps:
       - uses: geekyeggo/delete-artifact@v5

--- a/tools/linters/.eslintrc.js
+++ b/tools/linters/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    extends: ["json:recommended"],
+    ignorePatterns: ["!/tools/linters/.eslintrc.yml", "!/tools/linters/.stylelintrc.json"],
+    parserOptions: {
+        ecmaVersion: 2015,
+        sourceType: "module"
+    }
+};

--- a/tools/linters/.eslintrc.yml
+++ b/tools/linters/.eslintrc.yml
@@ -1,9 +1,0 @@
----
-
-extends: ["plugin:json/recommended"]
-
-ignorePatterns: ["!/tools/linters/.eslintrc.yml", "!/tools/linters/.stylelintrc.json"]
-
-parserOptions:
-  sourceType: "module"
-  ecmaVersion: 2015


### PR DESCRIPTION
eslint config commit fixes the Linter-job:

```
Oops! Something went wrong! :(

ESLint: 8.57.0

Error: ESLint configuration in --config » plugin:json/recommended is invalid:
	- Unexpected top-level property "files".

Referenced from: /github/workspace/tools/linters/.eslintrc.yml
```

Issue here is that the old `.eslintrc.yml` file is deprecated and a new style .js file is required.



--------

cleanup job commit fixes a bug that before was undetected:

```
 .github/workflows/php.yml:305:10: "{outputs: {}; result: string}" value cannot be compared to "string" value with "==" operator [expression]
    |
305 |       needs.coverage.result == 'success' ||
    |          ^~~~~~~~~~~~~~~~~~
```