### PR TITLE
Fix deprecation of Twig spaceless-filter

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -16,6 +16,11 @@ Released TBD
 `admin`
 
 * Fix metadata-viewer to output a valid PHP array
+* Fix text-overflow of the metadata-converter output-box
+
+Chores:
+
+* Solved deprecation notices in CI regarding the use of the Twig spaceless-filter (#2229)
 
 ## Version 2.3.0
 

--- a/modules/admin/templates/metadata_converter.twig
+++ b/modules/admin/templates/metadata_converter.twig
@@ -40,8 +40,8 @@
                 <i class="fa fa-copy"></i>
             </button>
         </div>
-        <div class="code-box-content">
-            <pre id="metadata{{ loop.index }}">{{ text|escape }}</pre>
+        <div id="metadata{{ loop.index }}" class="code-box-content">
+          {{- text|escape -}}
         </div>
     </div>
             <br><br>

--- a/modules/admin/templates/metadata_converter.twig
+++ b/modules/admin/templates/metadata_converter.twig
@@ -33,8 +33,6 @@
     <h2 id="converted">{{ 'Converted metadata'|trans }}</h2>
         {% for type, text in output -%}
             {%- if text -%}
-{# spaceless is to work around a clipboard.js bug that would add extra whitespace #}
-{% apply spaceless %}
     <div class="code-box">
         <div class="code-box-title">
             <h3>{{ type }}</h3>
@@ -46,7 +44,6 @@
             <pre id="metadata{{ loop.index }}">{{ text|escape }}</pre>
         </div>
     </div>
-{% endapply %}
             <br><br>
             {%- set i=i+1 %}
             {%- endif -%}

--- a/templates/_table.twig
+++ b/templates/_table.twig
@@ -7,17 +7,16 @@
             <td class="attrname">{{ name }}</td>
         {%- endblock %}
 
-        <td class="attrvalue">{% apply spaceless %}
-                {% for value in values %}
-                    {% if loop.length>1 and loop.first %}<ul>{% endif %}
-                    {% if loop.length>1 %}<li>{% endif -%}
+        <td class="attrvalue">
+            {% for value in values %}
+                {% if loop.length>1 and loop.first %}<ul>{% endif -%}
+                {%- if loop.length>1 %}<li>{% endif -%}
 
-                    {% block value %}{% endblock %}
+                {%- block value %}{% endblock -%}
 
-                    {% if loop.length>1 %}</li>{% endif %}
-                    {% if loop.length>1 and loop.last %}</ul>{% endif %}
-                {% endfor %}
-            {% endapply -%}
+                {%- if loop.length>1 %}</li>{% endif -%}
+                {%- if loop.length>1 and loop.last %}</ul>{% endif %}
+            {% endfor %}
         </td>
     </tr>
 {% endfor %}

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!DOCTYPE html>
 <html lang="{{ currentLanguage }}" dir="{{ isRTL ? 'rtl' : 'ltr' }}">
   <head>
@@ -33,4 +32,3 @@
     {% block postload %}{% endblock %}
   </body>
 </html>
-{% endapply %}


### PR DESCRIPTION
Closes #2228

The whitespace-issue turns out to be not a clipboard.js issue, but appears to be related to the `<pre>`-tag.