### PR TITLE
Scrub the expire key for session_set_cookie_params

### DIFF
--- a/src/SimpleSAML/SessionHandlerPHP.php
+++ b/src/SimpleSAML/SessionHandlerPHP.php
@@ -342,7 +342,7 @@ class SessionHandlerPHP extends SessionHandler
         }
 
         if (array_key_exists('expire', $cookieParams)) {
-            // Simiar to the Util\HTTP::setCookie()
+            // Similar to the Utils\HTTP::setCookie()
             if (isset($cookieParams['expire'])) {
                 $expire = intval($cookieParams['expire']);
                 $cookieParams['lifetime'] = $expire;

--- a/src/SimpleSAML/SessionHandlerPHP.php
+++ b/src/SimpleSAML/SessionHandlerPHP.php
@@ -341,6 +341,18 @@ class SessionHandlerPHP extends SessionHandler
             session_write_close();
         }
 
+        if (array_key_exists('expire', $cookieParams)) {
+            // Simiar to the Util\HTTP::setCookie()
+            if (isset($cookieParams['expire'])) {
+                $expire = intval($cookieParams['expire']);
+                // only set this if there is no lifetime already specified.
+                if (!isset($cookieParams['lifetime'])) {
+                    $cookieParams['lifetime'] = $expire;
+                }
+                unset($cookieParams['expire']);
+            }
+        }
+
         /** @psalm-suppress InvalidArgument */
         session_set_cookie_params($cookieParams);
 

--- a/src/SimpleSAML/SessionHandlerPHP.php
+++ b/src/SimpleSAML/SessionHandlerPHP.php
@@ -345,10 +345,7 @@ class SessionHandlerPHP extends SessionHandler
             // Simiar to the Util\HTTP::setCookie()
             if (isset($cookieParams['expire'])) {
                 $expire = intval($cookieParams['expire']);
-                // only set this if there is no lifetime already specified.
-                if (!isset($cookieParams['lifetime'])) {
-                    $cookieParams['lifetime'] = $expire;
-                }
+                $cookieParams['lifetime'] = $expire;
                 unset($cookieParams['expire']);
             }
         }


### PR DESCRIPTION
Scrub the `expire` key for `session_set_cookie_params`

If that is set then the session_set_cookie_params() will complain. It
is probably best to convert it to working on lifetime but only if
lifetime is also not explicitly set.

Util\HTTP::setCookie() handles the expire and passes that on to the php API.
https://github.com/simplesamlphp/simplesamlphp/blob/93ca2d0043ae1175192ab4aded579e328a3ee4fa/src/SimpleSAML/Utils/HTTP.php#L1117

This relates to https://github.com/simplesamlphp/simplesamlphp/issues/2425
