### PR TITLE
Add gettext compatible headers to PO files

### DIFF
--- a/bin/translations
+++ b/bin/translations
@@ -9,7 +9,11 @@ use Symfony\Component\Console\Application;
 umask(000);
 set_time_limit(0);
 
-require __DIR__.'/../vendor/autoload.php';
+if (str_ends_with(__DIR__, '/vendor/simplesamlphp/simplesamlphp/bin')) {
+    require __DIR__.'/../../../autoload.php';
+} else {
+    require __DIR__.'/../vendor/autoload.php';
+}
 
 $application = new Application();
 $application->add(new UnusedTranslatableStringsCommand());

--- a/locales/af/LC_MESSAGES/messages.po
+++ b/locales/af/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/ar/LC_MESSAGES/messages.po
+++ b/locales/ar/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/ca/LC_MESSAGES/messages.po
+++ b/locales/ca/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/cs/LC_MESSAGES/messages.po
+++ b/locales/cs/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/da/LC_MESSAGES/messages.po
+++ b/locales/da/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/de/LC_MESSAGES/messages.po
+++ b/locales/de/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/el/LC_MESSAGES/messages.po
+++ b/locales/el/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/en/LC_MESSAGES/messages.po
+++ b/locales/en/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/es/LC_MESSAGES/messages.po
+++ b/locales/es/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/et/LC_MESSAGES/messages.po
+++ b/locales/et/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/eu/LC_MESSAGES/messages.po
+++ b/locales/eu/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/fi/LC_MESSAGES/messages.po
+++ b/locales/fi/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/fr/LC_MESSAGES/messages.po
+++ b/locales/fr/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/he/LC_MESSAGES/messages.po
+++ b/locales/he/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/hr/LC_MESSAGES/messages.po
+++ b/locales/hr/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/hu/LC_MESSAGES/messages.po
+++ b/locales/hu/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/id/LC_MESSAGES/messages.po
+++ b/locales/id/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/it/LC_MESSAGES/messages.po
+++ b/locales/it/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/ja/LC_MESSAGES/messages.po
+++ b/locales/ja/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/lb/LC_MESSAGES/messages.po
+++ b/locales/lb/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/lt/LC_MESSAGES/messages.po
+++ b/locales/lt/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/lv/LC_MESSAGES/messages.po
+++ b/locales/lv/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/nb/LC_MESSAGES/messages.po
+++ b/locales/nb/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/nl/LC_MESSAGES/messages.po
+++ b/locales/nl/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/nn/LC_MESSAGES/messages.po
+++ b/locales/nn/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/no/LC_MESSAGES/messages.po
+++ b/locales/no/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: no\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/pl/LC_MESSAGES/messages.po
+++ b/locales/pl/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/pt/LC_MESSAGES/messages.po
+++ b/locales/pt/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/pt_BR/LC_MESSAGES/messages.po
+++ b/locales/pt_BR/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/ro/LC_MESSAGES/messages.po
+++ b/locales/ro/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/ru/LC_MESSAGES/messages.po
+++ b/locales/ru/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/se/LC_MESSAGES/messages.po
+++ b/locales/se/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: se\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/sk/LC_MESSAGES/messages.po
+++ b/locales/sk/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/sl/LC_MESSAGES/messages.po
+++ b/locales/sl/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/sr/LC_MESSAGES/messages.po
+++ b/locales/sr/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/st/LC_MESSAGES/messages.po
+++ b/locales/st/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: st\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/sv/LC_MESSAGES/messages.po
+++ b/locales/sv/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/tr/LC_MESSAGES/messages.po
+++ b/locales/tr/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/xh/LC_MESSAGES/messages.po
+++ b/locales/xh/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: xh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/zh/LC_MESSAGES/messages.po
+++ b/locales/zh/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/locales/zh_TW/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/locales/zu/LC_MESSAGES/messages.po
+++ b/locales/zu/LC_MESSAGES/messages.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: messages\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/src/SimpleSAML/Error/ErrorCodes.php:189

