### PR TITLE
i18n in 2.3 allow Brazilian to be selected again

### DIFF
--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -224,17 +224,6 @@ class Language
      */
     public function setLanguage(string $language, bool $setLanguageCookie = true): void
     {
-        $language = strtolower($language);
-
-        // @deprecated support these older names for now.
-        // @deprecated - remove entire if-block in a new major release
-        if ($language == 'pt_br') {
-            $language = 'pt_BR';
-        }
-        if ($language == 'zh_tw') {
-            $language = 'zh_TW';
-        }
-
         if (in_array($language, $this->availableLanguages, true)) {
             $this->language = $language;
             if ($setLanguageCookie === true) {

--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -224,7 +224,6 @@ class Language
      */
     public function setLanguage(string $language, bool $setLanguageCookie = true): void
     {
-        $language = strtolower($language);
         if (in_array($language, $this->availableLanguages, true)) {
             $this->language = $language;
             if ($setLanguageCookie === true) {

--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -420,7 +420,7 @@ class Language
         $name = $config->getOptionalString('language.cookie.name', 'language');
 
         if (isset($_COOKIE[$name])) {
-            $language = strtolower($_COOKIE[$name]);
+            $language = $_COOKIE[$name];
             if (in_array($language, $availableLanguages, true)) {
                 return $language;
             }

--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -224,6 +224,17 @@ class Language
      */
     public function setLanguage(string $language, bool $setLanguageCookie = true): void
     {
+        $language = strtolower($language);
+
+        // @deprecated support these older names for now.
+        // @deprecated - remove entire if-block in a new major release
+        if ($language == 'pt_br') {
+            $language = 'pt_BR';
+        }
+        if ($language == 'zh_tw') {
+            $language = 'zh_TW';
+        }
+
         if (in_array($language, $this->availableLanguages, true)) {
             $this->language = $language;
             if ($setLanguageCookie === true) {

--- a/tests/src/SimpleSAML/Locale/LanguageTest.php
+++ b/tests/src/SimpleSAML/Locale/LanguageTest.php
@@ -164,7 +164,7 @@ class LanguageTest extends TestCase
             'language.parameter.name' => 'xyz',
             'language.parameter.setcookie' => false,
         ], '', 'simplesaml');
-        $_GET['xyz'] = 'Es'; // test also that lang code is transformed to lower caps
+        $_GET['xyz'] = 'es';
         $l = new Language($c);
         $this->assertEquals('es', $l->getLanguage());
 


### PR DESCRIPTION
Changing this line allows Portuguese (Brazil) to be selectable from the language menu again in 2.3.

Note that setLanguageCookie() and getLanguageCookie() also contain forced lower casing which is worth investigating too in order to make sure things do not fall through the cracks there.