### PR TITLE
i18n: this is just the removal of the mo file loading. The patch looks a bit more complex than that

### DIFF
--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -250,29 +250,20 @@ class Localization
             }
         }
 
-        $file = new File($langPath . $domain . '.mo', false);
+        $file = new File($langPath . $domain . '.po', false);
         if ($file->getRealPath() !== false && $file->isReadable()) {
-            $translations = (new MoLoader())->loadFile($file->getRealPath());
+            $translations = (new PoLoader())->loadFile($file->getRealPath());
             $arrayGenerator = new ArrayGenerator();
             $this->translator->addTranslations(
                 $arrayGenerator->generateArray($translations),
             );
         } else {
-            $file = new File($langPath . $domain . '.po', false);
-            if ($file->getRealPath() !== false && $file->isReadable()) {
-                $translations = (new PoLoader())->loadFile($file->getRealPath());
-                $arrayGenerator = new ArrayGenerator();
-                $this->translator->addTranslations(
-                    $arrayGenerator->generateArray($translations),
-                );
-            } else {
-                Logger::debug(sprintf(
-                    "%s - Localization file '%s' not found or not readable in '%s', falling back to default",
-                    $_SERVER['PHP_SELF'],
-                    $file->getfileName(),
-                    $langPath,
-                ));
-            }
+            Logger::debug(sprintf(
+                "%s - Localization file '%s' not found or not readable in '%s', falling back to default",
+                $_SERVER['PHP_SELF'],
+                $file->getfileName(),
+                $langPath,
+            ));
         }
     }
 

--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -12,7 +12,6 @@ namespace SimpleSAML\Locale;
 
 use Exception;
 use Gettext\Generator\ArrayGenerator;
-use Gettext\Loader\MoLoader;
 use Gettext\Loader\PoLoader;
 use Gettext\{Translations, Translator, TranslatorFunctions};
 use SimpleSAML\{Configuration, Logger};


### PR DESCRIPTION
One of the scripts I ran made the mo files which were loaded by this path giving unexpected results. I think this path was in place to allow a transition but perhaps we should just say it is `po` files for now.

Perhaps this should be against 2.4 instead. 