### PR TITLE
Update the SP and IdP URIs to pass the URI regex.

### DIFF
--- a/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
+++ b/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
@@ -40,8 +40,8 @@ class NameIDAttributeTest extends TestCase
     public function testMinimalConfig(): void
     {
         $config = [];
-        $spId = 'eugeneSP';
-        $idpId = 'eugeneIdP';
+        $spId = 'eugene:SP';
+        $idpId = 'eugene:IdP';
 
 
         $nameId = new NameID(
@@ -72,8 +72,8 @@ class NameIDAttributeTest extends TestCase
     {
         $attributeName = 'eugeneNameIDAttribute';
         $config = ['attribute' => $attributeName];
-        $spId = 'eugeneSP';
-        $idpId = 'eugeneIdP';
+        $spId = 'eugene:SP';
+        $idpId = 'eugene:IdP';
 
         $nameId = new NameID(
             value: 'eugene@oombaas',
@@ -103,8 +103,8 @@ class NameIDAttributeTest extends TestCase
     public function testFormat(): void
     {
         $config = ['format' => '%V!%%'];
-        $spId = 'eugeneSP';
-        $idpId = 'eugeneIdP';
+        $spId = 'eugene:SP';
+        $idpId = 'eugene:IdP';
 
         $nameId = new NameID(
             value: 'eugene@oombaas',
@@ -133,8 +133,8 @@ class NameIDAttributeTest extends TestCase
     public function testInvalidFormatThrowsException(): void
     {
         $config = ['format' => '%X'];
-        $spId = 'eugeneSP';
-        $idpId = 'eugeneIdP';
+        $spId = 'eugene:SP';
+        $idpId = 'eugene:IdP';
 
         $nameId = new NameID('eugene@oombaas');
 
@@ -161,8 +161,8 @@ class NameIDAttributeTest extends TestCase
     public function testInvalidRequestLeavesStateUntouched(): void
     {
         $config = ['format' => '%V!%F'];
-        $spId = 'eugeneSP';
-        $idpId = 'eugeneIdP';
+        $spId = 'eugene:SP';
+        $idpId = 'eugene:IdP';
 
         $request = [
             'Source'     => [
@@ -186,8 +186,8 @@ class NameIDAttributeTest extends TestCase
     {
         $attributeName = 'eugeneNameIDAttribute';
         $config = ['attribute' => $attributeName, 'format' => '%V'];
-        $spId = 'eugeneSP';
-        $idpId = 'eugeneIdP';
+        $spId = 'eugene:SP';
+        $idpId = 'eugene:IdP';
 
         $nameId = new NameID(
             value: 'eugene@oombaas',
@@ -216,8 +216,8 @@ class NameIDAttributeTest extends TestCase
      */
     public function testOverrideNameID(): void
     {
-        $spId = 'eugeneSP';
-        $idpId = 'eugeneIdP';
+        $spId = 'eugene:SP';
+        $idpId = 'eugene:IdP';
 
         $nameId = new NameID('eugene@oombaas');
 

--- a/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
+++ b/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
@@ -40,8 +40,8 @@ class NameIDAttributeTest extends TestCase
     public function testMinimalConfig(): void
     {
         $config = [];
-        $spId = 'eugene:SP';
-        $idpId = 'eugene:IdP';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
 
 
         $nameId = new NameID(
@@ -72,8 +72,8 @@ class NameIDAttributeTest extends TestCase
     {
         $attributeName = 'eugeneNameIDAttribute';
         $config = ['attribute' => $attributeName];
-        $spId = 'eugene:SP';
-        $idpId = 'eugene:IdP';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
 
         $nameId = new NameID(
             value: 'eugene@oombaas',
@@ -103,8 +103,8 @@ class NameIDAttributeTest extends TestCase
     public function testFormat(): void
     {
         $config = ['format' => '%V!%%'];
-        $spId = 'eugene:SP';
-        $idpId = 'eugene:IdP';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
 
         $nameId = new NameID(
             value: 'eugene@oombaas',
@@ -133,8 +133,8 @@ class NameIDAttributeTest extends TestCase
     public function testInvalidFormatThrowsException(): void
     {
         $config = ['format' => '%X'];
-        $spId = 'eugene:SP';
-        $idpId = 'eugene:IdP';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
 
         $nameId = new NameID('eugene@oombaas');
 
@@ -161,8 +161,8 @@ class NameIDAttributeTest extends TestCase
     public function testInvalidRequestLeavesStateUntouched(): void
     {
         $config = ['format' => '%V!%F'];
-        $spId = 'eugene:SP';
-        $idpId = 'eugene:IdP';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
 
         $request = [
             'Source'     => [
@@ -186,8 +186,8 @@ class NameIDAttributeTest extends TestCase
     {
         $attributeName = 'eugeneNameIDAttribute';
         $config = ['attribute' => $attributeName, 'format' => '%V'];
-        $spId = 'eugene:SP';
-        $idpId = 'eugene:IdP';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
 
         $nameId = new NameID(
             value: 'eugene@oombaas',
@@ -216,8 +216,8 @@ class NameIDAttributeTest extends TestCase
      */
     public function testOverrideNameID(): void
     {
-        $spId = 'eugene:SP';
-        $idpId = 'eugene:IdP';
+        $spId = 'urn:x-simplesamlphp:sp';
+        $idpId = 'urn:x-simplesamlphp:idp';
 
         $nameId = new NameID('eugene@oombaas');
 


### PR DESCRIPTION
These were all failing because of
  "eugeneIdP" is not a SAML2-compliant URI

It seems that adding in the colon makes these a compliant test.

The regex that was failing things is
  /^([a-z][a-z0-9\+\-\.]+[:])/i

which is not anchored at both ends, so it seems you can have whatever you want after the colon. As long as there is one with a limited prefix.

I discovered this when making the AttributeNameIDTest for pr 2260. It may also cause other tests to fail creating a bunch of smoke around the harder tests to get working.
