### PR TITLE
Remove non-existing language

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -829,7 +829,7 @@ $config = [
     'language.available' => [
         'en', 'no', 'nn', 'se', 'da', 'de', 'sv', 'fi', 'es', 'ca', 'fr', 'it', 'nl', 'lb',
         'cs', 'sk', 'sl', 'lt', 'hr', 'hu', 'pl', 'pt', 'pt_BR', 'tr', 'ja', 'zh', 'zh_TW',
-        'ru', 'et', 'he', 'id', 'sr', 'lv', 'ro', 'eu', 'el', 'af', 'zu', 'xh', 'st',
+        'ru', 'et', 'he', 'id', 'sr', 'lv', 'ro', 'eu', 'el', 'af', 'zu', 'xh',
     ],
     'language.rtl' => ['ar', 'dv', 'fa', 'ur', 'he'],
     'language.default' => 'en',

--- a/tests/src/SimpleSAML/Locale/LanguageTest.php
+++ b/tests/src/SimpleSAML/Locale/LanguageTest.php
@@ -96,7 +96,7 @@ class LanguageTest extends TestCase
     {
         // test non-existent langs
         $c = Configuration::loadFromArray([
-            'language.available' => ['foo', 'baz'],
+            'language.available' => ['foo', 'baz', 'st'],
         ], '', 'simplesaml');
         $l = new Language($c);
         $l->setLanguage('foo');


### PR DESCRIPTION
Follow up for #2089 .

At the moment, using default config file would produce `ERROR Language "st" not installed. Check config.`