### PR TITLE
Make explicit what part of the config is wrong when non-array endpoint type encountered

### DIFF
--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1207,9 +1207,14 @@ class Configuration implements Utils\ClearableState
             return [];
         }
 
-
         $eps = $this->configuration[$endpointType];
-        Assert::isArray($eps, Error\CriticalConfigurationError::class);
+        if (!is_array($eps)) {
+            $filename = explode('/', $loc)[0];
+            throw new Error\CriticalConfigurationError(
+                "Endpoint of type $endpointType is not an array in $loc.",
+                $filename
+            );
+        }
 
         $eps_count = count($eps);
 

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -1212,7 +1212,7 @@ class Configuration implements Utils\ClearableState
             $filename = explode('/', $loc)[0];
             throw new Error\CriticalConfigurationError(
                 "Endpoint of type $endpointType is not an array in $loc.",
-                $filename
+                $filename,
             );
         }
 

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -960,7 +960,7 @@ class ConfigurationTest extends ClearStateTestCase
 
         // define a set of exception messages to expect
         $msgs = [
-            "The configuration ([ARRAY]['SingleSignOnService']:) is invalid: Endpoint of type SingleSignOnService is not an array",
+            "The configuration ([ARRAY]['SingleSignOnService']:) is invalid: Endpoint of type SingleSignOnService",
             'Expected a string or an array.',
             'Missing Location.',
             'Location must be a string.',

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -960,7 +960,8 @@ class ConfigurationTest extends ClearStateTestCase
 
         // define a set of exception messages to expect
         $msgs = [
-            "The configuration ([ARRAY]['SingleSignOnService']:) is invalid: Endpoint of type SingleSignOnService",
+            "The configuration ([ARRAY]['SingleSignOnService']:) is invalid: Endpoint of type " .
+            "SingleSignOnService is not an array in [ARRAY]['SingleSignOnService']:.",
             'Expected a string or an array.',
             'Missing Location.',
             'Location must be a string.',

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -960,7 +960,7 @@ class ConfigurationTest extends ClearStateTestCase
 
         // define a set of exception messages to expect
         $msgs = [
-            'The configuration is invalid: Expected an array. Got: integer',
+            "The configuration ([ARRAY]['SingleSignOnService']:) is invalid: Endpoint of type SingleSignOnService is not an array",
             'Expected a string or an array.',
             'Missing Location.',
             'Location must be a string.',


### PR DESCRIPTION
Since this was supported since 'always', this seems to be quickly becoming a FAQ given that the previous error is very cryptic.