### PR TITLE
Try to clarify attributes.NameFormat is uri by default

### DIFF
--- a/metadata/saml20-idp-hosted.php.dist
+++ b/metadata/saml20-idp-hosted.php.dist
@@ -24,7 +24,12 @@ $metadata['urn:x-simplesamlphp:example-idp'] = [
      */
     'auth' => 'example-userpass',
 
-    /* Uncomment the following to use the uri NameFormat on attributes. */
+    /* The default attribute NameFormat is the uri NameFormat.
+       To convert friendly names to urn, uncomment the below authproc.
+
+       Refer to https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted.html
+       for other NameFormat options.
+    */
     /*
     'attributes.NameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
     'authproc' => [

--- a/modules/saml/docs/nameid.md
+++ b/modules/saml/docs/nameid.md
@@ -150,7 +150,7 @@ Generating Persistent NameID and eduPersonTargetedID.
             'name2oid',
         ],
     ],
-    // The URN attribute NameFormat for OID attributes.
+    // The URN attribute NameFormat for OID attributes. This is the default.
     'attributes.NameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
     'attributeencodings' => [
         'urn:oid:1.3.6.1.4.1.5923.1.1.1.10' => 'raw', /* eduPersonTargetedID with oid NameFormat is a raw XML value */


### PR DESCRIPTION
The comment describing `attributes.NameFormat` in the .dist file was incorrect. I tried adjusting the comment, but maybe we are better off removing the option from the .dist file and letting people read the documentation.