### PR TITLE
bring the Logger deprecated method forward from 2.3

### DIFF
--- a/src/SimpleSAML/Logger.php
+++ b/src/SimpleSAML/Logger.php
@@ -228,6 +228,15 @@ class Logger
         self::log(self::WARNING, $string);
     }
 
+    /**
+     * Log a warning about deprecated code.
+     *
+     * @param string $string The message to log.
+     */
+    public static function deprecated(string $string): void
+    {
+        self::log(self::WARNING, 'DEPRECATION WARNING: ' . $string);
+    }
 
     /**
      * We reserve the notice level for statistics, so do not use this level for other kind of log messages.


### PR DESCRIPTION
I added the Logger deprecated method in https://github.com/simplesamlphp/simplesamlphp/pull/2223 to allow a clear statement that a logging message is about deprecated functionality that will be removed. 

The use in 2223 is not needed in master as the functionality was removed from there. The `deprecated` method is brought forward without a caller so it is not "missing" from master and doesn't cause an issue in the future if some code calling it is cherry picked.