### PR TITLE
NO MERGE: Example for testing of custom error codes in templates

### DIFF
--- a/src/SimpleSAML/Error/Error.php
+++ b/src/SimpleSAML/Error/Error.php
@@ -127,7 +127,7 @@ class Error extends Exception
      *
      * @return ErrorCodes
      */
-    protected function getErrorCodes(): ErrorCodes
+    public function getErrorCodes(): ErrorCodes
     {
         return new ErrorCodes();
     }


### PR DESCRIPTION
This is not intended to be merged.

This is a PR mainly to show the diff for testing of the use of a custom error code in templates. The PR needs both a better name for and some security around the use of the `codeclass` state variable. By storing the `ErrorCodes` class in the state we can recreate it later and thus support both normal and custom error codes in templates. 

By storing the errorcodes class both of the code paths tested in `UserPass.php` work. A regular `Error` can be thrown and will show up correctly as well as a custom `myError` object. If the class is instead fixed then your subclass will need to supply it's own codes as well as compatible ones with those in the normal ErrorCodes.

This relates to the issue https://github.com/simplesamlphp/simplesamlphp/issues/2133
