### PR TITLE
i18n move attributes into an attributes domain

### DIFF
--- a/bin/translateAttributes.php
+++ b/bin/translateAttributes.php
@@ -121,5 +121,6 @@ foreach (array_keys($languages) as $language) {
 
     $strings->setLanguage($language);
     echo "Saving translations to " . $base . "locales/" . $language . "/LC_MESSAGES/attributes.po\n";
+    $strings->setDomain("attributes");
     Gettext\Generators\Po::toFile($strings, $base . 'locales/' . $language . '/LC_MESSAGES/attributes.po');
 }

--- a/locales/af/LC_MESSAGES/attributes.po
+++ b/locales/af/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: af\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/ar/LC_MESSAGES/attributes.po
+++ b/locales/ar/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ar\n"
 "Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))));\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/ca/LC_MESSAGES/attributes.po
+++ b/locales/ca/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ca\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/cs/LC_MESSAGES/attributes.po
+++ b/locales/cs/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n >= 2 && n <= 4) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/da/LC_MESSAGES/attributes.po
+++ b/locales/da/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: da\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/de/LC_MESSAGES/attributes.po
+++ b/locales/de/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/el/LC_MESSAGES/attributes.po
+++ b/locales/el/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: el\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/en/LC_MESSAGES/attributes.po
+++ b/locales/en/LC_MESSAGES/attributes.po
@@ -9,6 +9,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
+
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/es/LC_MESSAGES/attributes.po
+++ b/locales/es/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/et/LC_MESSAGES/attributes.po
+++ b/locales/et/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: et\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/eu/LC_MESSAGES/attributes.po
+++ b/locales/eu/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: eu\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/fa/LC_MESSAGES/attributes.po
+++ b/locales/fa/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fa\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/fi/LC_MESSAGES/attributes.po
+++ b/locales/fi/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fi\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/fr/LC_MESSAGES/attributes.po
+++ b/locales/fr/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/he/LC_MESSAGES/attributes.po
+++ b/locales/he/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: he\n"
 "Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && n % 10 == 0) ? 2 : 3));\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/hr/LC_MESSAGES/attributes.po
+++ b/locales/hr/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: hr\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/hu/LC_MESSAGES/attributes.po
+++ b/locales/hu/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: hu\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/id/LC_MESSAGES/attributes.po
+++ b/locales/id/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/it/LC_MESSAGES/attributes.po
+++ b/locales/it/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/ja/LC_MESSAGES/attributes.po
+++ b/locales/ja/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/lb/LC_MESSAGES/attributes.po
+++ b/locales/lb/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lb\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/lt/LC_MESSAGES/attributes.po
+++ b/locales/lt/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lt\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 1 && (n % 100 < 11 || n % 100 > 19)) ? 0 : ((n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19)) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/lv/LC_MESSAGES/attributes.po
+++ b/locales/lv/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lv\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/nb/LC_MESSAGES/attributes.po
+++ b/locales/nb/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: nb\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/nl/LC_MESSAGES/attributes.po
+++ b/locales/nl/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: nl\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/nn/LC_MESSAGES/attributes.po
+++ b/locales/nn/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: nn\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/no/LC_MESSAGES/attributes.po
+++ b/locales/no/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: nb\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/pl/LC_MESSAGES/attributes.po
+++ b/locales/pl/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pl\n"
 "Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/pt/LC_MESSAGES/attributes.po
+++ b/locales/pt/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pt\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/pt_BR/LC_MESSAGES/attributes.po
+++ b/locales/pt_BR/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pt-br\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/ro/LC_MESSAGES/attributes.po
+++ b/locales/ro/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ro\n"
 "Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n != 1 && n % 100 >= 1 && n % 100 <= 19) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/ru/LC_MESSAGES/attributes.po
+++ b/locales/ru/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/se/LC_MESSAGES/attributes.po
+++ b/locales/se/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: se\n"
 "Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 2) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/sk/LC_MESSAGES/attributes.po
+++ b/locales/sk/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sk\n"
 "Plural-Forms: nplurals=3; plural=(n == 1 ? 0 : (n >= 2 && n <= 4 ? 1 : 2))\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/sl/LC_MESSAGES/attributes.po
+++ b/locales/sl/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sl\n"
 "Plural-Forms: nplurals=4; plural=(n % 100 == 1) ? 0 : ((n % 100 == 2) ? 1 : ((n % 100 == 3 || n % 100 == 4) ? 2 : 3));\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/sma/LC_MESSAGES/attributes.po
+++ b/locales/sma/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sma\n"
 "Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 2) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/sr/LC_MESSAGES/attributes.po
+++ b/locales/sr/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sr\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/st/LC_MESSAGES/attributes.po
+++ b/locales/st/LC_MESSAGES/attributes.po
@@ -10,6 +10,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/sv/LC_MESSAGES/attributes.po
+++ b/locales/sv/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sv\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/tr/LC_MESSAGES/attributes.po
+++ b/locales/tr/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: tr\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/ur/LC_MESSAGES/attributes.po
+++ b/locales/ur/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ur\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/xh/LC_MESSAGES/attributes.po
+++ b/locales/xh/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: xh\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/zh/LC_MESSAGES/attributes.po
+++ b/locales/zh/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: zh\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/zh_TW/LC_MESSAGES/attributes.po
+++ b/locales/zh_TW/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: zh-tw\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/locales/zu/LC_MESSAGES/attributes.po
+++ b/locales/zu/LC_MESSAGES/attributes.po
@@ -9,6 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: zu\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Domain: attributes\n"
 
 msgid "aRecord"
 msgstr "aRecord"

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -94,7 +94,7 @@ class Translate
 
                     // try attributes.po
                     if ($text === $original) {
-                        $text = TranslatorFunctions::getTranslator()->dgettext("", $original);
+                        $text = TranslatorFunctions::getTranslator()->dgettext("attributes", $original);
                     }
                 }
             }


### PR DESCRIPTION
A possible fix for https://github.com/simplesamlphp/simplesamlphp/issues/2324

I will be doing some more testing on this in an installed form.

I have been testing this with a bin/test4.php script which is as follows. Adding a new `test4` msgid in the attributes.po for `en` does find the new term when the domain is set in attributes.po and the code is looking for the "attributes" domain.

```
#!/usr/bin/env php
<?php

require __DIR__ . '/../vendor/autoload.php';

use SimpleSAML\Metadata\MetaDataStorageHandler;
use SimpleSAML\Configuration;
use SimpleSAML\Locale\Translate;
use SimpleSAML\Locale\Localization;

use Symfony\Component\Intl\Locales;

echo "---- hello ----- \n";


$configuration = Configuration::getConfig();
$loc = new Localization($configuration);
$tr = new Translate($configuration);
$loc->addAttributeDomains();

echo "locales path " . $configuration->resolvePath('locales') . "\n";


$v = Translate::translateSingularGettext("test4");
echo "$v \n";

```