### PR TITLE
i18n: allow a theme and module to work together

### DIFF
--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -17,6 +17,7 @@ use Gettext\Loader\PoLoader;
 use Gettext\{Translations, Translator, TranslatorFunctions};
 use SimpleSAML\{Configuration, Logger};
 use Symfony\Component\HttpFoundation\File\File;
+use SimpleSAML\Locale\Translate;
 
 class Localization
 {
@@ -137,6 +138,7 @@ class Localization
     public function defaultDomain(string $domain): self
     {
         $this->translator->defaultDomain($domain);
+        Translate::addDefaultDomain($domain);
         return $this;
     }
 

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -64,7 +64,7 @@ class Translate
 
     public static function addDefaultDomain(string $domain): void
     {
-        array_push( self::$defaultDomains, $domain );
+        array_push(self::$defaultDomains, $domain);
     }
 
     /**
@@ -85,14 +85,13 @@ class Translate
             if ($text === $original) {
                 $text = TranslatorFunctions::getTranslator()->dgettext("messages", $original);
                 if ($text === $original) {
-
-                    foreach( self::$defaultDomains as $d) { 
+                    foreach (self::$defaultDomains as $d) {
                         $text = TranslatorFunctions::getTranslator()->dgettext($d, $original);
                         if ($text != $original) {
                             return $text;
                         }
                     }
-                      
+
                     // try attributes.po
                     if ($text === $original) {
                         $text = TranslatorFunctions::getTranslator()->dgettext("", $original);

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Locale;
 
 use Gettext\TranslatorFunctions;
-use SimpleSAML\Configuration;
+use SimpleSAML\{Configuration, Logger};
 
 class Translate
 {
@@ -22,6 +22,10 @@ class Translate
      */
     private Language $language;
 
+    /**
+     * A theme and module may exist together as dual default translation domains
+     */
+    private static array $defaultDomains = [];
 
     /**
      * Constructor
@@ -58,6 +62,10 @@ class Translate
         return $tag;
     }
 
+    public static function addDefaultDomain(string $domain): void
+    {
+        array_push( self::$defaultDomains, $domain );
+    }
 
     /**
      * Translate a singular text.
@@ -76,9 +84,19 @@ class Translate
             $text = TranslatorFunctions::getTranslator()->dgettext("core", $original);
             if ($text === $original) {
                 $text = TranslatorFunctions::getTranslator()->dgettext("messages", $original);
-                // try attributes.po
                 if ($text === $original) {
-                    $text = TranslatorFunctions::getTranslator()->dgettext("", $original);
+
+                    foreach( self::$defaultDomains as $d) { 
+                        $text = TranslatorFunctions::getTranslator()->dgettext($d, $original);
+                        if ($text != $original) {
+                            return $text;
+                        }
+                    }
+                      
+                    // try attributes.po
+                    if ($text === $original) {
+                        $text = TranslatorFunctions::getTranslator()->dgettext("", $original);
+                    }
                 }
             }
         }


### PR DESCRIPTION
If you have a module in use such as `multiauth:MultiAuth` and use are using a theme at the same time then you have (or should have) two default translation domains in action: the multiauth and the theme. This PR allows both of these to be in use and will allow a theme to see the module translation domain as well as it's own.

This bug was reported on the users mailing list.
