### PR TITLE
syntax highlighting for php.dist files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,4 @@ phpunit.xml export-ignore
 .markdownlintignore export-ignore
 .markdownlint.yml export-ignore
 .markdownlintrc export-ignore
+*.php.dist linguist-language=php


### PR DESCRIPTION
This adds syntax highlighting to the various `*.php.dist` files (such as those in `config` and `metadata`.