### PR TITLE
BC-break: remove deprecated single-string format for endpoints

### DIFF
--- a/docs/simplesamlphp-metadata-endpoints.md
+++ b/docs/simplesamlphp-metadata-endpoints.md
@@ -12,32 +12,7 @@ Endpoint                       | Indexed | Default binding
 `SingleLogoutService`          | N       | HTTP-Redirect
 `SingleSignOnService`          | N       | HTTP-Redirect
 
-The various endpoints can be specified in three different ways:
-
-* A single string.
-* Array of strings.
-* Array of arrays.
-
-A single string
----------------
-
-    'AssertionConsumerService' => 'https://sp.example.org/ACS',
-
-This is the simplest endpoint format.
-It can be used when there is only a single endpoint that uses the default binding.
-
-Array of strings
-----------------
-
-    'AssertionConsumerService' => [
-        'https://site1.example.org/ACS',
-        'https://site2.example.org/ACS',
-    ],
-
-This endpoint format can be used to represent multiple endpoints, all of which use the default binding.
-
-Array of arrays
----------------
+The various endpoints can be specified in the following format:
 
     'AssertionConsumerService' => [
         [

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1210,10 +1210,7 @@ class Configuration implements Utils\ClearableState
 
 
         $eps = $this->configuration[$endpointType];
-        if (is_string($eps)) {
-            // for backwards-compatibility
-            $eps = [$eps];
-        } elseif (!is_array($eps)) {
+        if (!is_array($eps)) {
             throw new Exception($loc . ': Expected array or string.');
         }
 
@@ -1221,17 +1218,7 @@ class Configuration implements Utils\ClearableState
         foreach ($eps as $i => &$ep) {
             $iloc = $loc . '[' . var_export($i, true) . ']';
 
-            if (is_string($ep)) {
-                // for backwards-compatibility
-                $ep = [
-                    'Location' => $ep,
-                    'Binding'  => $this->getDefaultBinding($endpointType),
-                ];
-                $responseLocation = $this->getOptionalString($endpointType . 'Response', null);
-                if ($responseLocation !== null) {
-                    $ep['ResponseLocation'] = $responseLocation;
-                }
-            } elseif (!is_array($ep)) {
+            if (!is_array($ep)) {
                 throw new Exception($iloc . ': Expected a string or an array.');
             }
 


### PR DESCRIPTION
Fixes #2130

Since this is broken anyway, I'd like to backport this to the 2.3 branch and add an upgrade note about it.