### PR TITLE
Add the index directive to Nginx configuration

### DIFF
--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -181,6 +181,7 @@ look like this:
 server {
     listen 443 ssl;
     server_name idp.example.com;
+    index index.php;
 
     ssl_certificate        /etc/pki/tls/certs/idp.example.com.crt;
     ssl_certificate_key    /etc/pki/tls/private/idp.example.com.key;


### PR DESCRIPTION
The PR is meant to add index directive into Nginx configuration to solve the error `directory index of /var/www/service.example.com/public/ is forbidden,` Nginx error after successfully installation. 