### PR TITLE
i18n: set the domain for a theme if it is missing

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -9,6 +9,8 @@ See the [upgrade notes](https://simplesamlphp.org/docs/stable/simplesamlphp-upgr
 
 Released TBD
 
+* Fixed loading translations for themes where there is no explicit X-Domain set in the po file.
+
 ## Version 2.3.6
 
 Released 2025-02-17

--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -261,6 +261,10 @@ class Localization
             $file = new File($langPath . $domain . '.po', false);
             if ($file->getRealPath() !== false && $file->isReadable()) {
                 $translations = (new PoLoader())->loadFile($file->getRealPath());
+                if(empty($translations->getDomain())) {
+                    $translations->setDomain($domain);
+                }
+
                 $arrayGenerator = new ArrayGenerator();
                 $this->translator->addTranslations(
                     $arrayGenerator->generateArray($translations),

--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -261,7 +261,7 @@ class Localization
             $file = new File($langPath . $domain . '.po', false);
             if ($file->getRealPath() !== false && $file->isReadable()) {
                 $translations = (new PoLoader())->loadFile($file->getRealPath());
-                if(empty($translations->getDomain())) {
+                if (empty($translations->getDomain())) {
                     $translations->setDomain($domain);
                 }
 


### PR DESCRIPTION
If there is no header in the po file then it was not being found for a theme. This PR allows po files to exist without any header such as the below.

msgid ""
msgstr ""
"X-Domain: worldpeace\n"

This was reported here https://github.com/simplesamlphp/simplesamlphp/issues/2384

I have verified using the theme in that issue and with this PR the "MY CUSTOM TRANSLATION" should appear when one selects French and the po file lacks any explicit header.
