### PR TITLE
Configurably allow "Test Authentication Sources" for saml:SP authsources.

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -294,6 +294,12 @@ $config = [
     ],
      */
 
+    /*
+     * Allow public access to the admin module "Test Authentication Sources"
+     * with only saml:SP authsources listed.
+     */
+    'sp.public.test' => false,
+
 
     /************************
      | ERRORS AND DEBUGGING |

--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -294,12 +294,6 @@ $config = [
     ],
      */
 
-    /*
-     * Allow public access to the admin module "Test Authentication Sources"
-     * with only saml:SP authsources listed.
-     */
-    'sp.public.test' => false,
-
 
     /************************
      | ERRORS AND DEBUGGING |

--- a/modules/admin/src/Controller/Test.php
+++ b/modules/admin/src/Controller/Test.php
@@ -103,12 +103,12 @@ class Test
     {
         if (is_null($as)) {
             $t = new Template($this->config, 'admin:authsource_list.twig');
+
             if ($this->authUtils->isAdmin()) {
                 $t->data = [
                     'sources' => Auth\Source::getSources(),
                 ];
-            } elseif ($this->config->getValue('sp.public.test')) {
-
+            } else {
                 $samlSpSources = Auth\Source::getSourcesOfType('saml:SP');
                 $flattenedSources = [];
                 foreach ($samlSpSources as $source) {
@@ -123,7 +123,7 @@ class Test
             /** @psalm-suppress UndefinedClass */
             $authsource = new $this->authSimple($as);
 
-            if ($this->config->getValue('sp.public.test') != true || ! $authsource->getAuthSource() instanceof Module\saml\Auth\Source\SP) {
+            if (! $authsource->getAuthSource() instanceof Module\saml\Auth\Source\SP) {
                 $response = $this->authUtils->requireAdmin();
                 if ($response instanceof Response) {
                     return $response;


### PR DESCRIPTION
I am looking for a way to bring back the "Test Authentication Sources" page for having users test basic SSO login.
While there is the autotest module, it is less refined for a human to interact with.

This PR introduces a configuration option `sp.public.test` which when `true`  allows public access to `module.php/admin/test`. When not logged in as administrator, the listed sources are limited to `saml:SP` sources.