### PR TITLE
Disable clearing the cache for now on update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,11 +134,9 @@
             "php bin/console ssp-cache:clear --no-warmup"
         ],
         "post-update-cmd": [
-            "@clear-symfony-cache",
             "echo 'Post-update tasks completed!'"
         ],
         "post-install-cmd": [
-            "@clear-symfony-cache",
             "echo 'Post-install tasks completed!'"
         ]
     },


### PR DESCRIPTION
Some installs and composer checkouts are likely to not have the setfacl in place for the cache. The documentation is updated to mention that this is a really good idea but in the shorter term we should not assume this and not run these commands that depend on it automatically.