--- a/modules/admin/locales/af/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/af/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/ar/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/ar/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/ca/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/ca/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/cs/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/cs/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/da/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/da/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/de/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/de/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/el/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/el/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/en/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/en/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/en_LS/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/en_LS/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en_LS\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/es/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/es/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/et/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/et/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/eu/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/eu/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/fa/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/fa/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fa\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/fi/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/fi/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/fr/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/fr/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/he/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/he/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/hr/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/hr/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/hu/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/hu/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/id/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/id/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/it/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/it/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/ja/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/ja/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/lb/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/lb/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/lt/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/lt/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/lv/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/lv/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/nb/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/nb/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/nl/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/nl/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/nn/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/nn/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/no/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/no/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: no\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/pl/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/pl/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/pt/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/pt/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/pt_BR/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/pt_BR/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/ro/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/ro/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/ru/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/ru/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/se/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/se/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: se\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/sk/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/sk/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/sl/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/sl/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/sma/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/sma/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sma\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/sr/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/sr/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/sv/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/sv/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/tr/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/tr/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/ur/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/ur/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ur\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/xh/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/xh/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: xh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/zh/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/zh/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/zh_TW/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/zh_TW/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/admin/locales/zu/LC_MESSAGES/admin.po
+++ b/modules/admin/locales/zu/LC_MESSAGES/admin.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: admin\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/admin/src/Controller/Config.php:422

--- a/modules/core/locales/af/LC_MESSAGES/core.po
+++ b/modules/core/locales/af/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/ar/LC_MESSAGES/core.po
+++ b/modules/core/locales/ar/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/cs/LC_MESSAGES/core.po
+++ b/modules/core/locales/cs/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/da/LC_MESSAGES/core.po
+++ b/modules/core/locales/da/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/de/LC_MESSAGES/core.po
+++ b/modules/core/locales/de/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/el/LC_MESSAGES/core.po
+++ b/modules/core/locales/el/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/en/LC_MESSAGES/core.po
+++ b/modules/core/locales/en/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/en_LS/LC_MESSAGES/core.po
+++ b/modules/core/locales/en_LS/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en_LS\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/es/LC_MESSAGES/core.po
+++ b/modules/core/locales/es/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/et/LC_MESSAGES/core.po
+++ b/modules/core/locales/et/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/eu/LC_MESSAGES/core.po
+++ b/modules/core/locales/eu/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/fi/LC_MESSAGES/core.po
+++ b/modules/core/locales/fi/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/fr/LC_MESSAGES/core.po
+++ b/modules/core/locales/fr/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/he/LC_MESSAGES/core.po
+++ b/modules/core/locales/he/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/hr/LC_MESSAGES/core.po
+++ b/modules/core/locales/hr/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/hu/LC_MESSAGES/core.po
+++ b/modules/core/locales/hu/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/id/LC_MESSAGES/core.po
+++ b/modules/core/locales/id/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/it/LC_MESSAGES/core.po
+++ b/modules/core/locales/it/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/ja/LC_MESSAGES/core.po
+++ b/modules/core/locales/ja/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/lb/LC_MESSAGES/core.po
+++ b/modules/core/locales/lb/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/lt/LC_MESSAGES/core.po
+++ b/modules/core/locales/lt/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/lv/LC_MESSAGES/core.po
+++ b/modules/core/locales/lv/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/nb/LC_MESSAGES/core.po
+++ b/modules/core/locales/nb/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/nl/LC_MESSAGES/core.po
+++ b/modules/core/locales/nl/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/nn/LC_MESSAGES/core.po
+++ b/modules/core/locales/nn/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/pl/LC_MESSAGES/core.po
+++ b/modules/core/locales/pl/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/pt/LC_MESSAGES/core.po
+++ b/modules/core/locales/pt/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/pt_BR/LC_MESSAGES/core.po
+++ b/modules/core/locales/pt_BR/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/ro/LC_MESSAGES/core.po
+++ b/modules/core/locales/ro/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/ru/LC_MESSAGES/core.po
+++ b/modules/core/locales/ru/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/sk/LC_MESSAGES/core.po
+++ b/modules/core/locales/sk/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/sl/LC_MESSAGES/core.po
+++ b/modules/core/locales/sl/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/sr/LC_MESSAGES/core.po
+++ b/modules/core/locales/sr/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/sv/LC_MESSAGES/core.po
+++ b/modules/core/locales/sv/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/tr/LC_MESSAGES/core.po
+++ b/modules/core/locales/tr/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/xh/LC_MESSAGES/core.po
+++ b/modules/core/locales/xh/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: xh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/zh/LC_MESSAGES/core.po
+++ b/modules/core/locales/zh/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/zh_TW/LC_MESSAGES/core.po
+++ b/modules/core/locales/zh_TW/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/core/locales/zu/LC_MESSAGES/core.po
+++ b/modules/core/locales/zu/LC_MESSAGES/core.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: core\n"
 
 msgid "A service has requested you to authenticate yourself. Please enter your username and password in the form below."

