### PR TITLE
Fix IDPList setting in saml20-sp-remote not applied when SSP is in proxy mode

### DIFF
--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -582,6 +582,8 @@ class SP extends \SimpleSAML\Auth\Source
         if ($this->disable_scoping !== true && $idpMetadata->getOptionalBoolean('disable_scoping', false) !== true) {
             if (isset($state['IDPList'])) {
                 $ar->setIDPList($state['IDPList']);
+            } elseif (isset($state['saml:IDPList'])) {
+                $ar->setIDPList($state['saml:IDPList']);
             } elseif (!empty($this->metadata->getOptionalArray('IDPList', []))) {
                 $ar->setIDPList($this->metadata->getArray('IDPList'));
             } elseif (!empty($idpMetadata->getOptionalArray('IDPList', []))) {


### PR DESCRIPTION
In #1653 the way scoping is handled by the IDPList setting was changed. Currently this breaks the ability to apply IdP scoping when defined in  saml20-sp-remote.php because the IDPList will be set to the state as `saml:IDPList`.

Following a discussion with @tvdijen on Slack, I re-added the possibility to apply scoping through `$state['saml:IDPList']` add kept the changed version from #1653 (with `$state['IDPList']`) intact to prevent issues when this state parameter is explicitly set. I don't think this is the most beautiful approach, but it fixes this specific use case and is backwards compatible with the change from #1653.