### PR TITLE
Bugfix/preloaded resource not used

### DIFF
--- a/src/SimpleSAML/XHTML/Template.php
+++ b/src/SimpleSAML/XHTML/Template.php
@@ -192,7 +192,7 @@ class Template extends Response
             // don't be too harsh if an asset is missing, just pretend it's there...
             return $path;
         }
-        
+
         if ($tag === false) {
             // The asset is requested without a tag
             return $path;

--- a/src/SimpleSAML/XHTML/Template.php
+++ b/src/SimpleSAML/XHTML/Template.php
@@ -191,7 +191,10 @@ class Template extends Response
         if (!$this->fileSystem->exists($file)) {
             // don't be too harsh if an asset is missing, just pretend it's there...
             return $path;
-        } elseif ($tag === false) {
+        }
+        
+        if ($tag === false) {
+            // The asset is requested without a tag
             return $path;
         }
 

--- a/src/SimpleSAML/XHTML/Template.php
+++ b/src/SimpleSAML/XHTML/Template.php
@@ -170,9 +170,10 @@ class Template extends Response
      * the original file.
      * @param string $asset
      * @param string|null $module
+     * @param bool $tag
      * @return string
      */
-    public function asset(string $asset, string $module = null): string
+    public function asset(string $asset, string $module = null, bool $tag = true): string
     {
         $baseDir = $this->configuration->getBaseDir();
         $basePath = $this->configuration->getBasePath();
@@ -190,7 +191,10 @@ class Template extends Response
         if (!$this->fileSystem->exists($file)) {
             // don't be too harsh if an asset is missing, just pretend it's there...
             return $path;
+        } elseif ($tag === false) {
+            return $path;
         }
+
         $file = new File($file);
 
         $tag = $this->configuration->getVersion();

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -6,9 +6,9 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <title>{{ pagetitle }}</title>
-    <link rel="preload" href="{{ asset('fonts/fa-solid-900.woff2', null, false) }}" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="{{ asset("css/stylesheet.css") }}">
     <link rel="icon" href="{{ asset("icons/favicon.ico") }}">
+    <link rel="preload" href="{{ asset('fonts/fa-solid-900.woff2', null, false) }}" as="font" type="font/woff2" crossorigin>
     <meta name="robots" content="noindex, nofollow">
     {{ include('_head.twig', ignore_missing = true) }}
     {% block preload %}{% endblock %}

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -8,6 +8,7 @@
     <title>{{ pagetitle }}</title>
     <link rel="stylesheet" href="{{ asset("css/stylesheet.css") }}">
     <link rel="icon" href="{{ asset("icons/favicon.ico") }}">
+    {# Preloading must be done after referencing the resource #}
     <link rel="preload" href="{{ asset('fonts/fa-solid-900.woff2', null, false) }}" as="font" type="font/woff2" crossorigin>
     <meta name="robots" content="noindex, nofollow">
     {{ include('_head.twig', ignore_missing = true) }}

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <title>{{ pagetitle }}</title>
-    <link rel="preload" href="{{ asset('fonts/fa-solid-900.woff2') }}" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{ asset('fonts/fa-solid-900.woff2', null, false) }}" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="{{ asset("css/stylesheet.css") }}">
     <link rel="icon" href="{{ asset("icons/favicon.ico") }}">
     <meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
Fixes console warning in Edge+Chrome:

The resource https://example.org/assets/base/fonts/fa-solid-900.woff2?tag=0656d was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.

I'm not sure why Firefox is still complaining, but at least this is an improvement.