### PR TITLE
docs: update SP example to use the non string endpoint format

### DIFF
--- a/docs/simplesamlphp-sp.md
+++ b/docs/simplesamlphp-sp.md
@@ -96,13 +96,14 @@ $metadata['https://example.org/saml-idp'] = [
           'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ],
     ],
-    'SingleLogoutService'  => [
+    'SingleLogoutService' => [
         [
           'Location' => 'https://example.org/simplesaml/saml2/idp/SingleLogoutService.php',
           'ResponseLocation' => 'https://sp.example.org/LogoutResponse',
           'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ],
-  ],
+    ],
+    'certificate' => 'example.pem',
 ];
 ```
 

--- a/docs/simplesamlphp-sp.md
+++ b/docs/simplesamlphp-sp.md
@@ -90,9 +90,19 @@ metadata file:
 ```php
 <?php
 $metadata['https://example.org/saml-idp'] = [
-    'SingleSignOnService'  => 'https://example.org/simplesaml/saml2/idp/SSOService.php',
-    'SingleLogoutService'  => 'https://example.org/simplesaml/saml2/idp/SingleLogoutService.php',
-    'certificate'          => 'example.pem',
+    'SingleSignOnService' => [
+        [
+          'Location' => ''https://example.org/simplesaml/saml2/idp/SSOService.php',
+          'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+    ],
+    'SingleLogoutService'  => [
+        [
+          'Location' => 'https://example.org/simplesaml/saml2/idp/SingleLogoutService.php',
+          'ResponseLocation' => 'https://sp.example.org/LogoutResponse',
+          'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+  ],
 ];
 ```
 


### PR DESCRIPTION
The endpoints docs were updated here https://github.com/simplesamlphp/simplesamlphp/commit/28f21e762ad80cbbdd661cf0381b0da0b7411e93 to remove the single string format.

This PR updates the Service Provider QuickStart to not used the old single string format.

This was reported in https://github.com/simplesamlphp/simplesamlphp/issues/2258
