### PR TITLE
Remove remaining erroneous mention of st

### DIFF
--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -123,7 +123,7 @@ class Language
         );
 
         // @deprecated - remove entire if-block in a new major release
-        if (array_intersect(['pt-br', 'st', 'zh-tw'], $configuredAvailableLanguages)) {
+        if (array_intersect(['pt-br', 'zh-tw'], $configuredAvailableLanguages)) {
             Logger::warning(
                 "Deprecated locales found in `language.available`. "
                 . "Please replace 'pt-br' with 'pt_BR',"


### PR DESCRIPTION
It seems that even after #2305, 2.3.3 still has one erroneous mention of `st`. This just results in a superfluous warning in the logs (it doesn't actually affect translations).