### PR TITLE
Move the endpoint breaking change to the "BC break" section

### DIFF
--- a/docs/simplesamlphp-upgrade-notes-2.3.md
+++ b/docs/simplesamlphp-upgrade-notes-2.3.md
@@ -6,11 +6,6 @@ The following changes are relevant for installers and/or developers.
 - Session ID's are now hashed when stored in a database. This means all old sessions are effectively
   invalidated by this upgrade. We recommend clearing your session store as part of the upgrade-routine.
 
-- Endpoints are now only accepted in array-style. The old string-style was deprecated for 9 yrs
-  already and was broken anyway. See [endpoints]
-
-[endpoints]: https://simplesamlphp.org/docs/stable/simplesamlphp-metadata-endpoints.html
-
 ## Deprecations
 
 The following classes were marked `deprecated` and will be removed in a next major release.
@@ -37,3 +32,8 @@ The following properties were marked `deprecated` and will be removed in a next 
 
 - The language codes `pt-br` and `zh-tw` have been renamed to `pt_BR` and `zh_TW`.
   Please update your configuration to match the new names.
+
+- Endpoints are now only accepted in array-style. The old string-style was deprecated for 9 yrs
+  already and was broken anyway. See [endpoints]
+
+[endpoints]: https://simplesamlphp.org/docs/stable/simplesamlphp-metadata-endpoints.html


### PR DESCRIPTION
I realize the endpoint format change may have been omitted from the breaking change section because of the "9-year" deprecation. That, however, does not change the fact that it is actually a breaking change. This was also identified as a breaking change in the [commit](https://github.com/simplesamlphp/simplesamlphp/commit/f0189fd1e69e2d92034c5818d4b8a2586d270483) message.