### PR TITLE
Allow custom ErrorCodes subclasses through Login::handleLogin v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,8 @@
         "symfony/var-exporter": "^6.4",
         "symfony/yaml": "^6.4",
         "twig/intl-extra": "^3.7",
-        "twig/twig": "^3.5"
+        "twig/twig": "^3.5",
+        "simplesamlphpmiq/simplesamlphp-module-testauthsource": "dev-master"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8952ca20dc3522c35373953f9571f295",
+    "content-hash": "a54661ba80602c6fe957b3b0955b86bb",
     "packages": [
         {
             "name": "gettext/gettext",
@@ -869,6 +869,58 @@
                 "source": "https://github.com/simplesamlphp/xml-security/tree/v1.7.3"
             },
             "time": "2024-05-10T10:02:40+00:00"
+        },
+        {
+            "name": "simplesamlphpmiq/simplesamlphp-module-testauthsource",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/simplesamlphp/simplesamlphp-module-testauthsource.git",
+                "reference": "2c10d7ac23566670182f765b873c13f1d1c18828"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/simplesamlphp/simplesamlphp-module-testauthsource/zipball/2c10d7ac23566670182f765b873c13f1d1c18828",
+                "reference": "2c10d7ac23566670182f765b873c13f1d1c18828",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pdo": "*",
+                "php": "^8.1",
+                "simplesamlphp/assert": "^1.1.0",
+                "simplesamlphp/composer-module-installer": "^1.3.4",
+                "simplesamlphp/simplesamlphp": "^2.2"
+            },
+            "require-dev": {
+                "simplesamlphp/simplesamlphp-test-framework": "^1.6.0"
+            },
+            "default-branch": true,
+            "type": "simplesamlphp-module",
+            "autoload": {
+                "psr-4": {
+                    "SimpleSAML\\Module\\testauthsource\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Martin",
+                    "email": "monkeyiq@gmail.com"
+                }
+            ],
+            "description": "This is a authentication module used by the test suite",
+            "keywords": [
+                "simplesamlphp",
+                "testauthsource"
+            ],
+            "support": {
+                "issues": "https://github.com/simplesamlphp/simplesamlphp-module-testauthsource/issues",
+                "source": "https://github.com/simplesamlphp/simplesamlphp-module-testauthsource"
+            },
+            "time": "2024-07-30T23:53:11+00:00"
         },
         {
             "name": "symfony/cache",
@@ -5981,7 +6033,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "simplesamlphpmiq/simplesamlphp-module-testauthsource": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/SimpleSAML/Error/Error.php
+++ b/src/SimpleSAML/Error/Error.php
@@ -125,9 +125,12 @@ class Error extends Exception
      *
      * Extend this to use custom ErrorCodes instance (with custom error codes and their title / description tags).
      *
+     * This has to be public to allow Login to get an object
+     * containing custom error codes if they in use.
+     *
      * @return ErrorCodes
      */
-    protected function getErrorCodes(): ErrorCodes
+    public function getErrorCodes(): ErrorCodes
     {
         return new ErrorCodes();
     }

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -15,6 +15,13 @@ use function array_merge;
  */
 class ErrorCodes
 {
+    public function __construct()
+    {
+        // Automatically register instances of subclasses with Login to allow
+        // custom ErrorCodes to work in a redirect environment
+        \SimpleSAML\Module\core\Controller\Login::registerErrorCodeClass($this);
+    }
+
     // TODO PHPv8.1 - Consider moving to final consts for these default error codes to prevent overrides.
     public const ACSPARAMS = 'ACSPARAMS';
     public const ARSPARAMS = 'ARSPARAMS';

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -397,7 +397,7 @@ class Module
             $ret = $core_module ? true : false;
             Logger::error("isModuleEnabledWithConf(5) testauthsource ret $ret ");
         }
-        
+
         return $core_module ? true : false;
     }
 

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -387,10 +387,17 @@ class Module
             throw new Exception("Invalid module.enable value for the '$module' module.");
         }
         Logger::error("isModuleEnabledWithConf(4)");
-
+        if ($module == "testauthsource") {
+            Logger::error("isModuleEnabledWithConf(4) testauthsource");
+        }
         $core_module = array_key_exists($module, self::$core_modules) ? true : false;
 
         self::$module_info[$module]['enabled'] = $core_module ? true : false;
+        if ($module == "testauthsource") {
+            $ret = $core_module ? true : false;
+            Logger::error("isModuleEnabledWithConf(5) testauthsource ret $ret ");
+        }
+        
         return $core_module ? true : false;
     }
 

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -47,21 +47,6 @@ class LoginTest extends ClearStateTestCase
         );
 
         Configuration::setPreLoadedConfig($this->config, 'config.php');
