### PR TITLE
Move to direct execution of these to allow env to find php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,11 +127,11 @@
         }
     },
     "scripts": {
-        "translations:unused": "php bin/translations translations:unused",
-        "translations:update:translatable": "php bin/translations translations:update:translatable",
+        "translations:unused": "./bin/translations translations:unused",
+        "translations:update:translatable": "./bin/translations translations:update:translatable",
         "clear-symfony-cache": [
-            "php bin/console     cache:clear --no-warmup",
-            "php bin/console ssp-cache:clear --no-warmup"
+            "./bin/console     cache:clear --no-warmup",
+            "./bin/console ssp-cache:clear --no-warmup"
         ],
         "post-update-cmd": [
             "@clear-symfony-cache",


### PR DESCRIPTION
Sometimes folks might have php executable as php84 for example and the env command might be needed to find or resolve the php in use.