### PR TITLE
In Module::resolveClass throw a different error for class not found

### DIFF
--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -455,9 +455,9 @@ class Module
             $className = 'SimpleSAML\\Module\\' . $tmp[0] . $type . $tmp[1];
         }
 
-        if ($subclass !== null && !is_subclass_of($className, $subclass)) {
-            // If it is not a subclass check if it even exists to give a better
-            // error message.
+        if ($subclass !== null) {
+            // First check if the class exists to give a more informative error
+            // for cases where modules might have been moved or renamed.
             if (!class_exists($className, true)) {
                 throw new Exception(
                     'Could not resolve \'' . $id . '\': The class \'' . $className
@@ -465,10 +465,12 @@ class Module
                 );
             }
 
-            throw new Exception(
-                'Could not resolve \'' . $id . '\': The class \'' . $className
-                . '\' isn\'t a subclass of \'' . $subclass . '\'.',
-            );
+            if (!is_subclass_of($className, $subclass)) {
+                throw new Exception(
+                    'Could not resolve \'' . $id . '\': The class \'' . $className
+                    . '\' isn\'t a subclass of \'' . $subclass . '\'.',
+                );
+            }
         }
 
         return $className;

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -469,7 +469,7 @@ class Module
         if ($subclass !== null && !is_subclass_of($className, $subclass)) {
             throw new Exception(
                 'Could not resolve \'' . $id . '\': The class \'' . $className
-              . '\' isn\'t a subclass of \'' . $subclass . '\'.',
+                . '\' isn\'t a subclass of \'' . $subclass . '\'.',
             );
         }
 

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -456,6 +456,15 @@ class Module
         }
 
         if ($subclass !== null && !is_subclass_of($className, $subclass)) {
+            // If it is not a subclass check if it even exists to give a better
+            // error message.
+            if (!class_exists($className, true)) {
+                throw new Exception(
+                    'Could not resolve \'' . $id . '\': The class \'' . $className
+                    . '\' does not exist.',
+                );
+            }
+
             throw new Exception(
                 'Could not resolve \'' . $id . '\': The class \'' . $className
                 . '\' isn\'t a subclass of \'' . $subclass . '\'.',

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -462,10 +462,10 @@ class Module
         if (!class_exists($className, true)) {
             throw new Exception(
                 'Could not resolve \'' . $id . '\': The class \'' . $className
-              . '\' does not exist.',
+                . '\' does not exist.',
             );
         }
-        
+
         if ($subclass !== null && !is_subclass_of($className, $subclass)) {
             throw new Exception(
                 'Could not resolve \'' . $id . '\': The class \'' . $className

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -455,22 +455,22 @@ class Module
             $className = 'SimpleSAML\\Module\\' . $tmp[0] . $type . $tmp[1];
         }
 
-        if ($subclass !== null) {
-            // First check if the class exists to give a more informative error
-            // for cases where modules might have been moved or renamed.
-            if (!class_exists($className, true)) {
-                throw new Exception(
-                    'Could not resolve \'' . $id . '\': The class \'' . $className
-                    . '\' does not exist.',
-                );
-            }
-
-            if (!is_subclass_of($className, $subclass)) {
-                throw new Exception(
-                    'Could not resolve \'' . $id . '\': The class \'' . $className
-                    . '\' isn\'t a subclass of \'' . $subclass . '\'.',
-                );
-            }
+        // Check if the class exists to give a more informative error
+        // for cases where modules might have been moved or renamed.
+        // Otherwise a not subclass of error would be thrown for a class
+        // that does not exist.
+        if (!class_exists($className, true)) {
+            throw new Exception(
+                'Could not resolve \'' . $id . '\': The class \'' . $className
+              . '\' does not exist.',
+            );
+        }
+        
+        if ($subclass !== null && !is_subclass_of($className, $subclass)) {
+            throw new Exception(
+                'Could not resolve \'' . $id . '\': The class \'' . $className
+              . '\' isn\'t a subclass of \'' . $subclass . '\'.',
+            );
         }
 
         return $className;


### PR DESCRIPTION
This might help to debug when a class is renamed or moved to a new module.

This is a follow on to the thread "Unhandled exeception with v2.2.2" on google groups from today. I put the exists test inside the subclass one so it only runs when things are failing. 

Looking at the other side we should consider if we want this because although it is handy for debugging it does potentially allow probing for classes to see if they exist and perhaps leak information about what version is installed or what modules are available.
