### PR TITLE
New 'identifyingAttribute option for SAML Attribute NameID filter

### DIFF
--- a/modules/saml/docs/nameid.md
+++ b/modules/saml/docs/nameid.md
@@ -32,7 +32,8 @@ Uses the value of an attribute to generate a NameID.
 `identifyingAttributes`
 :   An array of attribute names to consider for the unique user ID.
 :   The first attribute found in this array that's being released to the SP
-:   will be used.
+:   will be used. Note that using this option means you must not also use 
+:   identifyingAttribute.
 
 `Format`
 :   The `Format` attribute of the generated NameID.

--- a/modules/saml/docs/nameid.md
+++ b/modules/saml/docs/nameid.md
@@ -29,6 +29,11 @@ Uses the value of an attribute to generate a NameID.
 `identifyingAttribute`
 :   The name of the attribute we should use as the unique user ID.
 
+`identifyingAttributes`
+:   An array of attribute names to consider for the unique user ID.
+:   The first attribute found in this array that's being released to the SP
+:   will be used.
+
 `Format`
 :   The `Format` attribute of the generated NameID.
 
@@ -113,7 +118,7 @@ This example makes three NameIDs available:
         ],
         3 => [
             'class' => 'saml:AttributeNameID',
-            'identifyingAttribute' => 'mail',
+            'identifyingAttributes' => ['mail','eduPersonPrincipalName'],
             'Format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
         ],
     ],

--- a/modules/saml/docs/nameid.md
+++ b/modules/saml/docs/nameid.md
@@ -32,7 +32,7 @@ Uses the value of an attribute to generate a NameID.
 `identifyingAttributes`
 :   An array of attribute names to consider for the unique user ID.
 :   The first attribute found in this array that's being released to the SP
-:   will be used. Note that using this option means you must not also use 
+:   will be used. Note that using this option means you must not also use
 :   identifyingAttribute.
 
 `Format`

--- a/modules/saml/src/Auth/Process/AttributeNameID.php
+++ b/modules/saml/src/Auth/Process/AttributeNameID.php
@@ -36,8 +36,8 @@ class AttributeNameID extends BaseNameIDGenerator
      * @param array $config Configuration information about this filter.
      * @param mixed $reserved For future use.
      *
-     * @throws \SimpleSAML\Error\Exception If the required options 'Format' or both 'identifyingAttribute'
-     *  and 'identifyingAttributes' are missing.
+     * @throws \SimpleSAML\Error\Exception If the required options 'Format' or 'identifyingAttribute'
+     *  and 'identifyingAttributes' are either both missing or both set.
      */
     public function __construct(array $config, $reserved)
     {
@@ -49,13 +49,17 @@ class AttributeNameID extends BaseNameIDGenerator
         $this->format = (string) $config['Format'];
 
         if (!isset($config['identifyingAttribute']) && !isset($config['identifyingAttributes'])) {
-            throw new Error\Exception("AttributeNameID: Missing required option one of 'identifyingAttribute' or 'identifyingAttributes'.");
+            throw new Error\Exception("AttributeNameID: Missing required " .
+            "option one of 'identifyingAttribute' or 'identifyingAttributes'.");
+        } elseif (isset($config['identifyingAttribute']) && isset($config['identifyingAttributes'])) {
+            throw new Error\Exception("AttributeNameID: Options " .
+            "'identifyingAttribute' and 'identifyingAttributes' are mutually " .
+            "exclusive but both were provided.");
         }
 
         if (isset($config['identifyingAttribute'])) {
             $this->identifyingAttributes[0] = (string) $config['identifyingAttribute'];
-        }
-        else {
+        } else {
             $this->identifyingAttributes = (array) $config['identifyingAttributes'];
         }
     }

