### PR TITLE
Use the appropriate way to set the charset in HTML5

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="{{ currentLanguage }}" dir="{{ isRTL ? 'rtl' : 'ltr' }}">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <title>{{ pagetitle }}</title>


### PR DESCRIPTION
See https://webhint.io/docs/user-guide/hints/hint-meta-charset-utf-8/?source=devtools for the reasoning behind this change. It's fully backwards compatible.