--- a/modules/cron/locales/af/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/af/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/ar/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/ar/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/cs/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/cs/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/da/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/da/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/de/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/de/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/el/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/el/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/en/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/en/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/es/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/es/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/et/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/et/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/eu/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/eu/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/fr/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/fr/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/he/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/he/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/hr/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/hr/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/hu/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/hu/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/id/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/id/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/it/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/it/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/ja/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/ja/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/lt/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/lt/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/lv/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/lv/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/nb/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/nb/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/nl/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/nl/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/nn/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/nn/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/pt/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/pt/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/pt_BR/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/pt_BR/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/ro/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/ro/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/ru/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/ru/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/sl/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/sl/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/sr/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/sr/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/sv/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/sv/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/zh/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/zh/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/cron/locales/zh_TW/LC_MESSAGES/cron.po
+++ b/modules/cron/locales/zh_TW/LC_MESSAGES/cron.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: cron\n"
 
 msgid "Click here to run the cron jobs:"

--- a/modules/multiauth/locales/af/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/af/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/ar/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/ar/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/cs/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/cs/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/da/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/da/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/de/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/de/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/el/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/el/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/en/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/en/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/en_LS/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/en_LS/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en_LS\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/es/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/es/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/et/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/et/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/eu/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/eu/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/fi/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/fi/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/fr/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/fr/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/he/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/he/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/hr/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/hr/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/hu/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/hu/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/id/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/id/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/it/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/it/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/ja/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/ja/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/lt/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/lt/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/lv/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/lv/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/nb/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/nb/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/nl/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/nl/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/nn/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/nn/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/pl/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/pl/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/pt/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/pt/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/ro/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/ro/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/ru/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/ru/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/sl/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/sl/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/sr/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/sr/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/sv/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/sv/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/xh/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/xh/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: xh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/zh/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/zh/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/zh_TW/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/zh_TW/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/multiauth/locales/zu/LC_MESSAGES/multiauth.po
+++ b/modules/multiauth/locales/zu/LC_MESSAGES/multiauth.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: multiauth\n"
 
 msgid "Select an authentication source"

--- a/modules/saml/locales/af/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/af/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/ar/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/ar/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/cs/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/cs/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/da/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/da/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/de/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/de/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/el/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/el/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/en/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/en/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/en_LS/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/en_LS/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en_LS\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/es/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/es/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/et/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/et/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/eu/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/eu/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/fr/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/fr/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/hr/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/hr/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/hu/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/hu/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/id/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/id/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/it/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/it/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/lt/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/lt/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/nl/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/nl/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/nn/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/nn/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/ro/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/ro/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/ru/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/ru/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/sk/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/sk/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/sr/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/sr/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/sv/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/sv/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/xh/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/xh/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: xh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/zh/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/zh/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/zh_TW/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/zh_TW/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/modules/saml/locales/zu/LC_MESSAGES/saml.po
+++ b/modules/saml/locales/zu/LC_MESSAGES/saml.po
@@ -1,5 +1,10 @@
 msgid ""
 msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zu\n"
+"MIME-Version: 1.0\n"
+"Project-Id-Version: SimpleSAMLphp\n"
 "X-Domain: saml\n"
 
 #: /home/runner/work/simplesamlphp/simplesamlphp/modules/saml/hooks/hook_sanitycheck.php:25

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -26,6 +26,7 @@ use function array_intersect;
 use function array_key_exists;
 use function array_key_first;
 use function array_merge;
+use function basename;
 use function dirname;
 use function in_array;
 use function ksort;
@@ -195,6 +196,13 @@ class UpdateTranslatableStringsCommand extends Command
                         $iter,
                     );
 
+                    $language = basename(dirname($poFile->getPath()));
+                    $merged->getHeaders()
+                        ->set('Project-Id-Version', 'SimpleSAMLphp')
+                        ->set('MIME-Version', '1.0')
+                        ->set('Content-Type', 'text/plain; charset=UTF-8')
+                        ->set('Content-Transfer-Encoding', '8bit')
+                        ->setLanguage($language);
                     $poGenerator->generateFile($merged, $poFile->getPathName());
                 }
             }


### PR DESCRIPTION
Add basic headers to the PO files generated by bin/translations translations:update:translatable to make them more compatible with external translation tools.

The headers aren't [complete](https://www.gnu.org/software/gettext/manual/html_node/Header-Entry.html), but they're now good enough that `msgfmt -c` issues warnings not errors.

There are some assumptions here, although they're not entirely mine ;-).

The big one is that all the PO files are UTF-8 encoded. I can find no mention of what encoding is actually used anywhere in the php-gettext tools, but I think this is fairly safe. Running `files` on the existing .po files suggests they're almost all already UTF-8, and those that aren't are probably ASCII/ISO8859-1 and implicitly compatible with UTF-8. If they're not, they're broken anyway because gettext reading a file without a header appears to assume ISO8859-1.

The other assumption is that the directory name under locales/ matches what should be in the Language header. I think that's fairly safe, particularly given the changes that lead to #2305.