### PR TITLE
Allow custom ErrorCodes subclasses through Login::handleLogin no test suite version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v6
+        uses: super-linter/super-linter/slim@v6.7.0
         env:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/modules/core/src/Controller/Login.php
+++ b/modules/core/src/Controller/Login.php
@@ -11,6 +11,7 @@ use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use SimpleSAML\Error\ErrorCodes;
 
 use function array_key_exists;
 use function substr;
@@ -128,9 +129,9 @@ class Login
      *
      * @para object ecc an instance of an ErrorCode or subclass
      */
-    public static function registerErrorCodeClass(\SimpleSAML\Error\ErrorCodes $ecc): void
+    public static function registerErrorCodeClass(ErrorCodes $ecc): void
     {
-        if (is_subclass_of($ecc, \SimpleSAML\Error\ErrorCodes::class, false)) {
+        if (is_subclass_of($ecc, ErrorCodes::class, false)) {
             $className = get_class($ecc);
             self::$registeredErrorCodeClasses[] = $className;
         }
@@ -309,7 +310,7 @@ class Login
         }
 
         $t->data['errorcode'] = $errorCode;
-        $t->data['errorcodes'] = Error\ErrorCodes::getAllErrorCodeMessages();
+        $t->data['errorcodes'] = ErrorCodes::getAllErrorCodeMessages();
         $t->data['errorparams'] = $errorParams;
 
         $className = $codeClass;
@@ -319,17 +320,17 @@ class Login
                     throw new Exception("Could not resolve error class. no class named '$className'.");
                 }
 