-
-/*
-        $v = \SimpleSAML\Module::isModuleEnabled('testauthsource');
-        Logger::info("in setup() have module v $v ");
- */
-
-/*
-        $core_modules = [
-            'core' => true,
-            'saml' => true,
-        ];
-        $config = new Configuration([], "config.php");
-        $module = 'testauthsource';
-//        $v = \SimpleSAML\Module::isModuleEnabledWithConf($module, $config->getOptionalArray('module.enable', $core_modules));
- */
     }
 
 
@@ -83,7 +68,7 @@ class LoginTest extends ClearStateTestCase
     /**
      * FIXME this seems to give some XML on scren and an incomplete result?
      */
-    public function xtestClearDiscoChoicesReturnToDisallowedUrlRejected(): void
+    public function testClearDiscoChoicesReturnToDisallowedUrlRejected(): void
     {
         $request = Request::create(
             '/cleardiscochoices',

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -11,6 +11,7 @@ use SimpleSAML\Module\core\Auth\UserPassBase;
 use SimpleSAML\TestUtils\ClearStateTestCase;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\Request;
+use SimpleSAML\Logger;
 
 /**
  * Set of tests for the controllers in the "core" module.

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -289,4 +289,30 @@ class LoginTest extends ClearStateTestCase
             "response page does not contain the expected normal error message",
         );
     }
+
+
+    /**
+     * Perform a login with loginuserpass and check that a custom error code related
+     * error message is shown on the resulting screen.
+     */
+    public function testLoginTestAuthSourceCustomError(): void
+    {
+        // We want a custom error from our auth source
+        $asConfig =  ['errorType' => ''];
+        $request = $this->setupPrivateAuthSource($asConfig);
+        $c = new Controller\Login($this->config);
+
+        // This relies on setupPrivateAuthSource doing a saveState() and will
+        // find the Auth\Source because we preloaded an authsources.php config
+        $response = $c->loginuserpass($request);
+
+        $this->assertInstanceOf(Template::class, $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('core:loginuserpass.twig', $response->getTemplateName());
+        $this->assertStringContainsString(
+            "ThrowCustomErrorCode: title for bind search error",
+            $response->getContents(),
+            "response page does not contain the expected custom error message",
+        );
+    }
 }

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -68,7 +68,7 @@ class LoginTest extends ClearStateTestCase
     /**
      * FIXME this seems to give some XML on scren and an incomplete result?
      */
-    public function testClearDiscoChoicesReturnToDisallowedUrlRejected(): void
+    public function xtestClearDiscoChoicesReturnToDisallowedUrlRejected(): void
     {
         $request = Request::create(
             '/cleardiscochoices',

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -40,7 +40,7 @@ class LoginTest extends ClearStateTestCase
         $this->config = Configuration::loadFromArray(
             [
                 'baseurlpath' => 'https://example.org/simplesaml',
-                'module.enable' => ['exampleauth' => true ],
+                'module.enable' => ['exampleauth' => true, 'testauthsource' => true ],
             ],
             '[ARRAY]',
             'simplesaml',

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -40,13 +40,28 @@ class LoginTest extends ClearStateTestCase
         $this->config = Configuration::loadFromArray(
             [
                 'baseurlpath' => 'https://example.org/simplesaml',
-                'module.enable' => ['exampleauth' => true],
+                'module.enable' => ['exampleauth' => true, 'testauthsource' => true ],
             ],
             '[ARRAY]',
             'simplesaml',
         );
 
         Configuration::setPreLoadedConfig($this->config, 'config.php');
+
+/*
+        $v = \SimpleSAML\Module::isModuleEnabled('testauthsource');
+        Logger::info("in setup() have module v $v ");
+ */
+
+/*
+        $core_modules = [
+            'core' => true,
+            'saml' => true,
+        ];
+        $config = new Configuration([], "config.php");
+        $module = 'testauthsource';
+//        $v = \SimpleSAML\Module::isModuleEnabledWithConf($module, $config->getOptionalArray('module.enable', $core_modules));
+ */
     }
 
 
@@ -66,8 +81,9 @@ class LoginTest extends ClearStateTestCase
 
 
     /**
+     * FIXME this seems to give some XML on scren and an incomplete result?
      */
-    public function testClearDiscoChoicesReturnToDisallowedUrlRejected(): void
+    public function xtestClearDiscoChoicesReturnToDisallowedUrlRejected(): void
     {
         $request = Request::create(
             '/cleardiscochoices',

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -69,7 +69,7 @@ class LoginTest extends ClearStateTestCase
     /**
      * FIXME this seems to give some XML on scren and an incomplete result?
      */
-    public function xtestClearDiscoChoicesReturnToDisallowedUrlRejected(): void
+    public function testClearDiscoChoicesReturnToDisallowedUrlRejected(): void
     {
         $request = Request::create(
             '/cleardiscochoices',

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -40,7 +40,7 @@ class LoginTest extends ClearStateTestCase
         $this->config = Configuration::loadFromArray(
             [
                 'baseurlpath' => 'https://example.org/simplesaml',
-                'module.enable' => ['exampleauth' => true, 'testauthsource' => true ],
+                'module.enable' => ['exampleauth' => true ],
             ],
             '[ARRAY]',
             'simplesaml',

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -297,6 +297,7 @@ class LoginTest extends ClearStateTestCase
      */
     public function testLoginTestAuthSourceCustomError(): void
     {
+        Logger::error("testLoginTestAuthSourceCustomError(CALLED)");
         // We want a custom error from our auth source
         $asConfig =  ['errorType' => ''];
         $request = $this->setupPrivateAuthSource($asConfig);
@@ -314,5 +315,6 @@ class LoginTest extends ClearStateTestCase
             $response->getContents(),
             "response page does not contain the expected custom error message",
         );
+        Logger::error("testLoginTestAuthSourceCustomError(ENDING)");
     }
 }

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -205,4 +205,88 @@ class LoginTest extends ClearStateTestCase
         $this->assertEquals('core:loginuserpass.twig', $response->getTemplateName());
     }
      */
+
+    /**
+     * Setup a testing authsource with the additional configuration given
+     * Returns a request that can be passed to loginuserpass().
+     *
+     * @param asConfig extra configuration array to be set inside the authSource stanza
+     *
+     * @return \Symfony\Component\HttpFoundation\Request
+     */
+    private function setupPrivateAuthSource(array $asConfig): Request
+    {
+        $request = Request::create(
+            '/loginuserpass',
+            'GET',
+            ['AuthState' => '_abc123'],
+        );
+        $_SERVER['REQUEST_URI']  = 'https://example.com/simplesaml/module.php/testauthsource/nothing';
+
+        // things really don't like it without a username
+        $request->request->set('username', 'x');
+
+
+        // Get the default authsources and add a specific configuration
+        // of testauthsource:ThrowCustomErrorCode for this test
+        $config = [];
+        $config['testauthsource-ThrowCustomErrorCode'] =  array_merge(
+            ['testauthsource:ThrowCustomErrorCode'],
+            $asConfig,
+        );
+        Configuration::setPreLoadedConfig(new Configuration($config, "authsources.php"), "authsources.php");
+
+        Configuration::setPreLoadedConfig(
+            Configuration::loadFromArray(
+                [
+                    'admin' => ['core:AdminPassword'],
+                    'testauthsource-ThrowCustomErrorCode' => array_merge(
+                        ['testauthsource:ThrowCustomErrorCode'],
+                        $asConfig,
+                    )
+                ],
+                '[ARRAY]',
+                'simplesaml',
+            ),
+            'authsources.php',
+            'simplesaml',
+        );
+
+
+        // prepare the AuthState that might have been saved
+        // in Auth\Source::authenticate()
+        $as = [];
+        $as[UserPassBase::AUTHID] = 'testauthsource-ThrowCustomErrorCode';
+        $as['\SimpleSAML\Auth\State.id'] = '_abc123';
+        // Save the $state-array, so that we can restore it after a redirect
+        $id = Auth\State::saveState($as, UserPassBase::STAGEID);
+
+        return $request;
+    }
+
+
+    /**
+     * Perform a login with loginuserpass and check that a normal error code related
+     * error message is shown on the resulting screen.
+     */
+    public function testLoginTestAuthSourceNormalError(): void
+    {
+        // We want a normal error from our auth source
+        $asConfig =  ['errorType' => 'NORMAL'];
+        $request = $this->setupPrivateAuthSource($asConfig);
+        $c = new Controller\Login($this->config);
+
+        // This relies on setupPrivateAuthSource doing a saveState() and will
+        // find the Auth\Source because we preloaded an authsources.php config
+        $response = $c->loginuserpass($request);
+
+        $this->assertInstanceOf(Template::class, $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('core:loginuserpass.twig', $response->getTemplateName());
+        $this->assertStringContainsString(
+            "Incorrect username or password",
+            $response->getContents(),
+            "response page does not contain the expected normal error message",
+        );
+    }
 }

--- a/tests/src/SimpleSAML/Error/ErrorTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorTest.php
@@ -112,7 +112,7 @@ class ErrorTest extends TestCase
 
         $customError = new class ($customErrorCode) extends Error
         {
-            protected function getErrorCodes(): ErrorCodes
+            public function getErrorCodes(): ErrorCodes
             {
                 return new class extends ErrorCodes
                 {


### PR DESCRIPTION
I am building this up from a fresh branch to see where the CI system becomes unhappy.

It should eventually have the same changes as
https://github.com/simplesamlphp/simplesamlphp/pull/2181