### PR TITLE
Fixes to encryption optional

### DIFF
--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -1436,7 +1436,7 @@ class SAML2
             $key = new XMLSecurityKey($algo);
             $key->loadKey($sharedKey);
         } else {
-            $keys = $spMetadata->getPublicKeys('encryption', true);
+            $keys = $spMetadata->getPublicKeys('encryption');
             if (!empty($keys)) {
                 $key = $keys[0];
                 switch ($key['type']) {

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1415,7 +1415,9 @@ class Configuration implements Utils\ClearableState
                 }
                 $ret[] = $key;
             }
-            return $ret;
+            if (!empty($ret)) {
+                return $ret;
+            }
         } elseif ($this->hasValue($prefix . 'certData')) {
             $certData = $this->getString($prefix . 'certData');
             $certData = preg_replace('/\s+/', '', $certData);
@@ -1460,7 +1462,10 @@ class Configuration implements Utils\ClearableState
                     'X509Certificate' => $certData,
                 ],
             ];
-        } elseif ($required === true) {
+        }
+
+        // If still here, we didn't find a certificate of the requested use
+        if ($required === true) {
             throw new Error\Exception($this->location . ': Missing certificate in metadata.');
         } else {
             return [];


### PR DESCRIPTION
The new feature from f99217b43 only worked if a signing cert was present. With no certs present, getPublicKeys threw an exception. Fixed the call from encryptAssertion to getPublicKeys to not require that a key be returned.

Also fixed logic in getPublicKeys
in Configuration.php. Previous logic would return an empty array if a use type was passed in but no keys of that type were found even if required was set to true. Thus, the encryptAssertion bug didn't appear until we had an SP with no certs at all rather than just one without an encryption cert.