### PR TITLE
Make translations tool theme-aware

### DIFF
--- a/src/SimpleSAML/Command/UnusedTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UnusedTranslatableStringsCommand.php
@@ -55,6 +55,13 @@ class UnusedTranslatableStringsCommand extends Command
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Which modules to perform this action on',
         );
+        $this->addOption(
+            'themes',
+            null,
+            InputOption::VALUE_NEGATABLE,
+            'Include/exclude templates from themes directories of modules (default --themes)',
+            true, /* safe default, so we don't lose translations */
+        );
     }
 
 
@@ -110,7 +117,10 @@ class UnusedTranslatableStringsCommand extends Command
             $phpScanner = $translationUtils->getTranslationsFromPhp($module, $phpScanner);
 
             // Scan Twig-templates
-            $twigTranslations = array_merge($twigTranslations, $translationUtils->getTranslationsFromTwig($module));
+            $twigTranslations = array_merge(
+                $twigTranslations,
+                $translationUtils->getTranslationsFromTwig($module, $input->getOption('themes')),
+            );
         }
 
         // The catalogue returns an array with strings, while the php-scanner returns Translations-objects.

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -63,6 +63,13 @@ class UpdateTranslatableStringsCommand extends Command
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Which modules to perform this action on',
         );
+        $this->addOption(
+            'themes',
+            null,
+            InputOption::VALUE_NEGATABLE,
+            'Include/exclude templates from themes directories of modules (default --no-themes)',
+            false,
+        );
     }
 
     /**
@@ -138,7 +145,10 @@ class UpdateTranslatableStringsCommand extends Command
             $phpScanner = $translationUtils->getTranslationsFromPhp($module, $phpScanner);
 
             // Scan Twig-templates
-            $twigTranslations = array_merge($twigTranslations, $translationUtils->getTranslationsFromTwig($module));
+            $twigTranslations = array_merge(
+                $twigTranslations,
+                $translationUtils->getTranslationsFromTwig($module, $input->getOption('themes')),
+            );
         }
 
         // The catalogue returns an array with strings, while the php-scanner returns Translations-objects.

--- a/src/SimpleSAML/Utils/Translate.php
+++ b/src/SimpleSAML/Utils/Translate.php
@@ -6,10 +6,19 @@ namespace SimpleSAML\Utils;
 
 use Gettext\Scanner\PhpScanner;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\Exception;
+use SimpleSAML\Module;
 use SimpleSAML\XHTML\Template;
 use Symfony\Bridge\Twig\Translation\TwigExtractor;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Translation\MessageCatalogue;
+
+use function array_merge;
+use function explode;
+use function is_dir;
+use function str_starts_with;
+use function strlen;
+use function substr;
 
 /**
  * @package SimpleSAMLphp
@@ -45,19 +54,54 @@ class Translate
     }
 
 
-    public function getTranslationsFromTwig(string $module): array
+    public function getTranslationsFromTwig(string $module, bool $includeThemes = false): array
     {
         $twigTranslations = [];
         $moduleDir = $this->baseDir . ($module === '' ? '' : 'modules/' . $module . '/');
         $moduleTemplateDir = $moduleDir . 'templates/';
+        $moduleThemeDir = $moduleDir . 'themes/';
+        $moduleDirs = [];
+        if (is_dir($moduleTemplateDir)) {
+            $moduleDirs[] = $moduleTemplateDir;
+        }
+        if ($includeThemes && is_dir($moduleThemeDir)) {
+            $moduleDirs[] = $moduleThemeDir;
+        }
 
         // Scan Twig-templates
         $finder = new Finder();
-        foreach ($finder->files()->in($moduleTemplateDir)->name('*.twig') as $file) {
-            $template = new Template(
-                $this->configuration,
-                ($module ? ($module . ':') : '') . $file->getRelativePathname(),
-            );
+        foreach ($finder->files()->in($moduleDirs)->name('*.twig') as $file) {
+            if (!($includeThemes && str_starts_with($file->getPathname(), $moduleThemeDir))) {
+                /* process templates/ directory */
+                $template = new Template(
+                    $this->configuration,
+                    ($module ? ($module . ':') : '') . $file->getRelativePathname(),
+                );
+            } else {
+                /* process themed templates from other modules */
+                list($theme, $themedModule) = explode(
+                    DIRECTORY_SEPARATOR,
+                    substr($file->getPath(), strlen($moduleThemeDir)),
+                    2,
+                );
+                if ($themedModule !== 'default' && !Module::isModuleEnabled($themedModule)) {
+                    throw new Exception(
+                        'The module \'' . $themedModule . '\' (themed by \'' . $module . ':' . $theme . '\') ' .
+                        'is not enabled. Perhaps you need to need to require --dev simplesamlphp-module-' .
+                        $themedModule . ' within the ' . $module . ' module?',
+                    );
+                }
+                $template = new Template(
+                    Configuration::loadFromArray(
+                        array_merge(
+                            $this->configuration->toArray(),
+                            ['theme.use' => $module . ':' . $theme,],
+                        ),
+                    ),
+                    ($themedModule !== 'default' ? ($themedModule . ':') : '') .
+                    substr($file->getRelativePathname(), strlen($theme . DIRECTORY_SEPARATOR . $themedModule) + 1),
+                );
+            }
 
             $catalogue = new MessageCatalogue('en', []);
             $extractor = new TwigExtractor($template->getTwig());


### PR DESCRIPTION
With [#2312](https://github.com/simplesamlphp/simplesamlphp/pull/2312/commits/e2f4e0cc53eb1f1b176ce23b94a1000f599e3064), the bin/translations tool becomes useable to module developers as well as SSP itself. However, I realised that there's one bit missing -- theme modules that include additional strings in their overridden templates.

This makes the tool theme-aware, allowing people to (optionally) parse the themes/ directory as well.

In my theme module I can now do:
```sh
dev:~/simplesamlphp-module-safire$ ./vendor/simplesamlphp/simplesamlphp/bin/translations translations:update:translatable --module=safire --themes
```
and end up with updated .po files that include all the translatable strings, including those in my theme overrides. That's a lot easier than the hand extraction I used to do :)

I've made the default for the `translations:update:translatable` command to ignore themes (--no-themes), since I suspect the most common use case is to make minor adjustments to layout and the original translations in the source module would remain usable.

However, I've made the default for `translations:unused` to include themes (--themes), so that we don't mark any existing strings as unused if they are used in themes.

One caveat is that the modules that the theme refers to must exist and be enabled for the tool to work. This is easily achieved by doing a composer require --dev for the appropriate module. The tool will generate an error suggesting this if it encounters an unknown module in a theme.
