### PR TITLE
Allow SP initiated Artifact binding

### DIFF
--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -659,14 +659,6 @@ class SP extends \SimpleSAML\Auth\Source
                     Constants::BINDING_HOK_SSO,
                 ],
             );
-        } elseif ($ar->getProtocolBinding() === Constants::BINDING_HTTP_ARTIFACT) {
-            /** @var array $dst */
-            $dst = $idpMetadata->getDefaultEndpoint(
-                'SingleSignOnService',
-                [
-                    Constants::BINDING_HTTP_ARTIFACT,
-                ],
-            );
         } else {
             /** @var array $dst */
             $dst = $idpMetadata->getEndpointPrioritizedByBinding(


### PR DESCRIPTION
If this block is in use then the SP will send an `art` request using the binding to the IdP which will fail. It seems the request from the SP to the IdP must be a normal redirect but with the special artifact attribute to indicate to the IdP that the login should be processed using an artifact.

Without this explicit elseif block an AuthnRequest will be delivered normally to the IdP and will still have the artifact attribute. The successful SAML login will see a GET with an `art` and in the samltracer you don't get to see the response because it is happening in the background between the SP and IdP.

For example:
GET https://FQDN/sspsmall/module.php/saml/sp/saml2-acs.php/default-sp?SAMLart=AAQ

This relates to a recent discussion on the mailing list with topic "Using artifact binding with simplesamlphp SP and IdP".
