### PR TITLE
Use entityID from state to allow overriding the issuer

### DIFF
--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -1141,7 +1141,7 @@ class SAML2
         }
 
         $issuer = new Issuer();
-        $issuer->setValue($idpMetadata->getString('entityid'));
+        $issuer->setValue($state['IdPMetadata']['entityid']);
         $issuer->setFormat(Constants::NAMEID_ENTITY);
         $a->setIssuer($issuer);
 


### PR DESCRIPTION
To me this is both a bugfix and a feature:

Using the configured value for the entityID _instead_ of the state-version has two downsides:
- No possibility to overrule the issuer using an authproc (*)
- Configuration might have changed mid-authflow

(*) I have a clear use-case to dynamically change the issuer based on the userPrincipalName, to be able to support [Entra Multiple top-level domain](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-install-multiple-domains#multiple-top-level-domain-support).

To decide:
- Is this a bug or a feature (target at 2.4 or backport to supported versions)?

To do:
- If we agree that my use-case is desirable, I will add an authproc-filter that will override the issuer based on a scoped attribute (likely userPrincipalName, but configurable) that can be used by anyone wanting to use SSP + EntraID in a multi-domain environment.

**The discussions should probably go into the attached issue rather than here.**

**Update:**  I only need control over the issuer set in the Assertion.. the response should remain untouched.