### PR TITLE
dist files: update endpoints to new array only format

### DIFF
--- a/metadata/saml20-sp-remote.php.dist
+++ b/metadata/saml20-sp-remote.php.dist
@@ -10,8 +10,20 @@
  * Example SimpleSAMLphp SAML 2.0 SP
  */
 $metadata['https://saml2sp.example.org'] = [
-    'AssertionConsumerService' => 'https://saml2.example.org/module.php/saml/sp/saml2-acs.php/default-sp',
-    'SingleLogoutService' => 'https://saml2sp.example.org/module.php/saml/sp/saml2-logout.php/default-sp',
+    'AssertionConsumerService' => [
+        [
+            'index' => 1,
+            'isDefault' => true,
+            'Location' => 'https://saml2.example.org/module.php/saml/sp/saml2-acs.php/default-sp',
+            'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        ],
+    ],
+    'SingleLogoutService' =>  => [
+        [
+            'Location' => 'https://saml2sp.example.org/module.php/saml/sp/saml2-logout.php/default-sp',
+            'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+    ],
 ];
 
 /*
@@ -22,7 +34,14 @@ $metadata['https://saml2sp.example.org'] = [
  * this user has the value of 'john'.
  */
 $metadata['google.com'] = [
-    'AssertionConsumerService' => 'https://www.google.com/a/g.feide.no/acs',
+    'AssertionConsumerService' => [
+        [
+            'index' => 1,
+            'isDefault' => true,
+            'Location' => 'https://www.google.com/a/g.feide.no/acs',
+            'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        ],
+    ], 
     'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
     'authproc' => [
       1 => [
@@ -34,8 +53,17 @@ $metadata['google.com'] = [
     'simplesaml.attributes' => false,
 ];
 
+
 $metadata['https://legacy.example.edu'] = [
-    'AssertionConsumerService' => 'https://legacy.example.edu/saml/acs',
+    'AssertionConsumerService' =>  => [
+        [
+            'index' => 1,
+            'isDefault' => true,
+            'Location' => 'https://legacy.example.edu/saml/acs',
+            'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        ],
+    ],
+    
     /*
      * Currently, SimpleSAMLphp defaults to the SHA-256 hashing algorithm.
      * Uncomment the following option to use SHA-1 for signatures directed


### PR DESCRIPTION
Update the endpoints in the php.dist files to the new only array of arrays format.

Raised in https://github.com/simplesamlphp/simplesamlphp/issues/2258