### PR TITLE
Throw exception also when ReturnTo is specified but empty

### DIFF
--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -165,6 +165,13 @@ class ServiceProvider
         ) {
             throw new Error\BadRequest('Missing ReturnTo parameter.');
         }
+        if (
+            $request->query->has('ReturnTo') &&
+            $request->query->getString('ReturnTo') === ""
+        ) {
+            throw new Error\BadRequest('Empty ReturnTo parameter specified.');
+        }
+
         if (!isset($options['ReturnTo'])) {
             $options['ReturnTo'] = $httpUtils->checkURLAllowed(
                 $request->query->get('ReturnTo') ?? $spSource->getMetadata()->getString('RelayState'),

--- a/tests/modules/saml/src/Controller/ServiceProviderTest.php
+++ b/tests/modules/saml/src/Controller/ServiceProviderTest.php
@@ -144,6 +144,26 @@ class ServiceProviderTest extends TestCase
         $c->login($request, 'phpunit');
     }
 
+    /**
+     * Test that accessing the login-endpoint with empty ReturnTo parameter leads to an exception
+     *
+     * @return void
+     */
+    public function testLoginEmptyReturnTo(): void
+    {
+        $request = Request::create(
+            '/sp/login/phpunit',
+            'GET',
+            ['ReturnTo' => ''],
+        );
+
+        $c = new Controller\ServiceProvider($this->config, $this->session);
+
+        $this->expectException(Error\BadRequest::class);
+        $this->expectExceptionMessage('Empty ReturnTo parameter specified.');
+        $c->login($request, 'phpunit');
+    }
+
 
     /**
      * @TODO: This cannot be tested until we are PSR-7 compliant


### PR DESCRIPTION
Some bots generate requests that have an empty ReturnTo. This causes a lot of load (e.g. generating a discovery screen) while it's obviously wrong. Therefore check for this explicitly early on and stop processing.