### PR TITLE
Bugfix: Continue unencrypted if no encryption key is available

### DIFF
--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -1453,11 +1453,8 @@ class SAML2
                 $key = new XMLSecurityKey(XMLSecurityKey::RSA_OAEP_MGF1P, ['type' => 'public']);
                 $key->loadKey($pemKey);
             } else {
-                throw new Error\ConfigurationError(
-                    'Missing encryption key for entity `' . $spMetadata->getString('entityid') . '`',
-                    $spMetadata->getString('metadata-set') . '.php',
-                    null,
-                );
+                // Our policy is to encrypt assertions, but without a key it cannot be done.
+                return $assertion;
             }
         }
 


### PR DESCRIPTION
See:  https://groups.google.com/g/simplesamlphp/c/PVX0f99OJqg

We can set `assertion.encrypted` all we want on our IdP-side, but if the SP doesn't provide a key it's useless. Instead of failing the hard way, see if the SP is willing to accept an unencrypted assertion.

Alternative: add another configuration flag that enforces the use of encryption. This could be a more generic flag to enforce SAML2INT compliance.