### PR TITLE
Use print_r to output the filters to handle cycles

### DIFF
--- a/src/SimpleSAML/Auth/ProcessingChain.php
+++ b/src/SimpleSAML/Auth/ProcessingChain.php
@@ -89,8 +89,10 @@ class ProcessingChain
             self::addFilters($this->filters, $spFilters);
         }
 
-        Logger::debug('Filter config for ' . $idpMetadata['entityid'] . '->' .
-            $spMetadata['entityid'] . ': ' . str_replace("\n", '', VarExporter::export($this->filters)));
+        if( Logger::debugActive()) {
+            Logger::debug('Filter config for ' . $idpMetadata['entityid'] . '->' .
+                          $spMetadata['entityid'] . ': ' . str_replace("\n", '', print_r($this->filters,true)));
+        }
     }
 
 

--- a/src/SimpleSAML/Auth/ProcessingChain.php
+++ b/src/SimpleSAML/Auth/ProcessingChain.php
@@ -88,10 +88,8 @@ class ProcessingChain
             self::addFilters($this->filters, $spFilters);
         }
 
-        if (Logger::debugActive()) {
-            Logger::debug('Filter config for ' . $idpMetadata['entityid'] . '->' .
-                          $spMetadata['entityid'] . ': ' . str_replace("\n", '', print_r($this->filters, true)));
-        }
+        Logger::debug('Filter config for ' . $idpMetadata['entityid'] . '->' .
+                      $spMetadata['entityid'] . ': ' . str_replace("\n", '', print_r($this->filters, true)));
     }
 
 

--- a/src/SimpleSAML/Auth/ProcessingChain.php
+++ b/src/SimpleSAML/Auth/ProcessingChain.php
@@ -12,7 +12,6 @@ use SimpleSAML\Error;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
 use SimpleSAML\Utils;
-use Symfony\Component\VarExporter\VarExporter;
 
 use function array_key_exists;
 use function array_shift;
@@ -89,9 +88,9 @@ class ProcessingChain
             self::addFilters($this->filters, $spFilters);
         }
 
-        if( Logger::debugActive()) {
+        if (Logger::debugActive()) {
             Logger::debug('Filter config for ' . $idpMetadata['entityid'] . '->' .
-                          $spMetadata['entityid'] . ': ' . str_replace("\n", '', print_r($this->filters,true)));
+                          $spMetadata['entityid'] . ': ' . str_replace("\n", '', print_r($this->filters, true)));
         }
     }
 

--- a/src/SimpleSAML/Logger.php
+++ b/src/SimpleSAML/Logger.php
@@ -555,4 +555,18 @@ class Logger
             self::$loggingHandler->log($level, $string);
         }
     }
+
+    /**
+     * Is logging enabled for this level?
+     *
+     * @param int $level The desired log level
+     */
+    public static function isActiveFor(int $level): bool
+    {
+        return self::$logLevel >= $level;
+    }
+    public static function debugActive(): bool
+    {
+        return self::isActiveFor(self::DEBUG);
+    }
 }

--- a/src/SimpleSAML/Logger.php
+++ b/src/SimpleSAML/Logger.php
@@ -555,18 +555,4 @@ class Logger
             self::$loggingHandler->log($level, $string);
         }
     }
-
-    /**
-     * Is logging enabled for this level?
-     *
-     * @param int $level The desired log level
-     */
-    public static function isActiveFor(int $level): bool
-    {
-        return self::$logLevel >= $level;
-    }
-    public static function debugActive(): bool
-    {
-        return self::isActiveFor(self::DEBUG);
-    }
 }


### PR DESCRIPTION
Using `print_r` will allow `__debugInfo` to customize how things are print/dumped. This should allow for cases with cycles to be handled without running out of memory.

Relates to [issues/2367](https://github.com/simplesamlphp/simplesamlphp/issues/2367)

I also found that although this is a Logger::debug the string being passed to the function is probably being evaluated all the time. Even if debug is not on the export, dump, or print_r would run. To help with this I have the debugActive() method to only run the `debug()` call if debug is active. I have some testing using a getString() function and that will always be called when used as part of the string concat to the Logger::debug() method call. As the dumping could be expensive and is not used at all if not debugging this might be handy to have.

Formatting needs a phpcs or whatnot and the new methods in Logger need some docs. This is mainly an initial drop to discuss.