### PR TITLE
skip test if xdebug.mode does not contain develop

### DIFF
--- a/tests/src/SimpleSAML/SessionHandlerPHPTest.php
+++ b/tests/src/SimpleSAML/SessionHandlerPHPTest.php
@@ -72,6 +72,10 @@ class SessionHandlerPHPTest extends ClearStateTestCase
     #[RunInSeparateProcess]
     public function testSetCookie(): void
     {
+        if (!in_array('develop', xdebug_info( 'mode' ))) {
+            $this->markTestSkipped('xdebug.mode != develop');
+        }
+
         Configuration::loadFromArray($this->sessionConfig, '[ARRAY]', 'simplesaml');
         $sh = SessionHandlerPHP::getSessionHandler();
         $sh->setCookie('SimpleSAMLSessionID', '1');
@@ -95,6 +99,10 @@ class SessionHandlerPHPTest extends ClearStateTestCase
     #[RunInSeparateProcess]
     public function testSetCookieSameSiteNone(): void
     {
+        if (!in_array('develop', xdebug_info( 'mode' ))) {
+            $this->markTestSkipped('xdebug.mode != develop');
+        }
+
         Configuration::loadFromArray(
             array_merge($this->sessionConfig, ['session.cookie.samesite' => 'None']),
             '[ARRAY]',
@@ -115,6 +123,10 @@ class SessionHandlerPHPTest extends ClearStateTestCase
     #[RunInSeparateProcess]
     public function testSetCookieSameSiteLax(): void
     {
+        if (!in_array('develop', xdebug_info( 'mode' ))) {
+            $this->markTestSkipped('xdebug.mode != develop');
+        }
+
         Configuration::loadFromArray(
             array_merge($this->sessionConfig, ['session.cookie.samesite' => 'Lax']),
             '[ARRAY]',
@@ -135,6 +147,10 @@ class SessionHandlerPHPTest extends ClearStateTestCase
     #[RunInSeparateProcess]
     public function testSetCookieSameSiteStrict(): void
     {
+        if (!in_array('develop', xdebug_info( 'mode' ))) {
+            $this->markTestSkipped('xdebug.mode != develop');
+        }
+
         Configuration::loadFromArray(
             array_merge($this->sessionConfig, ['session.cookie.samesite' => 'Strict']),
             '[ARRAY]',
@@ -155,6 +171,10 @@ class SessionHandlerPHPTest extends ClearStateTestCase
     #[RunInSeparateProcess]
     public function testRestorePrevious(): void
     {
+        if (!in_array('develop', xdebug_info( 'mode' ))) {
+            $this->markTestSkipped('xdebug.mode != develop');
+        }
+
         session_name('PHPSESSID');
         $sid = session_id();
         session_start();

--- a/tests/src/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/src/SimpleSAML/Utils/HTTPTest.php
@@ -454,6 +454,10 @@ class HTTPTest extends ClearStateTestCase
     #[RunInSeparateProcess]
     public function testSetCookie(): void
     {
+        if (!in_array('develop', xdebug_info( 'mode' ))) {
+            $this->markTestSkipped('xdebug.mode != develop');
+        }
+
         $original = $_SERVER;
         $httpUtils = new Utils\HTTP();
 
@@ -530,12 +534,14 @@ class HTTPTest extends ClearStateTestCase
     }
 
 
-    /**
-     */
     #[RequiresPhpExtension('xdebug')]
     #[RunInSeparateProcess]
     public function testSetCookieSameSite(): void
     {
+        if (!in_array('develop', xdebug_info( 'mode' ))) {
+            $this->markTestSkipped('xdebug.mode != develop');
+        }
+
         $httpUtils = new Utils\HTTP();
         $httpUtils->setCookie('SSNull', 'value', ['samesite' => null]);
         $httpUtils->setCookie('SSNone', 'value', ['samesite' => 'None']);


### PR DESCRIPTION
usually if have the extension xdebug loaded but configured to off. so test like this:

```php
    #[RequiresPhpExtension('xdebug')]
    #[RunInSeparateProcess]
    public function testSetCookieSameSite(): void
```

will run but fail due to `xdebug_get_headers()` not being defined. so i added checks to mark them as skipped, if the extension is not configured as expected