--- a/modules/saml/src/Auth/Process/AttributeNameID.php
+++ b/modules/saml/src/Auth/Process/AttributeNameID.php
@@ -21,11 +21,13 @@ use function var_export;
 class AttributeNameID extends BaseNameIDGenerator
 {
     /**
-     * The attribute we should use as the NameID.
+     * A list of possible attributes we can use as the NameID.
+     * The first one found in the attributes being released to the SP
+     * will be used.
      *
-     * @var string
+     * @var array
      */
-    private string $identifyingAttribute;
+    private array $identifyingAttributes;
 
 
     /**
@@ -34,7 +36,8 @@ class AttributeNameID extends BaseNameIDGenerator
      * @param array $config Configuration information about this filter.
      * @param mixed $reserved For future use.
      *
-     * @throws \SimpleSAML\Error\Exception If the required options 'Format' or 'identifyingAttribute' are missing.
+     * @throws \SimpleSAML\Error\Exception If the required options 'Format' or both 'identifyingAttribute'
+     *  and 'identifyingAttributes' are missing.
      */
     public function __construct(array $config, $reserved)
     {
@@ -45,10 +48,16 @@ class AttributeNameID extends BaseNameIDGenerator
         }
         $this->format = (string) $config['Format'];
 
-        if (!isset($config['identifyingAttribute'])) {
-            throw new Error\Exception("AttributeNameID: Missing required option 'identifyingAttribute'.");
+        if (!isset($config['identifyingAttribute']) && !isset($config['identifyingAttributes'])) {
+            throw new Error\Exception("AttributeNameID: Missing required option one of 'identifyingAttribute' or 'identifyingAttributes'.");
         }
-        $this->identifyingAttribute = (string) $config['identifyingAttribute'];
+
+        if (isset($config['identifyingAttribute'])) {
+            $this->identifyingAttributes[0] = (string) $config['identifyingAttribute'];
+        }
+        else {
+            $this->identifyingAttributes = (array) $config['identifyingAttributes'];
+        }
     }
 
 
@@ -60,35 +69,43 @@ class AttributeNameID extends BaseNameIDGenerator
      */
     protected function getValue(array &$state): ?string
     {
-        if (
-            !isset($state['Attributes'][$this->identifyingAttribute])
-            || count($state['Attributes'][$this->identifyingAttribute]) === 0
-        ) {
-            Logger::warning(
-                'Missing attribute ' . var_export($this->identifyingAttribute, true) .
-                ' on user - not generating attribute NameID.',
-            );
-            return null;
-        }
-        if (count($state['Attributes'][$this->identifyingAttribute]) > 1) {
-            Logger::warning(
-                'More than one value in attribute ' . var_export($this->identifyingAttribute, true) .
-                ' on user - not generating attribute NameID.',
-            );
-            return null;
-        }
-        // just in case the first index is no longer 0
-        $value = array_values($state['Attributes'][$this->identifyingAttribute]);
-        $value = strval($value[0]);
+        foreach ($this->identifyingAttributes as $attr) {
+            if (
+                !isset($state['Attributes'][$attr])
+                || count($state['Attributes'][$attr]) === 0
+            ) {
+                Logger::warning(
+                    'Missing attribute ' . var_export($attr, true) .
+                    ' on user - not using for attribute NameID.',
+                );
+                continue;
+            }
+            if (count($state['Attributes'][$attr]) > 1) {
+                Logger::warning(
+                    'More than one value in attribute ' . var_export($attr, true) .
+                    ' on user - not using for attribute NameID.',
+                );
+                continue;
+            }
+            // just in case the first index is no longer 0
+            $value = array_values($state['Attributes'][$attr]);
+            $value = strval($value[0]);
 
-        if (empty($value)) {
-            Logger::warning(
-                'Empty value in attribute ' . var_export($this->identifyingAttribute, true) .
-                ' on user - not generating attribute NameID.',
-            );
+            if (empty($value)) {
+                Logger::warning(
+                    'Empty value in attribute ' . var_export($attr, true) .
+                    ' on user - not using for attribute NameID.',
+                );
+                continue;
+            }
+            // If we're still here, we found an attribute value for NameID
+            break;
+        }
+        unset($attr);
+
+        if (!isset($value)) {
             return null;
         }
-
         return $value;
     }
 }

--- a/modules/saml/src/Auth/Process/AttributeNameID.php
+++ b/modules/saml/src/Auth/Process/AttributeNameID.php
@@ -74,36 +74,34 @@ class AttributeNameID extends BaseNameIDGenerator
     protected function getValue(array &$state): ?string
     {
         foreach ($this->identifyingAttributes as $attr) {
-            if (
-                !isset($state['Attributes'][$attr])
-                || count($state['Attributes'][$attr]) === 0
-            ) {
+            if (isset($state['Attributes'][$attr])) {
+                if (count($state['Attributes'][$attr]) === 1) {
+                    // just in case the first index is no longer 0
+                    $value = array_values($state['Attributes'][$attr]);
+                    $value = strval($value[0]);
+
+                    if (!empty($value)) {
+                        // Found the attribute
+                        break;
+                    } else { // empty value
+                        unset($value);
+                        Logger::warning(
+                            'Empty value in attribute ' . var_export($attr, true) .
+                            ' on user - not using for attribute NameID.',
+                        );
+                    }
+                } else { // multi-valued attribute
+                    Logger::warning(
+                        'More than one value in attribute ' . var_export($attr, true) .
+                        ' on user - not using for attribute NameID.',
+                    );
+                }
+            } else { // attribute not returned
                 Logger::warning(
                     'Missing attribute ' . var_export($attr, true) .
                     ' on user - not using for attribute NameID.',
                 );
-                continue;
             }
-            if (count($state['Attributes'][$attr]) > 1) {
-                Logger::warning(
-                    'More than one value in attribute ' . var_export($attr, true) .
-                    ' on user - not using for attribute NameID.',
-                );
-                continue;
-            }
-            // just in case the first index is no longer 0
-            $value = array_values($state['Attributes'][$attr]);
-            $value = strval($value[0]);
-
-            if (empty($value)) {
-                Logger::warning(
-                    'Empty value in attribute ' . var_export($attr, true) .
-                    ' on user - not using for attribute NameID.',
-                );
-                continue;
-            }
-            // If we're still here, we found an attribute value for NameID
-            break;
         }
         unset($attr);
 

--- a/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
@@ -38,8 +38,8 @@ class AttributeNameIDTest extends TestCase
     public function testMinimalConfig(): void
     {
         $config = [];
-        $spId = 'eugen:sp';
-        $idpId = 'eugene:idp';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
         $expectedEmail = 'foo@there';
 
         $config = [
@@ -73,8 +73,8 @@ class AttributeNameIDTest extends TestCase
     public function testSuccessInThirdElement(): void
     {
         $config = [];
-        $spId = 'eugen:sp';
-        $idpId = 'eugene:idp';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
         $expectedEmail = 'foo@there';
 
         $config = [
@@ -108,8 +108,8 @@ class AttributeNameIDTest extends TestCase
     public function testNotFound(): void
     {
         $config = [];
-        $spId = 'eugen:sp';
-        $idpId = 'eugene:idp';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
         $expectedEmail = 'foo@there';
 
         $config = [

--- a/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\Module\saml\Auth\Process;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Error;
+use SimpleSAML\Module\saml\Auth\Process\AttributeNameID;
+use SimpleSAML\SAML2\Constants as C;
+use SimpleSAML\SAML2\XML\saml\NameID;
+
+/**
+ * Test for the AttributeNameID filter.
+ *
+ * @package SimpleSAMLphp
+ */
+#[CoversClass(AttributeNameID::class)]
+class AttributeNameIDTest extends TestCase
+{
+    /**
+     * Helper function to run the filter with a given configuration.
+     *
+     * @param array $config  The filter configuration.
+     * @param array $request  The request state.
+     * @return array  The state array after processing.
+     */
+    private function processFilter(array $config, array $request): array
+    {
+        $filter = new AttributeNameID($config, null);
+        $filter->process($request);
+        return $request;
+    }
+
+
+    /**
+     * Test minimal configuration.
+     */
+    public function testMinimalConfig(): void
+    {
+        $config = [];
+        $spId = 'eugen:sp';
+        $idpId = 'eugene:idp';
+        $expectedEmail = 'foo@there';
+
+        $config = [
+            'class' => 'saml:AttributeNameID',
+            'identifyingAttributes' => ['mail','eduPersonPrincipalName'],
+            'Format' => C::NAMEID_PERSISTENT,
+        ];
+
+        $request = [
+            'Source'     => [
+                'entityid' => $spId,
+            ],
+            'Destination' => [
+                'entityid' => $idpId,
+            ],
+            'Attributes' => [
+                'eduPersonPrincipalName' => ['foo@there'],
+            ],
+        ];
+        $result = $this->processFilter($config, $request);
+        $this->assertNotNull($result['saml:NameID']);
+        $resultNameId = $result['saml:NameID'][C::NAMEID_PERSISTENT];
+        $this->assertNotNull($resultNameId);
+        $this->assertEquals($expectedEmail,$resultNameId->toArray()['value']);
+    }
+
+
+    /**
+     * Test third element in chain
+     */
+    public function testSuccessInThirdElement(): void
+    {
+        $config = [];
+        $spId = 'eugen:sp';
+        $idpId = 'eugene:idp';
+        $expectedEmail = 'foo@there';
+
+        $config = [
+            'class' => 'saml:AttributeNameID',
+            'identifyingAttributes' => ['mail','somethingelse','eduPersonPrincipalName'],
+            'Format' => C::NAMEID_PERSISTENT,
+        ];
+
+        $request = [
+            'Source'     => [
+                'entityid' => $spId,
+            ],
+            'Destination' => [
+                'entityid' => $idpId,
+            ],
+            'Attributes' => [
+                'eduPersonPrincipalName' => ['foo@there'],
+            ],
+        ];
+        $result = $this->processFilter($config, $request);
+        $this->assertNotNull($result['saml:NameID']);
+        $resultNameId = $result['saml:NameID'][C::NAMEID_PERSISTENT];
+        $this->assertNotNull($resultNameId);
+        $this->assertEquals($expectedEmail,$resultNameId->toArray()['value']);
+    }
+
+
+    /**
+     * Test attributes in list not found.
+     */
+    public function testNotFound(): void
+    {
+        $config = [];
+        $spId = 'eugen:sp';
+        $idpId = 'eugene:idp';
+        $expectedEmail = 'foo@there';
+
+        $config = [
+            'class' => 'saml:AttributeNameID',
+            'identifyingAttributes' => ['mail','eduPersonPrincipalName'],
+            'Format' => C::NAMEID_PERSISTENT,
+        ];
+
+        $request = [
+            'Source'     => [
+                'entityid' => $spId,
+            ],
+            'Destination' => [
+                'entityid' => $idpId,
+            ],
+            'Attributes' => [
+                'magic' => ['foo@there'],
+            ],
+        ];
+        $result = $this->processFilter($config, $request);
+        $this->assertNull($result['saml:NameID']);
+    }
+
+}

--- a/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
@@ -6,10 +6,8 @@ namespace SimpleSAML\Test\Module\saml\Auth\Process;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\Error;
 use SimpleSAML\Module\saml\Auth\Process\AttributeNameID;
 use SimpleSAML\SAML2\Constants as C;
-use SimpleSAML\SAML2\XML\saml\NameID;
 
 /**
  * Test for the AttributeNameID filter.
@@ -65,7 +63,7 @@ class AttributeNameIDTest extends TestCase
         $this->assertNotNull($result['saml:NameID']);
         $resultNameId = $result['saml:NameID'][C::NAMEID_PERSISTENT];
         $this->assertNotNull($resultNameId);
-        $this->assertEquals($expectedEmail,$resultNameId->toArray()['value']);
+        $this->assertEquals($expectedEmail, $resultNameId->toArray()['value']);
     }
 
 
@@ -100,7 +98,7 @@ class AttributeNameIDTest extends TestCase
         $this->assertNotNull($result['saml:NameID']);
         $resultNameId = $result['saml:NameID'][C::NAMEID_PERSISTENT];
         $this->assertNotNull($resultNameId);
-        $this->assertEquals($expectedEmail,$resultNameId->toArray()['value']);
+        $this->assertEquals($expectedEmail, $resultNameId->toArray()['value']);
     }
 
 
@@ -134,5 +132,4 @@ class AttributeNameIDTest extends TestCase
         $result = $this->processFilter($config, $request);
         $this->assertNull($result['saml:NameID']);
     }
-
 }


### PR DESCRIPTION
Allow a new option in place of identifyingAttribute called identifyingAttributes. This option expects an array of attribute names. The first one in the list that's available in the attributes being released to the SP will be used. This is particularly useful in the hosted IdP configuration. One can specify multiple attribute names in order of precedence, and the IdP will release the first one from that list to the SP that's in the SP's 'attributes' array. This avoids having to define a new authproc filter for each SP that needs a different value than the single one that was previously specified using 'identifyingAttribute'.

The change still supports identifyingAttribute option which will be used instead of the new option if both are set.