### PR TITLE
Better handle win paths here by splitting on dir separator

### DIFF
--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -611,7 +611,7 @@ class HTTP
             return '/';
         }
         // get the name of the current script
-        $path = explode('/', $_SERVER['SCRIPT_FILENAME']);
+        $path = explode(DIRECTORY_SEPARATOR, $_SERVER['SCRIPT_FILENAME']);
         $script = array_pop($path);
 
         // get the portion of the URI up to the script, i.e.: /simplesaml/some/directory/script.php
@@ -619,7 +619,7 @@ class HTTP
             return '/';
         }
         $uri_s = explode('/', $matches[0]);
-        $file_s = explode('/', $_SERVER['SCRIPT_FILENAME']);
+        $file_s = explode(DIRECTORY_SEPARATOR, $_SERVER['SCRIPT_FILENAME']);
 
         // compare both arrays from the end, popping elements matching out of them
         while ($uri_s[count($uri_s) - 1] === $file_s[count($file_s) - 1]) {

--- a/tests/src/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/src/SimpleSAML/Utils/HTTPTest.php
@@ -76,10 +76,10 @@ class HTTPTest extends ClearStateTestCase
         $this->assertEquals($url . '&bar=foo', $httpUtils->addURLParameters($url, $params));
     }
 
-    private function makeNativePath( $s )
+    private function makeNativePath($s)
     {
-        if( DIRECTORY_SEPARATOR == '\\' ) {
-            $s = str_replace("/","\\",$s );
+        if (DIRECTORY_SEPARATOR == '\\') {
+            $s = str_replace("/", "\\", $s);
         }
         return $s;
     }

--- a/tests/src/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/src/SimpleSAML/Utils/HTTPTest.php
@@ -76,6 +76,13 @@ class HTTPTest extends ClearStateTestCase
         $this->assertEquals($url . '&bar=foo', $httpUtils->addURLParameters($url, $params));
     }
 
+    private function makeNativePath( $s )
+    {
+        if( DIRECTORY_SEPARATOR == '\\' ) {
+            $s = str_replace("/","\\",$s );
+        }
+        return $s;
+    }
 
     /**
      * Test SimpleSAML\Utils\HTTP::guessBasePath().
@@ -86,35 +93,35 @@ class HTTPTest extends ClearStateTestCase
         $httpUtils = new Utils\HTTP();
 
         $_SERVER['REQUEST_URI'] = '/simplesaml/module.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/public/module.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/public/module.php');
         $this->assertEquals('/simplesaml/', $httpUtils->guessBasePath());
 
         $_SERVER['REQUEST_URI'] = '/simplesaml/module.php/some/path/to/other/script.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/public/module.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/public/module.php');
         $this->assertEquals('/simplesaml/', $httpUtils->guessBasePath());
 
         $_SERVER['REQUEST_URI'] = '/module.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/public/module.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/public/module.php');
         $this->assertEquals('/', $httpUtils->guessBasePath());
 
         $_SERVER['REQUEST_URI'] = '/module.php/some/path/to/other/script.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/public/module.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/public/module.php');
         $this->assertEquals('/', $httpUtils->guessBasePath());
 
         $_SERVER['REQUEST_URI'] = '/some/path/module.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/public/module.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/public/module.php');
         $this->assertEquals('/some/path/', $httpUtils->guessBasePath());
 
         $_SERVER['REQUEST_URI'] = '/some/path/module.php/some/path/to/other/script.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/public/module.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/public/module.php');
         $this->assertEquals('/some/path/', $httpUtils->guessBasePath());
 
         $_SERVER['REQUEST_URI'] = '/some/dir/in/www/script.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/www/some/dir/in/www/script.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/www/some/dir/in/www/script.php');
         $this->assertEquals('/', $httpUtils->guessBasePath());
 
         $_SERVER['REQUEST_URI'] = '/simplesaml/some/dir/in/www/script.php';
-        $_SERVER['SCRIPT_FILENAME'] = '/some/path/simplesamlphp/www/some/dir/in/www/script.php';
+        $_SERVER['SCRIPT_FILENAME'] = self::makeNativePath('/some/path/simplesamlphp/www/some/dir/in/www/script.php');
         $this->assertEquals('/simplesaml/', $httpUtils->guessBasePath());
 
         $_SERVER = $original;


### PR DESCRIPTION
The $matches[0] should not be using the DIRECTORY_SEPARATOR since it is working on a string that is created using '/' and the REQUEST_URI.

This relates to https://github.com/simplesamlphp/simplesamlphp/issues/2424