### PR TITLE
Destroy session cookies on logout

### DIFF
--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -579,7 +579,12 @@ class ServiceProvider
 
             $state = $this->authState::loadState($relayState, 'saml:slosent');
             $state['saml:sp:LogoutStatus'] = $message->getStatus();
-            return $source::completeLogout($state);
+
+            // Destroy session cookies.
+            $session = Session::getSessionFromRequest();
+            $session->updateSessionCookies(['expire' => TRUE]);
+
+	    return $source::completeLogout($state);
         } elseif ($message instanceof LogoutRequest) {
             Logger::debug('module/saml2/sp/logout: Request from ' . $idpEntityId);
             Logger::stats('saml20-idp-SLO idpinit ' . $spEntityId . ' ' . $idpEntityId);

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -581,8 +581,7 @@ class ServiceProvider
             $state['saml:sp:LogoutStatus'] = $message->getStatus();
 
             // Destroy session cookies.
-            $session = Session::getSessionFromRequest();
-            $session->updateSessionCookies(['expire' => TRUE]);
+            $this->session->updateSessionCookies(['expire' => TRUE]);
 
 	        return $source::completeLogout($state);
         } elseif ($message instanceof LogoutRequest) {

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -584,7 +584,7 @@ class ServiceProvider
             $session = Session::getSessionFromRequest();
             $session->updateSessionCookies(['expire' => TRUE]);
 
-	    return $source::completeLogout($state);
+	        return $source::completeLogout($state);
         } elseif ($message instanceof LogoutRequest) {
             Logger::debug('module/saml2/sp/logout: Request from ' . $idpEntityId);
             Logger::stats('saml20-idp-SLO idpinit ' . $spEntityId . ' ' . $idpEntityId);

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -581,9 +581,9 @@ class ServiceProvider
             $state['saml:sp:LogoutStatus'] = $message->getStatus();
 
             // Destroy session cookies.
-            $this->session->updateSessionCookies(['expire' => TRUE]);
+            $this->session->updateSessionCookies(['expire' => true]);
 
-	        return $source::completeLogout($state);
+            return $source::completeLogout($state);
         } elseif ($message instanceof LogoutRequest) {
             Logger::debug('module/saml2/sp/logout: Request from ' . $idpEntityId);
             Logger::stats('saml20-idp-SLO idpinit ' . $spEntityId . ' ' . $idpEntityId);


### PR DESCRIPTION
During a security review it was found:

_It was possible to retrieve the authentication cookies from the browser and reuse this to
continue on the target website using a different browser and without any authentication.
The cookie and the SAML authentication token were set to HTTPOnly to strengthen the
security of the cookie.
It would be possible to extract the authentication details using CSRF techniques and use
these details to authenticate against the target web application. Similar behaviour would
be observed by users where the application would not request login credentials if the
expire duration has not been reached yet._

Therefore it seems the simplesamlphp cookies should be deleted on logout. I'm not sure if this cookie expiry is perhaps better done in `doLogout()`.