### PR TITLE
Fix MDQ cache file bugs

### DIFF
--- a/src/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/src/SimpleSAML/Metadata/Sources/MDQ.php
@@ -130,7 +130,7 @@ class MDQ extends MetaDataStorageSource
         }
 
         $cachekey = sha1($entityId);
-        return $this->cacheDir . '/' . $set . '-' . $cachekey . '.cached.xml';
+        return $this->cacheDir . '/' . $set . '-' . $cachekey . '.cached.json';
     }
 
 

--- a/src/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/src/SimpleSAML/Metadata/Sources/MDQ.php
@@ -183,7 +183,8 @@ class MDQ extends MetaDataStorageSource
             ));
         }
 
-        $data = json_decode($rawData);
+        // ensure json is decoded as an associative array not an object
+        $data = json_decode($rawData, true);
         if ($data === false) {
             throw new Exception(
                 sprintf('%s: error unserializing cached data from file "%s".', __CLASS__, strval($file)),

--- a/src/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/src/SimpleSAML/Metadata/Sources/MDQ.php
@@ -218,8 +218,8 @@ class MDQ extends MetaDataStorageSource
 
         Logger::debug(sprintf('%s: Writing cache [%s] => [%s]', __CLASS__, $entityId, $cacheFileName));
 
-        /** @psalm-suppress TooManyArguments */
-        $this->fileSystem->appendToFile($cacheFileName, json_encode($data), true);
+        // using dumpFile instead of appendToFile here to replace any existing cache data
+        $this->fileSystem->dumpFile($cacheFileName, json_encode($data));
     }
 
 


### PR DESCRIPTION
Fixes #2199 

* The MDQ cache file is now explicitly decoded as an associative array to match subsequent code expectations.
* The MDQ cache file is overwritten instead of appended to, to prevent an ever-growing corrupt JSON file.
* The cache file extension was updated to `.json` instead of `.xml` to better reflect the content of the file.
  * If this change isn't wanted, please let me know and I can revert it.
  * I believe this change will also help anyone impacted by the growing cache file since the application will immediately stop trying to read a large file into memory.

The steps to reproduce from the linked issue verifies that the application is no longer re-querying MDQ metadata on every request, and the `<FILE> wasn't an array` errors are no longer appearing in the logs.