### PR TITLE
i18n warn if a module has an unexpected domain in its po file.

### DIFF
--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -255,6 +255,14 @@ class Localization
             if (empty($translations->getDomain())) {
                 $translations->setDomain($domain);
             }
+            if ($domain != $translations->getDomain()) {
+                Logger::warning(sprintf(
+                    "The translation file at %s has domain %s but is expected to have a domain %s",
+                    $file->getPath(),
+                    $translations->getDomain(),
+                    $domain,
+                ));
+            }
             $arrayGenerator = new ArrayGenerator();
             $this->translator->addTranslations(
                 $arrayGenerator->generateArray($translations),


### PR DESCRIPTION
This is a follow up to the theme domain handling update from https://github.com/simplesamlphp/simplesamlphp/issues/2384

If you copy the translations for an existing theme or module and forget to change the domain setting in the po file then it might not be found by SSP. With this warning message you will at least have some indication as to why this might have happened.