### PR TITLE
i18n allow the substitution of SPNAME and other TWIG variables

### DIFF
--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -72,6 +72,16 @@ class Translate
      *
      * @param string|null $original The string before translation.
      *
+     *
+     * NOTE: This may be called from TwigTranslator::trans()
+     * which will pass the following arguments.
+     * The $id will match $original above but there are other arguments which may also be used in this method.
+     *
+     * @param string $id
+     * @param array $parameters
+     * @param string|null $domain
+     * @param string|null $locale
+     *
      * @return string The translated string.
      */
     public static function translateSingularGettext(?string $original): string
@@ -88,7 +98,7 @@ class Translate
                     foreach (self::$defaultDomains as $d) {
                         $text = TranslatorFunctions::getTranslator()->dgettext($d, $original);
                         if ($text != $original) {
-                            return $text;
+                            break;
                         }
                     }
 
@@ -104,7 +114,6 @@ class Translate
         }
 
         $args = array_slice(func_get_args(), 1);
-
         return strtr($text, is_array($args[0]) ? $args[0] : $args);
     }
 

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -114,6 +114,7 @@ class Translate
         }
 
         $args = array_slice(func_get_args(), 1);
+
         return strtr($text, is_array($args[0]) ? $args[0] : $args);
     }
 


### PR DESCRIPTION
This was raised with solution at
https://github.com/simplesamlphp/simplesamlphp/issues/2407

I have added a comment to the method doc block to warn about these extra parameters which are expected in some contexts