### PR TITLE
Update test suite for no single string endpoints

### DIFF
--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1187,6 +1187,7 @@ class Configuration implements Utils\ClearableState
             case 'saml20-sp-remote:AssertionConsumerService':
                 return Constants::BINDING_HTTP_POST;
             case 'saml20-idp-remote:ArtifactResolutionService':
+            case 'attributeauthority-remote:AttributeService':
                 return Constants::BINDING_SOAP;
             default:
                 throw new Exception('Missing default binding for ' . $endpointType . ' in ' . $set);

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -6,7 +6,9 @@ namespace SimpleSAML;
 
 use Exception;
 use ParseError;
+use SAML2\Binding;
 use SAML2\Constants;
+use SAML2\Exception\Protocol\UnsupportedBindingException;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Error;
 use SimpleSAML\Utils;
@@ -1191,28 +1193,6 @@ class Configuration implements Utils\ClearableState
         }
     }
 
-    private function isValidBinding(string $binding): bool
-    {
-        if ($binding == Constants::BINDING_HTTP_REDIRECT) {
-            return true;
-        }
-        if ($binding == Constants::BINDING_HTTP_POST) {
-            return true;
-        }
-        if ($binding == Constants::BINDING_SOAP) {
-            return true;
-        }
-        if ($binding == Constants::BINDING_HOK_SSO) {
-            return true;
-        }
-        if ($binding == Constants::BINDING_HTTP_ARTIFACT) {
-            return true;
-        }
-
-        return false;
-    }
-
-
     /**
      * Helper function for dealing with metadata endpoints.
      *
@@ -1265,7 +1245,9 @@ class Configuration implements Utils\ClearableState
                 if (array_key_exists('isDefault', $ep) && $ep['isDefault']) {
                     $isDefault = true;
                 } else {
-                    if (!$this->isValidBinding($ep['Binding'])) {
+                    try {
+                        Binding::getBinding($ep['Binding']);
+                    } catch (UnsupportedBindingException $e) {
                         $ep['Binding'] = $this->getDefaultBinding($endpointType);
                     }
                 }

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1193,16 +1193,21 @@ class Configuration implements Utils\ClearableState
 
     private function isValidBinding(string $binding): bool
     {
-        if($binding == Constants::BINDING_HTTP_REDIRECT)
+        if ($binding == Constants::BINDING_HTTP_REDIRECT) {
             return true;
-        if($binding == Constants::BINDING_HTTP_POST)
+        }
+        if ($binding == Constants::BINDING_HTTP_POST) {
             return true;
-        if($binding == Constants::BINDING_SOAP)
+        }
+        if ($binding == Constants::BINDING_SOAP) {
             return true;
-        if($binding == Constants::BINDING_HOK_SSO)
+        }
+        if ($binding == Constants::BINDING_HOK_SSO) {
             return true;
-        if($binding == Constants::BINDING_HTTP_ARTIFACT)
+        }
+        if ($binding == Constants::BINDING_HTTP_ARTIFACT) {
             return true;
+        }
 
         return false;
     }
@@ -1255,12 +1260,12 @@ class Configuration implements Utils\ClearableState
                 throw new Exception($iloc . ': Binding must be a string.');
             }
 
-            if( $eps_count <= 1 ) {
+            if ($eps_count <= 1) {
                 $isDefault = false;
-                if( array_key_exists('isDefault', $ep) && $ep['isDefault']) {
+                if (array_key_exists('isDefault', $ep) && $ep['isDefault']) {
                     $isDefault = true;
                 } else {
-                    if( !$this->isValidBinding($ep['Binding'])) {
+                    if (!$this->isValidBinding($ep['Binding'])) {
                         $ep['Binding'] = $this->getDefaultBinding($endpointType);
                     }
                 }

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1191,6 +1191,22 @@ class Configuration implements Utils\ClearableState
         }
     }
 
+    private function isValidBinding(string $binding): bool
+    {
+        if($binding == Constants::BINDING_HTTP_REDIRECT)
+            return true;
+        if($binding == Constants::BINDING_HTTP_POST)
+            return true;
+        if($binding == Constants::BINDING_SOAP)
+            return true;
+        if($binding == Constants::BINDING_HOK_SSO)
+            return true;
+        if($binding == Constants::BINDING_HTTP_ARTIFACT)
+            return true;
+
+        return false;
+    }
+
 
     /**
      * Helper function for dealing with metadata endpoints.
@@ -1216,6 +1232,7 @@ class Configuration implements Utils\ClearableState
             throw new Exception($loc . ': Expected array or string.');
         }
 
+        $eps_count = count($eps);
 
         foreach ($eps as $i => &$ep) {
             $iloc = $loc . '[' . var_export($i, true) . ']';
@@ -1238,6 +1255,16 @@ class Configuration implements Utils\ClearableState
                 throw new Exception($iloc . ': Binding must be a string.');
             }
 
+            if( $eps_count <= 1 ) {
+                $isDefault = false;
+                if( array_key_exists('isDefault', $ep) && $ep['isDefault']) {
+                    $isDefault = true;
+                } else {
+                    if( !$this->isValidBinding($ep['Binding'])) {
+                        $ep['Binding'] = $this->getDefaultBinding($endpointType);
+                    }
+                }
+            }
             if (array_key_exists('ResponseLocation', $ep)) {
                 if (!is_string($ep['ResponseLocation'])) {
                     throw new Exception($iloc . ': ResponseLocation must be a string.');

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1232,7 +1232,7 @@ class Configuration implements Utils\ClearableState
             }
 
             if (!array_key_exists('Binding', $ep)) {
-                throw new Exception($iloc . ': Missing Binding.');
+                $ep['Binding'] = $this->getDefaultBinding($endpointType);
             }
             if (!is_string($ep['Binding'])) {
                 throw new Exception($iloc . ': Binding must be a string.');

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -815,7 +815,7 @@ class ConfigurationTest extends ClearStateTestCase
             Constants::BINDING_HTTP_ARTIFACT,
             Constants::BINDING_SOAP,
         ];
-        
+
         $a = [
             'metadata-set' => 'saml20-sp-remote',
             'ArtifactResolutionService' => [[ 'Location' => 'https://example.com/ars', 'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP' ]],
@@ -835,7 +835,7 @@ class ConfigurationTest extends ClearStateTestCase
                 'AssertionConsumerService',
                 $valid_bindings,
             );
-            $this->assertEquals($acs_expected_eps[$i], $actual );
+            $this->assertEquals($acs_expected_eps[$i], $actual);
         }
 
         $a['metadata-set'] = 'saml20-idp-remote';

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -822,7 +822,7 @@ class ConfigurationTest extends ClearStateTestCase
                 [
                     'Location' => 'https://example.com/ars',
                 ],
-            ].
+            ],
             'SingleSignOnService' => [
                 [
                     'Location' => 'https://example.com/sso',

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -818,18 +818,22 @@ class ConfigurationTest extends ClearStateTestCase
 
         $a = [
             'metadata-set' => 'saml20-sp-remote',
-            'ArtifactResolutionService' =>
-                [[
+            'ArtifactResolutionService' => [
+                [
                     'Location' => 'https://example.com/ars',
-                ]],
-            'SingleSignOnService' =>
-                [[
+                ],
+            ].
+            'SingleSignOnService' => [
+                [
                     'Location' => 'https://example.com/sso',
-                ]],
-            'SingleLogoutService' => [[
-                'Location' => 'https://example.com/slo',
-                'Binding' => 'valid_binding', // test unknown bindings if we don't specify a list of valid ones
-            ]],
+                ],
+            ],
+            'SingleLogoutService' => [
+                [
+                    'Location' => 'https://example.com/slo',
+                    'Binding' => 'valid_binding', // test unknown bindings if we don't specify a list of valid ones
+                ],
+            ],
         ];
 
 

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -818,8 +818,16 @@ class ConfigurationTest extends ClearStateTestCase
 
         $a = [
             'metadata-set' => 'saml20-sp-remote',
-            'ArtifactResolutionService' => [[ 'Location' => 'https://example.com/ars', 'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP' ]],
-            'SingleSignOnService' => [[ 'Location' => 'https://example.com/sso',       'Binding' => Constants::BINDING_HTTP_REDIRECT  ]],
+            'ArtifactResolutionService' =>
+                [[
+                    'Location' => 'https://example.com/ars',
+                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP',
+                ]],
+            'SingleSignOnService' =>
+                [[
+                    'Location' => 'https://example.com/sso',
+                    'Binding' => Constants::BINDING_HTTP_REDIRECT,
+                ]],
             'SingleLogoutService' => [[
                 'Location' => 'https://example.com/slo',
                 'Binding' => 'valid_binding', // test unknown bindings if we don't specify a list of valid ones

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -717,14 +717,14 @@ class ConfigurationTest extends ClearStateTestCase
          * tests for AssertionConsumerService.
          */
         $acs_eps = [
-            // define location and binding
+            // 0. define location and binding
             [
                 [
                     'Location' => 'https://example.com/endpoint.php',
                     'Binding' => Constants::BINDING_HTTP_POST,
                 ],
             ],
-            // define the ResponseLocation too
+            // 1. define the ResponseLocation too
             [
                 [
                     'Location' => 'https://example.com/endpoint.php',
@@ -732,7 +732,7 @@ class ConfigurationTest extends ClearStateTestCase
                     'ResponseLocation' => 'https://example.com/endpoint.php',
                 ],
             ],
-            // make sure indexes are NOT taken into account (they just identify endpoints)
+            // 2. make sure indexes are NOT taken into account (they just identify endpoints)
             [
                 [
                     'index' => 1,
@@ -745,7 +745,7 @@ class ConfigurationTest extends ClearStateTestCase
                     'Binding' => Constants::BINDING_HTTP_POST,
                 ],
             ],
-            // make sure isDefault has priority over indexes
+            // 3. make sure isDefault has priority over indexes
             [
                 [
                     'index' => 1,
@@ -759,7 +759,7 @@ class ConfigurationTest extends ClearStateTestCase
                     'Binding' => Constants::BINDING_HTTP_REDIRECT,
                 ],
             ],
-            // make sure endpoints with invalid bindings are ignored and those marked as NOT default are still used
+            // 4. make sure endpoints with invalid bindings are ignored and those marked as NOT default are still used
             [
                 [
                     'index' => 1,
@@ -856,7 +856,7 @@ class ConfigurationTest extends ClearStateTestCase
         $this->assertEquals(
             [
                 'Location' => 'https://example.com/slo',
-                'Binding' => 'valid_binding', // Constants::BINDING_HTTP_REDIRECT,
+                'Binding' => Constants::BINDING_HTTP_REDIRECT,
             ],
             $c->getDefaultEndpoint('SingleLogoutService'),
         );

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -821,12 +821,10 @@ class ConfigurationTest extends ClearStateTestCase
             'ArtifactResolutionService' =>
                 [[
                     'Location' => 'https://example.com/ars',
-                    'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP',
                 ]],
             'SingleSignOnService' =>
                 [[
                     'Location' => 'https://example.com/sso',
-                    'Binding' => Constants::BINDING_HTTP_REDIRECT,
                 ]],
             'SingleLogoutService' => [[
                 'Location' => 'https://example.com/slo',
@@ -884,7 +882,7 @@ class ConfigurationTest extends ClearStateTestCase
         $a['metadata-set'] = 'foo';
         $c = Configuration::loadFromArray($a);
         try {
-            $c->getDefaultEndpoint('SingleSignOnService');
+            $v = $c->getDefaultEndpoint('SingleSignOnService');
             $this->fail('No valid metadata set specified.');
         } catch (Exception $e) {
             $this->assertStringStartsWith('Missing default binding for', $e->getMessage());


### PR DESCRIPTION
This is an update after single string and single array endpoints were removed. See https://github.com/simplesamlphp/simplesamlphp/pull/2131

Note that there are some heuristics that seem to have been implicit.

This will effect all endpoints ArtifactResolutionService, SingleSignOnService, and SingleLogoutService.

If there is no binding set then one is set for you. This matches the default value table from
https://github.com/simplesamlphp/simplesamlphp/blob/simplesamlphp-2.2/docs/simplesamlphp-metadata-endpoints.md

If there is only one end point in the array and the binding is not valid then it is refreshed for you to something that is valid.

On the other hand, for a list of end points no such refreshing is done so that the case of a non default Location with a valid Binding can be the one that is used.