-                if (!is_subclass_of($className, \SimpleSAML\Error\ErrorCodes::class)) {
+                if (!is_subclass_of($className, ErrorCodes::class)) {
                     throw new Exception(
                         'Could not resolve error class: The class \'' . $className
-                        . '\' isn\'t a subclass of \'' . \SimpleSAML\Error\ErrorCodes::class . '\'.',
+                        . '\' isn\'t a subclass of \'' . ErrorCodes::class . '\'.',
                     );
                 }
 
-                $obj = Module::createObject($className, \SimpleSAML\Error\ErrorCodes::class);
+                $obj = Module::createObject($className, ErrorCodes::class);
                 $t->data['errorcodes'] = $obj->getAllErrorCodeMessages();
             } else {
-                if ($className != \SimpleSAML\Error\ErrorCodes::class) {
+                if ($className != ErrorCodes::class) {
                     throw new BuiltinException(
                         'The desired error code class is not found or of the wrong type ' . $className,
                     );

--- a/modules/core/src/Controller/Login.php
+++ b/modules/core/src/Controller/Login.php
@@ -315,7 +315,17 @@ class Login
         $className = $codeClass;
         if ($className) {
             if (in_array($className, self::$registeredErrorCodeClasses)) {
-                $className = Module::resolveNonModuleClass($className, \SimpleSAML\Error\ErrorCodes::class);
+                if (!class_exists($className)) {
+                    throw new Exception("Could not resolve error class. no class named '$className'.");
+                }
+
+                if (!is_subclass_of($className, \SimpleSAML\Error\ErrorCodes::class)) {
+                    throw new Exception(
+                        'Could not resolve error class: The class \'' . $className
+                        . '\' isn\'t a subclass of \'' . \SimpleSAML\Error\ErrorCodes::class . '\'.',
+                    );
+                }
+
                 $obj = Module::createObject($className, \SimpleSAML\Error\ErrorCodes::class);
                 $t->data['errorcodes'] = $obj->getAllErrorCodeMessages();
             } else {

--- a/src/SimpleSAML/Error/Error.php
+++ b/src/SimpleSAML/Error/Error.php
@@ -125,9 +125,12 @@ class Error extends Exception
      *
      * Extend this to use custom ErrorCodes instance (with custom error codes and their title / description tags).
      *
+     * This has to be public to allow Login to get an object
+     * containing custom error codes if they in use.
+     *
      * @return ErrorCodes
      */
-    protected function getErrorCodes(): ErrorCodes
+    public function getErrorCodes(): ErrorCodes
     {
         return new ErrorCodes();
     }

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Error;
 
 use SimpleSAML\Locale\Translate;
+use SimpleSAML\Module\core\Controller\Login;
 
 use function array_merge;
 
@@ -19,7 +20,7 @@ class ErrorCodes
     {
         // Automatically register instances of subclasses with Login to allow
         // custom ErrorCodes to work in a redirect environment
-        \SimpleSAML\Module\core\Controller\Login::registerErrorCodeClass($this);
+        Login::registerErrorCodeClass($this);
     }
 
     // TODO PHPv8.1 - Consider moving to final consts for these default error codes to prevent overrides.

--- a/src/SimpleSAML/Error/ErrorCodes.php
+++ b/src/SimpleSAML/Error/ErrorCodes.php
@@ -15,6 +15,13 @@ use function array_merge;
  */
 class ErrorCodes
 {
+    public function __construct()
+    {
+        // Automatically register instances of subclasses with Login to allow
+        // custom ErrorCodes to work in a redirect environment
+        \SimpleSAML\Module\core\Controller\Login::registerErrorCodeClass($this);
+    }
+
     // TODO PHPv8.1 - Consider moving to final consts for these default error codes to prevent overrides.
     public const ACSPARAMS = 'ACSPARAMS';
     public const ARSPARAMS = 'ARSPARAMS';

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -478,6 +478,67 @@ class Module
 
 
     /**
+     * Resolve non module class.
+     *
+     * This function takes a string on the form "<className>" and converts it to a class
+     * name. Note that the <className> might also include line number offsets after a colon character.
+     * The method can also check that the given class is a subclass of a specific class.
+     *
+     * This method can resolve classnames for local classes with a specific file offset in them.
+     * The file offset with append something like :43$f to the class name and thus will conflict
+     * if passed to resolveClass() because resolveClass() will interpret the string as
+     * module:class rather than class:offset
+     *
+     * Although fairly simple, this method was created to make a central location for such lookups.
+     *
+     * An exception will be thrown if the class can't be resolved.
+     *
+     * @param string      $id The string we should resolve.
+     * @param string|null $subclass The class should be a subclass of this class. Optional.
+     *
+     * @return string The classname.
+     *
+     * @throws \Exception If the class cannot be resolved.
+     */
+    public static function resolveNonModuleClass(string $className, ?string $subclass = null): string
+    {
+        if (!class_exists($className)) {
+            throw new Exception("Could not resolve '$id': no class named '$className'.");
+        }
+
+        if ($subclass !== null && !is_subclass_of($className, $subclass)) {
+            throw new Exception(
+                'Could not resolve \'' . $id . '\': The class \'' . $className
+                . '\' isn\'t a subclass of \'' . $subclass . '\'.',
+            );
+        }
+
+        return $className;
+    }
+
+    /**
+     * Create an object of a class returned by resolveNonModuleClass() or resolveClass().
+     *
+     * @param string The classname.
+     * @param string|null $subclass The class should be a subclass of this class. Optional.
+     *
+     * @return the new object
+     */
+    public static function createObject(string $className, ?string $subclass = null): object
+    {
+        $obj = new $className();
+        if ($subclass) {
+            if (!is_subclass_of($obj, $subclass, false)) {
+                throw new Exception(
+                    'Could not instantiate \'' . $className . '\': The class \'' . $className
+                    . '\' isn\'t a subclass of \'' . $subclass . '\'.',
+                );
+            }
+        }
+        return $obj;
+    }
+
+    /**
      * Get absolute URL to a specified module resource.
      *
      * This function creates an absolute URL to a resource stored under ".../modules/<module>/public/".

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -478,45 +478,6 @@ class Module
 
 
     /**
-     * Resolve non module class.
-     *
-     * This function takes a string on the form "<className>" and converts it to a class
-     * name. Note that the <className> might also include line number offsets after a colon character.
-     * The method can also check that the given class is a subclass of a specific class.
-     *
-     * This method can resolve classnames for local classes with a specific file offset in them.
-     * The file offset with append something like :43$f to the class name and thus will conflict
-     * if passed to resolveClass() because resolveClass() will interpret the string as
-     * module:class rather than class:offset
-     *
-     * Although fairly simple, this method was created to make a central location for such lookups.
-     *
-     * An exception will be thrown if the class can't be resolved.
-     *
-     * @param string      $id The string we should resolve.
-     * @param string|null $subclass The class should be a subclass of this class. Optional.
-     *
-     * @return string The classname.
-     *
-     * @throws \Exception If the class cannot be resolved.
-     */
-    public static function resolveNonModuleClass(string $className, ?string $subclass = null): string
-    {
-        if (!class_exists($className)) {
-            throw new Exception("Could not resolve '$id': no class named '$className'.");
-        }
-
-        if ($subclass !== null && !is_subclass_of($className, $subclass)) {
-            throw new Exception(
-                'Could not resolve \'' . $id . '\': The class \'' . $className
-                . '\' isn\'t a subclass of \'' . $subclass . '\'.',
-            );
-        }
-
-        return $className;
-    }
-
-    /**
      * Create an object of a class returned by resolveNonModuleClass() or resolveClass().
      *
      * @param string The classname.

--- a/tests/src/SimpleSAML/Error/ErrorTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorTest.php
@@ -112,7 +112,7 @@ class ErrorTest extends TestCase
 
         $customError = new class ($customErrorCode) extends Error
         {
-            protected function getErrorCodes(): ErrorCodes
+            public function getErrorCodes(): ErrorCodes
             {
                 return new class extends ErrorCodes
                 {


### PR DESCRIPTION
This is a version of https://github.com/simplesamlphp/simplesamlphp/pull/2181 without the test suite update.

I found a few side issues while trying to get the test suite update going so thought I would split out the code code here for consideration.

The goal is to allow a custom ErrorCodes subclasses to be used and have Login keep that association and be able to present information from those custom error codes on the web page.

This is an update to https://github.com/simplesamlphp/simplesamlphp/pull/2181

This relates to and should resolve issue https://github.com/simplesamlphp/simplesamlphp/issues/2133

The ErrorCodes subclass name needs to be saved in the state information in order to set data['errorcodes'] to the custom error code class later in the login method.

To restrict which classes can be used this way
Login::registerErrorCodeClass() explicitly tracks each errorcodes subclass. This is automatic in the constructor of ErrorCodes but it does mean that any subclass will need to be instantiated at least once before use or an explicit call to Login::registerErrorCodeClass made.

Although it is not strictly Module related I have put the resolveNonModuleClass() method in the module class for now to compliment the resolveClass() method. One needs the have the NonModule version to allow inline classes and the like to resolve as they contain the class name followed by a colon and number/offset information. That colon will make the resolveClass() assume we are dealing with a module:class specification.