### PR TITLE
Run the language through Locale::canonicalize to clean it up

### DIFF
--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -442,6 +442,9 @@ class Language
         $config = Configuration::getInstance();
         $availableLanguages = $config->getOptionalArray('language.available', [self::FALLBACKLANGUAGE]);
 
+        // sanitize the langugage code
+        $language = \Locale::canonicalize($language);
+
         if (!in_array($language, $availableLanguages, true) || headers_sent()) {
             return;
         }


### PR DESCRIPTION
This relates to
https://github.com/simplesamlphp/simplesamlphp/issues/2327

This may or may not be needed or desired. It should allow more language code to be accepted, and possibly incorrect ones which will be converted into something that can be acted on.