### PR TITLE
Fix bug in post.twig

### DIFF
--- a/templates/post.twig
+++ b/templates/post.twig
@@ -21,7 +21,7 @@
         {%- if value is iterable %}
           {%- for index, item in value %}
 
-      <input type="hidden" name="{{ name }}[{{ index }}]" value="{{ value }}">
+      <input type="hidden" name="{{ name }}[{{ index }}]" value="{{ item }}">
           {%- endfor %}
         {%- else %}
 


### PR DESCRIPTION
If a posted value is an array, this template iterates through it as 'index' and 'item' and then passes 'value' to the template where it should be 'item'. This is causing post values that are supposed to be the elements of arrays to be the string "Array" instead.