### PR TITLE
v23: allow admin password to be stored in config.php without hashing …

### DIFF
--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -61,6 +61,12 @@ class AdminPassword extends UserPassBase
 
         $pwinfo = password_get_info($adminPassword);
         if ($pwinfo['algo'] === null) {
+            // @deprecated: remove this in the future.
+            // Continue to allow admin login when the config contains
+            // a password that is not hashed
+            if ($adminPassword === $password) {
+                return ['user' => ['admin']];
+            }
             throw new Error\Error(Error\ErrorCodes::ADMINNOTHASHED);
         }
 


### PR DESCRIPTION
Given that this touches the admin login route directly, some more eyes to review are appreciated.

The code uses the result of `password_get_info` and if the `algo` is null then we know the `auth.adminpassword` from config.php is not set to a hashed password. At that stage the new lines do a direct string compare in the same way that `pwValid` does in 2.2 and used to in 2.3. More explicitly:
 https://github.com/simplesamlphp/simplesamlphp/blob/a9dc9579774e4aea4f147d11aee87b8030e3b0d5/src/SimpleSAML/Utils/Crypto.php#L379

This is the intent of the code. Admins can again put plaintext passwords in config.php for auth.adminpassword if desired. Hashing is recommended but not required any more and functionality returns to that of v2.2.

We can see a null for the password for example in the following test
```
php > var_dump(password_get_info("123"));
array(3) {
  ["algo"]=>
  NULL
  ["algoName"]=>
  string(7) "unknown"
  ["options"]=>
  array(0) {
  }
}

```

This was requested here https://github.com/simplesamlphp/simplesamlphp/pull/2216#issuecomment-2311931730

More information about the changes around the admin password hashing and how we got where we are in 2.3 is at https://github.com/simplesamlphp/simplesamlphp/issues/2212#issuecomment-2305550977
