### PR TITLE
plain text admin password follow-up

### DIFF
--- a/docs/simplesamlphp-upgrade-notes-2.3.md
+++ b/docs/simplesamlphp-upgrade-notes-2.3.md
@@ -32,8 +32,12 @@ The following properties were marked `deprecated` and will be removed in a next 
 
 ## BC break
 
-- Plain-text admin-passwords are no longer allowed.
-  Please use the `bin/pwgen.php` script to generate a secure password hash.
+- As of 2.3.1+ Plain-text admin-passwords are allowed again.
+  No change is needed to auth.adminpassword to upgrade from 2.2 to 2.3.1+.
+  In 2.3.0 only Plain-text admin-passwords were not allowed.
+
+  In either case you might like to use the `bin/pwgen.php` script to
+  generate a secure password hash for auth.adminpassword.
 
 - The language codes `pt-br` and `zh-tw` have been renamed to `pt_BR` and `zh_TW`.
   Please update your configuration to match the new names.

--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Module\core\Auth\Source;
 
 use SimpleSAML\Configuration;
 use SimpleSAML\Error;
+use SimpleSAML\Logger;
 use SimpleSAML\Module\core\Auth\UserPassBase;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
 
@@ -65,6 +66,9 @@ class AdminPassword extends UserPassBase
             // Continue to allow admin login when the config contains
             // a password that is not hashed
             if ($adminPassword === $password) {
+                Logger::deprecated('Please consider hashing the admin password stored in auth.adminpassword'
+                                 . ' in config.php. Using a plain text password in that config setting'
+                                 . ' will be removed in the future.');
                 return ['user' => ['admin']];
             }
             throw new Error\Error(Error\ErrorCodes::ADMINNOTHASHED);

--- a/src/SimpleSAML/Logger.php
+++ b/src/SimpleSAML/Logger.php
@@ -207,6 +207,15 @@ class Logger
         self::log(self::WARNING, $string);
     }
 
+    /**
+     * Log a warning about deprecated code.
+     *
+     * @param string $string The message to log.
+     */
+    public static function deprecated(string $string): void
+    {
+        self::log(self::WARNING, 'DEPRECATION WARNING: ' . $string);
+    }
 
     /**
      * We reserve the notice level for statistics, so do not use this level for other kind of log messages.


### PR DESCRIPTION
This is a follow up to https://github.com/simplesamlphp/simplesamlphp/pull/2222.

I added a new `deprecated` method to Logger. I think this is useful as there are many parts of the code that have `@depcreated` in comments. If that code is wanting to issue a warning then using a specific logger method signals exactly what the intent is.

The upgrade-notes-2.3.md are a little more complex but I tried to make the 2.3.1+ case the default and read easily for folks who are upgrading from 2.2 to 2.3.1+. I notice that the changelog is already updated https://github.com/simplesamlphp/simplesamlphp/commit/023688b50470076e04217726a3618f93e0e82797  to reflect the changes in https://github.com/simplesamlphp/simplesamlphp/pull/2222

We could refine the `Logger::deprecated` to have it's own DEPRECATED=8 and so on if we like. Having it has a WARNING behind the API call is a good start.
