### PR TITLE
Backport support for IDP Discovery protocol

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "simplesamlphp/assert": "^1.1",
         "simplesamlphp/composer-module-installer": "^1.3",
         "simplesamlphp/saml2": "^5@dev",
-        "simplesamlphp/saml2-legacy": "^4.17",
+        "simplesamlphp/saml2-legacy": "^4.18.1",
         "simplesamlphp/simplesamlphp-assets-base": "~2.3.0",
         "simplesamlphp/xml-security": "^1.7",
         "symfony/cache": "^6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77586376f11e4c1eab1222b1a369fa2e",
+    "content-hash": "7e2052956920d887c88b413079a40a77",
     "packages": [
         {
             "name": "gettext/gettext",
@@ -1167,16 +1167,16 @@
         },
         {
             "name": "simplesamlphp/saml2-legacy",
-            "version": "v4.17.0",
+            "version": "v4.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2-legacy.git",
-                "reference": "78934f4d776281a2a78821ef6b6be0a2e0e07f78"
+                "reference": "9bbf43a5ace9c8e5107dad3a613b014b456ecd56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2-legacy/zipball/78934f4d776281a2a78821ef6b6be0a2e0e07f78",
-                "reference": "78934f4d776281a2a78821ef6b6be0a2e0e07f78",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2-legacy/zipball/9bbf43a5ace9c8e5107dad3a613b014b456ecd56",
+                "reference": "9bbf43a5ace9c8e5107dad3a613b014b456ecd56",
                 "shasum": ""
             },
             "require": {
@@ -1221,9 +1221,9 @@
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
             "support": {
-                "source": "https://github.com/simplesamlphp/saml2-legacy/tree/v4.17.0"
+                "source": "https://github.com/simplesamlphp/saml2-legacy/tree/v4.18.1"
             },
-            "time": "2025-03-11T17:48:43+00:00"
+            "time": "2025-03-16T11:50:02+00:00"
         },
         {
             "name": "simplesamlphp/simplesamlphp-assets-base",

--- a/docs/simplesamlphp-metadata-extensions-idpdisc.md
+++ b/docs/simplesamlphp-metadata-extensions-idpdisc.md
@@ -1,0 +1,47 @@
+SAML V2.0 Metadata Extensions for Identity Provider Discovery Service Protocol and Profile
+=============================
+
+[TOC]
+
+This is a reference for the SimpleSAMLphp implementation of the [SAML
+V2.0 Metadata Extensions for Identity Provider Discovery Service Protocol and Profile](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-idp-discovery.pdf)
+defined by OASIS.
+
+The metadata extension is available to SP usage of SimpleSAMLphp. The entries are placed inside the relevant
+entry in `authsources.php`.
+
+An example:
+
+    <?php
+    $config = [
+
+        'default-sp' => [
+            'saml:SP',
+
+            'DiscoveryResponse' => [
+                [
+                    'index' => 1,
+                    'Binding' => 'urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol',
+                    'Location' => 'https://simplesamlphp.org/some/endpoint',
+                    'isDefault' => true,
+                ],
+            ],
+            /* ... */
+        ],
+    ];
+
+Generated XML Metadata Examples
+----------------
+
+The example given above will generate the following XML metadata:
+
+    <?xml version="1.0"?>
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://example.com/saml-idp">
+      <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:Extensions>
+          <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://simplesamlphp.org/some/endpoint" index="1" isDefault="true" />
+        </md:Extensions>
+        <md:KeyDescriptor use="signing">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+            ...

--- a/modules/saml/docs/sp.md
+++ b/modules/saml/docs/sp.md
@@ -12,6 +12,7 @@ and with entity attributes. See the documentation for those extensions for more 
 * [MDUI extension](../simplesamlphp-metadata-extensions-ui)
 * [MDRPI extension](../simplesamlphp-metadata-extensions-rpi)
 * [Attributes extension](../simplesamlphp-metadata-extensions-attributes)
+* [DiscoveryResponse extension](../simplesamlphp-metadata-extensions-idpdisc)
 
 **Parameters**:
 

--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -164,6 +164,7 @@ class SP extends \SimpleSAML\Auth\Source
             'metadata-set' => 'saml20-sp-remote',
             'SingleLogoutService' => $this->getSLOEndpoints(),
             'AssertionConsumerService' => $this->getACSEndpoints(),
+            'DiscoveryResponse' => $this->getDiscoveryResponseEndpoints(),
         ];
 
         // add NameIDPolicy
@@ -439,6 +440,19 @@ class SP extends \SimpleSAML\Auth\Source
             ];
         }
         return $endpoints;
+    }
+
+    /**
+     * Get the DiscoveryResponse endpoint available for a given local SP.
+     */
+    private function getDiscoveryResponseEndpoints(): array
+    {
+        $location = Module::getModuleURL('saml/sp/discoResponse/' . $this->getAuthId());
+
+        return [ 0 => [
+                'Binding' => Constants::NS_IDPDISC,
+                'Location' => $location,
+        ] ];
     }
 
     /**

--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -949,7 +949,6 @@ class SAML2
             $metadata['saml:Extensions'] = $config->getArray('saml:Extensions');
         }
 
-
         if ($config->hasValue('UIInfo')) {
             $metadata['UIInfo'] = $config->getArray('UIInfo');
         }

--- a/src/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/src/SimpleSAML/Metadata/SAMLBuilder.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Metadata;
 
 use DOMElement;
 use SAML2\Constants;
+use SAML2\XML\idpdisc\DiscoveryResponse;
 use SAML2\XML\md\AttributeAuthorityDescriptor;
 use SAML2\XML\md\AttributeConsumingService;
 use SAML2\XML\md\ContactPerson;
@@ -202,6 +203,14 @@ class SAMLBuilder
             );
         }
 
+        if ($metadata->hasValue('DiscoveryResponse')) {
+            $discoResponse = self::createEndpoints($metadata->getArray('DiscoveryResponse'), true);
+
+            $e->setExtensions(
+                array_merge($e->getExtensions(), $discoResponse),
+            );
+        }
+
         if ($metadata->hasValue('UIInfo')) {
             $ui = new UIInfo();
             foreach ($metadata->getArray('UIInfo') as $uiName => $uiValues) {
@@ -323,7 +332,12 @@ class SAMLBuilder
 
         foreach ($endpoints as &$ep) {
             if ($indexed) {
-                $t = new IndexedEndpointType();
+                if ($ep['Binding'] === Constants::NS_IDPDISC) {
+                    $t = new DiscoveryResponse();
+                } else {
+                    $t = new IndexedEndpointType();
+                }
+
                 if (!isset($ep['index'])) {
                     // Find the maximum index
                     $maxIndex = -1;


### PR DESCRIPTION
Closes https://github.com/simplesamlphp/simplesamlphp/issues/28

I know next to nothing about this specification, but I've made the following assumptions:

- Multiple entries of this element are allowed
- These entries only make sense in the Extensions of an SPSSODescriptor

I've verified that:
- Setting this in a `saml:SP`-entry results in an entry in the SP-metadata
- Parsing XML-metadata containing this entry results in a proper SSP metadata-array.