### PR TITLE
Possibly use the HSTS response header

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -287,6 +287,7 @@ $config = [
             "base-uri 'none'",
         'Referrer-Policy' => 'origin-when-cross-origin',
         'X-Content-Type-Options' => 'nosniff',
+        'Strict-Transport-Security: max-age=63072000; includeSubDomains',
     ],
      */
 

--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -269,6 +269,9 @@ $config = [
 
     /*
      * Set custom security headers. The defaults can be found in \SimpleSAML\Configuration::DEFAULT_SECURITY_HEADERS
+     * and \SimpleSAML\Configuration::DEFAULT_SECURITY_HEADERS_HTTPS_MERGE.
+     * When a request is performed over https then the later is merged with
+     * DEFAULT_SECURITY_HEADERS.
      *
      * NOTE: When a header is already set on the response we will NOT overrule it and leave it untouched.
      *
@@ -287,6 +290,8 @@ $config = [
             "base-uri 'none'",
         'Referrer-Policy' => 'origin-when-cross-origin',
         'X-Content-Type-Options' => 'nosniff',
+    ],
+    'headers.security.https.merge' => [
         'Strict-Transport-Security: max-age=63072000; includeSubDomains',
     ],
      */

--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -9,7 +9,7 @@ require_once('../_include.php');
 $config = Configuration::getInstance();
 $httpUtils = new Utils\HTTP();
 
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 $redirect = Module::getModuleURL('admin/');
 $response = $httpUtils->redirectTrustedURL($redirect);
 foreach ($headers as $header => $value) {

--- a/public/index.php
+++ b/public/index.php
@@ -9,7 +9,7 @@ require_once('_include.php');
 $config = Configuration::getInstance();
 $httpUtils = new Utils\HTTP();
 
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 $redirect = $config->getOptionalString('frontpage.redirect', Module::getModuleURL('core/welcome'));
 $response = $httpUtils->redirectTrustedURL($redirect);
 foreach ($headers as $header => $value) {

--- a/public/module.php
+++ b/public/module.php
@@ -12,7 +12,7 @@ namespace SimpleSAML;
 require_once('_include.php');
 
 $config = Configuration::getInstance();
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 
 $response = Module::process();
 foreach ($headers as $header => $value) {

--- a/public/saml2/idp/ArtifactResolutionService.php
+++ b/public/saml2/idp/ArtifactResolutionService.php
@@ -18,7 +18,7 @@ $config = Configuration::getInstance();
 $controller = new Controller\WebBrowserSingleSignOn($config);
 $request = Request::createFromGlobals();
 
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 
 $response = $controller->ArtifactResolutionService($request);
 foreach ($headers as $header => $value) {

--- a/public/saml2/idp/SSOService.php
+++ b/public/saml2/idp/SSOService.php
@@ -18,7 +18,7 @@ $config = Configuration::getInstance();
 $controller = new Controller\WebBrowserSingleSignOn($config);
 $request = Request::createFromGlobals();
 
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 
 $response = $controller->singleSignOnService($request);
 foreach ($headers as $header => $value) {

--- a/public/saml2/idp/SingleLogoutService.php
+++ b/public/saml2/idp/SingleLogoutService.php
@@ -18,7 +18,7 @@ $request = Request::createFromGlobals();
 $config = Configuration::getInstance();
 $controller = new Controller\SingleLogout($config);
 
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 
 $response = $controller->singleLogout($request);
 foreach ($headers as $header => $value) {

--- a/public/saml2/idp/initSLO.php
+++ b/public/saml2/idp/initSLO.php
@@ -18,7 +18,7 @@ $request = Request::createFromGlobals();
 $config = Configuration::getInstance();
 $controller = new Controller\SingleLogout($config);
 
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 
 $response = $controller->initSingleLogout($request);
 foreach ($headers as $header => $value) {

--- a/public/saml2/idp/metadata.php
+++ b/public/saml2/idp/metadata.php
@@ -18,7 +18,7 @@ $request = Request::createFromGlobals();
 $config = Configuration::getInstance();
 $controller = new Controller\Metadata($config);
 
-$headers = $config->getOptionalArray('headers.security', Configuration::DEFAULT_SECURITY_HEADERS);
+$headers = $config->getHeadersSecurity();
 
 $response = $controller->metadata($request);
 foreach ($headers as $header => $value) {

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -66,6 +66,8 @@ class Configuration implements Utils\ClearableState
             "base-uri 'none'",
         'Referrer-Policy' => 'origin-when-cross-origin',
         'X-Content-Type-Options' => 'nosniff',
+    ];
+    public const DEFAULT_SECURITY_HEADERS_HTTPS_MERGE = [
         'Strict-Transport-Security' => 'max-age=63072000; includeSubDomains',
     ];
 
@@ -980,6 +982,39 @@ class Configuration implements Utils\ClearableState
         return $ret;
     }
 
+
+    /**
+     * As the headers can be different for http and https requests this method should be used
+     * when reading headers.security to allow them to be augmented when https requests are in use.
+     *
+     * @return array the security headers that should be used.
+     */
+    public function getHeadersSecurity(): ?array
+    {
+        $httpUtils = new Utils\HTTP();
+        if ($httpUtils->isHTTPS()) {
+            $headers = $this->getOptionalArray(
+                'headers.security',
+                Configuration::DEFAULT_SECURITY_HEADERS,
+            );
+            $httpsheaders = $this->getOptionalArray(
+                'headers.security.https.merge',
+                Configuration::DEFAULT_SECURITY_HEADERS_HTTPS_MERGE,
+            );
+            if ($headers == null) {
+                $headers = [];
+            }
+            if ($httpsheaders == null) {
+                $httpsheaders = [];
+            }
+            return array_merge($headers, $httpsheaders);
+        }
+
+        return $this->getOptionalArray(
+            'headers.security',
+            Configuration::DEFAULT_SECURITY_HEADERS,
+        );
+    }
 
     /**
      * This function retrieves an array configuration option.

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -66,6 +66,7 @@ class Configuration implements Utils\ClearableState
             "base-uri 'none'",
         'Referrer-Policy' => 'origin-when-cross-origin',
         'X-Content-Type-Options' => 'nosniff',
+        'Strict-Transport-Security' => 'max-age=63072000; includeSubDomains',
     ];
 
     /**


### PR DESCRIPTION
I would imagine that almost all interaction with web servers in the SAML process is going to be via https. Given that perhaps we want to remove the possibility of a user somehow being sent to a non https page?

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#preloading_strict_transport_security