### PR TITLE
Add exception annotations to PhpDoc docblocks

### DIFF
--- a/modules/admin/src/Controller/Config.php
+++ b/modules/admin/src/Controller/Config.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\admin\Controller;
 
-use SimpleSAML\{Configuration, Module, Session, Utils};
+use SimpleSAML\{Configuration, Error\ConfigurationError, Error\CriticalConfigurationError, Error\Exception, Module, Session, Utils};
 use SimpleSAML\Locale\Translate;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{Request, Response, StreamedResponse};
@@ -49,6 +49,9 @@ class Config
      *
      * @param \SimpleSAML\Configuration $config The configuration to use.
      * @param \SimpleSAML\Session $session The current user session.
+     * @throws \SimpleSAML\Error\CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function __construct(
         protected Configuration $config,
@@ -77,6 +80,10 @@ class Config
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws CriticalConfigurationError
+     * @throws ConfigurationError
+     * @throws Exception
+     * @throws \Throwable
      */
     public function diagnostics(Request $request): Response
     {
@@ -114,6 +121,10 @@ class Config
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws Exception
+     * @throws ConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function main(/** @scrutinizer ignore-unused */ Request $request): Response
     {
@@ -153,6 +164,7 @@ class Config
 
     /**
      * @return array
+     * @throws \Exception
      */
     protected function getModuleList(): array
     {
@@ -172,6 +184,8 @@ class Config
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \Symfony\Component\HttpFoundation\Response The output of phpinfo()
+     * @throws Exception
+     * @throws \Throwable
      */
     public function phpinfo(/** @scrutinizer ignore-unused */ Request $request): Response
     {
@@ -201,6 +215,8 @@ class Config
      *   - enabled: True if the prerequisite is met, false otherwise.
      *
      * @return array
+     * @throws Exception
+     * @throws \Exception
      */
     protected function getPrerequisiteChecks(): array
     {
@@ -402,6 +418,7 @@ class Config
      *     {{ e[0]|trans(e[1])|raw }}
      *
      * @return array
+     * @throws \Exception
      */
     protected function getWarnings(): array
     {

--- a/modules/admin/src/Controller/Federation.php
+++ b/modules/admin/src/Controller/Federation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\admin\Controller;
 
 use Exception;
-use SimpleSAML\{Auth, Configuration, Logger, Module, Utils};
+use SimpleSAML\{Auth, Configuration, Error\ConfigurationError, Error\MetadataNotFound, Logger, Module, Utils};
 use SimpleSAML\Assert\{Assert, AssertionFailedException};
 use SimpleSAML\Locale\Translate;
 use SimpleSAML\Metadata\{MetaDataStorageHandler, SAMLBuilder, SAMLParser, Signer};
@@ -16,6 +16,7 @@ use SimpleSAML\SAML2\Exception\ArrayValidationException;
 use SimpleSAML\SAML2\XML\md\ContactPerson;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{Request, Response, ResponseHeaderBag};
+use Symfony\Component\VarExporter\Exception\ExceptionInterface;
 use Symfony\Component\VarExporter\VarExporter;
 
 use function array_merge;
@@ -64,6 +65,7 @@ class Federation
      * FederationController constructor.
      *
      * @param \SimpleSAML\Configuration $config The configuration to use.
+     * @throws Exception
      */
     public function __construct(
         protected Configuration $config,
@@ -114,7 +116,9 @@ class Federation
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response
      * @throws \SimpleSAML\Error\Exception
-     * @throws \SimpleSAML\Error\Exception
+     * @throws Exception
+     * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function main(/** @scrutinizer ignore-unused */ Request $request): Response
     {
@@ -192,6 +196,7 @@ class Federation
      *
      * @return array
      * @throws \Exception
+     * @throws ExceptionInterface
      */
     private function getHostedIdP(): array
     {
@@ -334,6 +339,8 @@ class Federation
      *
      * @return array
      * @throws \SimpleSAML\Error\Exception If OrganizationName is set for an SP instance but OrganizationURL is not.
+     * @throws ExceptionInterface
+     * @throws Exception
      */
     private function getHostedSP(): array
     {
@@ -401,6 +408,10 @@ class Federation
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws ConfigurationError
+     * @throws ExceptionInterface
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \Throwable
      */
     public function metadataConverter(Request $request): Response
     {
@@ -493,6 +504,9 @@ class Federation
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \Symfony\Component\HttpFoundation\Response PEM-encoded certificate.
+     * @throws \SimpleSAML\Error\Exception
+     * @throws MetadataNotFound
+     * @throws \Throwable
      */
     public function downloadCert(Request $request): Response
     {
@@ -539,6 +553,11 @@ class Federation
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws ExceptionInterface
+     * @throws ConfigurationError
+     * @throws MetadataNotFound
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \Throwable
      */
     public function showRemoteEntity(Request $request): Response
     {

--- a/modules/admin/src/Controller/Menu.php
+++ b/modules/admin/src/Controller/Menu.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\admin\Controller;
 
 use SimpleSAML\Assert\Assert;
+use SimpleSAML\Error\CriticalConfigurationError;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Locale\Translate;
 use SimpleSAML\Module;
 use SimpleSAML\XHTML\Template;
@@ -24,6 +26,9 @@ final class Menu
      * Menu constructor.
      *
      * Initialize the menu with some default admin options, and call a hook for anyone willing to extend it.
+     * @throws CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function __construct()
     {
@@ -83,6 +88,8 @@ final class Menu
      * @param \SimpleSAML\XHTML\Template $template The template we should insert this menu into.
      *
      * @return \SimpleSAML\XHTML\Template The template with the added menu.
+     * @throws Exception
+     * @throws \Exception
      */
     public function insert(Template $template): Template
     {

--- a/modules/admin/src/Controller/Sandbox.php
+++ b/modules/admin/src/Controller/Sandbox.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\admin\Controller;
 
-use SimpleSAML\{Configuration, Session};
+use SimpleSAML\{Configuration, Error\ConfigurationError, Session};
 use SimpleSAML\XHTML\Template;
 
 use function time;
@@ -35,6 +35,8 @@ class Sandbox
      * Display the sandbox page
      *
      * @return \SimpleSAML\XHTML\Template
+     * @throws ConfigurationError
+     * @throws \Exception
      */
     public function main(): Template
     {

--- a/modules/admin/src/Controller/Test.php
+++ b/modules/admin/src/Controller/Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\admin\Controller;
 
-use SimpleSAML\{Auth, Configuration, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error\ConfigurationError, Error\Exception, Module, Session, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Locale\Translate;
 use SimpleSAML\XHTML\Template;
@@ -49,6 +49,9 @@ class Test
      *
      * @param \SimpleSAML\Configuration $config The configuration to use.
      * @param \SimpleSAML\Session $session The current user session.
+     * @throws \SimpleSAML\Error\CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function __construct(
         protected Configuration $config,
@@ -98,6 +101,10 @@ class Test
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string|null $as
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws ConfigurationError
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function main(Request $request, ?string $as = null): Response
     {
@@ -163,6 +170,8 @@ class Test
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \SimpleSAML\XHTML\Template
+     * @throws ConfigurationError
+     * @throws \Exception
      */
     public function logout(/** @scrutinizer ignore-unused */Request $request): Template
     {

--- a/modules/core/src/Auth/Process/AttributeAdd.php
+++ b/modules/core/src/Auth/Process/AttributeAdd.php
@@ -44,6 +44,7 @@ class AttributeAdd extends Auth\ProcessingFilter
      *
      * @param array &$config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @throws Exception
      */
     public function __construct(array &$config, $reserved)
     {

--- a/modules/core/src/Auth/Process/AttributeCopy.php
+++ b/modules/core/src/Auth/Process/AttributeCopy.php
@@ -41,6 +41,7 @@ class AttributeCopy extends Auth\ProcessingFilter
      *
      * @param array &$config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @throws Exception
      */
     public function __construct(array &$config, $reserved)
     {

--- a/modules/core/src/Auth/Process/AttributeLimit.php
+++ b/modules/core/src/Auth/Process/AttributeLimit.php
@@ -130,6 +130,7 @@ class AttributeLimit extends Auth\ProcessingFilter
      *
      * @param array &$state  The current request
      * @throws \SimpleSAML\Error\Exception If invalid configuration is found.
+     * @throws \Exception
      */
     public function process(array &$state): void
     {
@@ -196,6 +197,7 @@ class AttributeLimit extends Auth\ProcessingFilter
      * @param array $values The current values for a given attribute
      * @param array $allowedConfigValues The allowed values, and possibly configuration options.
      * @return array The filtered values
+     * @throws \Exception
      */
     private function filterAttributeValues(array $values, ?array $allowedConfigValues): array
     {

--- a/modules/core/src/Auth/Process/AttributeValueMap.php
+++ b/modules/core/src/Auth/Process/AttributeValueMap.php
@@ -59,6 +59,7 @@ class AttributeValueMap extends Auth\ProcessingFilter
      * @param array &$config Configuration information about this filter.
      * @param mixed $reserved For future use.
      * @throws \SimpleSAML\Error\Exception If the configuration is not valid.
+     * @throws \Exception
      */
     public function __construct(array &$config, $reserved)
     {
@@ -114,6 +115,7 @@ class AttributeValueMap extends Auth\ProcessingFilter
      * Apply filter.
      *
      * @param array &$state The current request
+     * @throws \Exception
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/Cardinality.php
+++ b/modules/core/src/Auth/Process/Cardinality.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Auth\Process;
 
-use SimpleSAML\{Auth, Error, Logger, Module, Utils};
+use SimpleSAML\{Auth, Error, Error\CriticalConfigurationError, Error\Exception, Logger, Module, Utils};
 use SimpleSAML\Assert\Assert;
 
 use function array_key_exists;
@@ -112,6 +112,10 @@ class Cardinality extends Auth\ProcessingFilter
      * Process this filter
      *
      * @param array &$state  The current request
+     * @throws Exception
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/CardinalitySingle.php
+++ b/modules/core/src/Auth/Process/CardinalitySingle.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\core\Auth\Process;
 
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\{Auth, Logger, Module, Utils};
+use SimpleSAML\{Auth, Error\CriticalConfigurationError, Error\Exception, Logger, Module, Utils};
 
 use function array_key_exists;
 use function array_shift;
@@ -86,6 +86,10 @@ class CardinalitySingle extends Auth\ProcessingFilter
      * Process this filter
      *
      * @param array &$state  The current request
+     * @throws Exception
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/ExtendIdPSession.php
+++ b/modules/core/src/Auth/Process/ExtendIdPSession.php
@@ -15,6 +15,8 @@ class ExtendIdPSession extends Auth\ProcessingFilter
 {
     /**
      * @param array &$state
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/GenerateGroups.php
+++ b/modules/core/src/Auth/Process/GenerateGroups.php
@@ -36,6 +36,7 @@ class GenerateGroups extends Auth\ProcessingFilter
      *
      * @param array &$config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @throws Exception
      */
     public function __construct(array &$config, $reserved)
     {
@@ -65,6 +66,7 @@ class GenerateGroups extends Auth\ProcessingFilter
      * Apply filter to add groups attribute.
      *
      * @param array &$state  The current request
+     * @throws Exception
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/LanguageAdaptor.php
+++ b/modules/core/src/Auth/Process/LanguageAdaptor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Auth\Process;
 
-use SimpleSAML\{Auth, Logger};
+use SimpleSAML\{Auth, Error\CannotSetCookie, Logger};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Locale\Language;
 
@@ -43,6 +43,8 @@ class LanguageAdaptor extends Auth\ProcessingFilter
      * Add or replace existing attributes with the configured values.
      *
      * @param array &$state  The current request
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/ScopeAttribute.php
+++ b/modules/core/src/Auth/Process/ScopeAttribute.php
@@ -54,6 +54,7 @@ class ScopeAttribute extends Auth\ProcessingFilter
      *
      * @param array &$config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function __construct(array &$config, $reserved)
     {

--- a/modules/core/src/Auth/Process/ScopeFromAttribute.php
+++ b/modules/core/src/Auth/Process/ScopeFromAttribute.php
@@ -48,6 +48,7 @@ class ScopeFromAttribute extends Auth\ProcessingFilter
      *
      * @param array &$config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function __construct(array &$config, $reserved)
     {
@@ -63,6 +64,8 @@ class ScopeFromAttribute extends Auth\ProcessingFilter
      * Apply this filter.
      *
      * @param array &$state  The current request
+     * @throws \Exception
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/TargetedID.php
+++ b/modules/core/src/Auth/Process/TargetedID.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\core\Auth\Process;
 
 use Exception;
-use SimpleSAML\{Auth, Logger, Utils};
+use SimpleSAML\{Auth, Error\CriticalConfigurationError, Logger, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\XML\saml\NameID;
@@ -62,6 +62,7 @@ class TargetedID extends Auth\ProcessingFilter
      *
      * @param array &$config  Configuration information about this filter.
      * @param mixed $reserved  For future use.
+     * @throws Exception
      */
     public function __construct(array &$config, $reserved)
     {
@@ -101,6 +102,8 @@ class TargetedID extends Auth\ProcessingFilter
      * Apply filter to add the targeted ID.
      *
      * @param array &$state  The current state.
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Process/WarnShortSSOInterval.php
+++ b/modules/core/src/Auth/Process/WarnShortSSOInterval.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Auth\Process;
 
-use SimpleSAML\{Auth, Logger, Module, Utils};
+use SimpleSAML\{Auth, Error\CriticalConfigurationError, Error\Exception, Logger, Module, Utils};
 
 use function array_key_exists;
 use function time;
@@ -24,6 +24,10 @@ class WarnShortSSOInterval extends Auth\ProcessingFilter
      * If it is to short a while since, we will show a warning to the user.
      *
      * @param array $state  The state of the response.
+     * @throws Exception
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function process(array &$state): void
     {

--- a/modules/core/src/Auth/Source/AbstractSourceSelector.php
+++ b/modules/core/src/Auth/Source/AbstractSourceSelector.php
@@ -29,6 +29,7 @@ abstract class AbstractSourceSelector extends Auth\Source
      *
      * @param array $info Information about this authentication source.
      * @param array $config Configuration.
+     * @throws Exception
      */
     public function __construct(array $info, array $config)
     {
@@ -54,6 +55,9 @@ abstract class AbstractSourceSelector extends Auth\Source
      *
      * @param \Symfony\Component\HttpFoundation\Request $request The current request
      * @param array &$state Information about the current authentication.
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function authenticate(Request $request, array &$state): ?Response
     {
@@ -72,6 +76,9 @@ abstract class AbstractSourceSelector extends Auth\Source
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param \SimpleSAML\Auth\Source $as
      * @param array $state
+     * @throws Error\Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function doAuthentication(Request $request, Auth\Source $as, array &$state): ?Response
     {

--- a/modules/core/src/Auth/Source/AdminPassword.php
+++ b/modules/core/src/Auth/Source/AdminPassword.php
@@ -22,6 +22,7 @@ class AdminPassword extends UserPassBase
      *
      * @param array $info  Information about this authentication source.
      * @param array $config  Configuration.
+     * @throws \Exception
      */
     public function __construct(array $info, array $config)
     {
@@ -44,6 +45,8 @@ class AdminPassword extends UserPassBase
      * @param string $username  The username the user wrote.
      * @param string $password  The password the user wrote.
      * @return array  Associative array with the users attributes.
+     * @throws Error\Error
+     * @throws \Exception
      */
     protected function login(
         string $username,

--- a/modules/core/src/Auth/Source/RequestedAuthnContextSelector.php
+++ b/modules/core/src/Auth/Source/RequestedAuthnContextSelector.php
@@ -68,6 +68,8 @@ class RequestedAuthnContextSelector extends AbstractSourceSelector
      *
      * @param array $info Information about this authentication source.
      * @param array $config Configuration.
+     * @throws Exception
+     * @throws \Exception
      */
     public function __construct(array $info, array $config)
     {
@@ -104,6 +106,8 @@ class RequestedAuthnContextSelector extends AbstractSourceSelector
      *
      * @param array &$state Information about the current authentication.
      * @return string
+     * @throws Exception
+     * @throws \Exception
      */
     protected function selectAuthSource(array &$state): string
     {

--- a/modules/core/src/Auth/Source/SourceIPSelector.php
+++ b/modules/core/src/Auth/Source/SourceIPSelector.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Auth\Source;
 
-use SimpleSAML\{Error, Logger};
+use SimpleSAML\{Error, Error\Exception, Error\NotFound, Logger};
 use SimpleSAML\Assert\Assert;
 use Symfony\Component\HttpFoundation\{IpUtils, Request};
 
@@ -52,6 +52,8 @@ class SourceIPSelector extends AbstractSourceSelector
      *
      * @param array $info Information about this authentication source.
      * @param array $config Configuration.
+     * @throws Exception
+     * @throws \Exception
      */
     public function __construct(array $info, array $config)
     {
@@ -87,6 +89,8 @@ class SourceIPSelector extends AbstractSourceSelector
      *
      * @param array &$state Information about the current authentication.
      * @return string
+     * @throws NotFound
+     * @throws \Exception
      */
     protected function selectAuthSource(/** @scrutinizer ignore-unused */ array &$state): string
     {

--- a/modules/core/src/Auth/UserPassBase.php
+++ b/modules/core/src/Auth/UserPassBase.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\core\Auth;
 
 use Exception;
-use SimpleSAML\{Auth, Configuration, Error, Logger, Module, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\NoState, Logger, Module, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Constants as C;
 use Symfony\Component\HttpFoundation\{Request, Response};
@@ -95,6 +95,7 @@ abstract class UserPassBase extends Auth\Source
      *
      * @param array $info  Information about this authentication source.
      * @param array &$config  Configuration for this authentication source.
+     * @throws Exception
      */
     public function __construct(array $info, array &$config)
     {
@@ -191,6 +192,10 @@ abstract class UserPassBase extends Auth\Source
      *
      * @param \Symfony\Component\HttpFoundation\Request $request  The current request
      * @param array &$state  Information about the current authentication.
+     * @throws Error\Error
+     * @throws Error\Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public function authenticate(Request $request, array &$state): ?Response
     {
@@ -276,6 +281,10 @@ abstract class UserPassBase extends Auth\Source
      * @param string $authStateId  The identifier of the authentication state.
      * @param string $username  The username the user wrote.
      * @param string $password  The password the user wrote.
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws NoState
+     * @throws \Throwable
      */
     public static function handleLogin(
         string $authStateId,

--- a/modules/core/src/Auth/UserPassOrgBase.php
+++ b/modules/core/src/Auth/UserPassOrgBase.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\core\Auth;
 
 use Exception;
-use SimpleSAML\{Auth, Error, Logger, Module, Utils};
+use SimpleSAML\{Auth, Error, Error\CriticalConfigurationError, Error\NoState, Logger, Module, Utils};
 use SimpleSAML\Assert\Assert;
 use Symfony\Component\HttpFoundation\{Request, Response};
 
@@ -208,6 +208,10 @@ abstract class UserPassOrgBase extends Auth\Source
      *
      * @param \Symfony\Component\HttpFoundation\Request $request  The current request
      * @param array &$state  Information about the current authentication.
+     * @throws Error\Exception
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \Throwable
      */
     public function authenticate(Request $request, array &$state): ?Response
     {
@@ -270,6 +274,11 @@ abstract class UserPassOrgBase extends Auth\Source
      * @param string $username  The username the user wrote.
      * @param string $password  The password the user wrote.
      * @param string $organization  The id of the organization the user chose.
+     * @throws Exception
+     * @throws Error\Error
+     * @throws Error\Exception
+     * @throws NoState
+     * @throws \Throwable
      */
     public static function handleLogin(
         string $authStateId,
@@ -334,6 +343,10 @@ abstract class UserPassOrgBase extends Auth\Source
      * @param string $authStateId  The identifier of the authentication state.
      * @return array|null  Array of organizations. NULL if the user must enter the
      *         organization as part of the username.
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws NoState
+     * @throws \Throwable
      */
     public static function listOrganizations(string $authStateId): ?array
     {

--- a/modules/core/src/Controller/ErrorReport.php
+++ b/modules/core/src/Controller/ErrorReport.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\core\Controller;
 
 use Exception as BuiltinException;
-use SimpleSAML\{Configuration, Error, Logger, Session, Utils};
+use SimpleSAML\{Configuration, Error, Error\ConfigurationError, Logger, Session, Utils};
+use PHPMailer\PHPMailer\Exception;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
 
@@ -42,6 +43,10 @@ class ErrorReport
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \SimpleSAML\XHTML\Template|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws ConfigurationError
+     * @throws BuiltinException
      */
     public function main(Request $request): RedirectResponse|Template
     {

--- a/modules/core/src/Controller/Exception.php
+++ b/modules/core/src/Controller/Exception.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Module\core\Controller;
 
 use DateTimeInterface;
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\{Auth, Configuration, Error, Logger, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\ConfigurationError, Error\NoState, Logger, Module, Session, Utils};
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
 
@@ -52,6 +52,8 @@ class Exception
      * @param Request $request The request that lead to this login operation.
      * @param string $code The error code
      * @return \SimpleSAML\XHTML\Template  An HTML template
+     * @throws ConfigurationError
+     * @throws \Exception
      */
     public function error(Request $request, string $code): Response
     {
@@ -109,8 +111,12 @@ class Exception
      * Show cardinality error.
      *
      * @param Request $request The request that lead to this login operation.
-     * @throws \SimpleSAML\Error\BadRequest
      * @return \SimpleSAML\XHTML\Template  An HTML template
+     * @throws ConfigurationError
+     * @throws \SimpleSAML\Error\BadRequest
+     * @throws NoState
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function cardinality(Request $request): Response
     {
@@ -144,6 +150,10 @@ class Exception
      * @param Request $request The request that lead to this login operation.
      * @return \SimpleSAML\XHTML\Template|\Symfony\Component\HttpFoundation\RedirectResponse
      *   An HTML template or a redirection if we are not authenticated.
+     * @throws ConfigurationError
+     * @throws Error\Exception
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function nocookie(Request $request): Template|RedirectResponse
     {
@@ -170,6 +180,10 @@ class Exception
      * An HTML template, a redirect or a "runnable" response.
      *
      * @throws \SimpleSAML\Error\BadRequest
+     * @throws ConfigurationError
+     * @throws NoState
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function shortSsoInterval(Request $request): Template|Response
     {

--- a/modules/core/src/Controller/Login.php
+++ b/modules/core/src/Controller/Login.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\core\Controller;
 
-use SimpleSAML\{Auth, Configuration, Error, Module, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\BadRequest, Error\CannotSetCookie, Error\ConfigurationError, Error\CriticalConfigurationError, Error\Exception, Error\NoState, Module, Utils};
 use SimpleSAML\Module\core\Auth\{UserPassBase, UserPassOrgBase};
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{Cookie, RedirectResponse, Request, Response};
@@ -83,6 +83,8 @@ class Login
 
     /**
      * @return \SimpleSAML\XHTML\Template
+     * @throws ConfigurationError
+     * @throws \Exception
      */
     public function welcome(): Template
     {
@@ -97,6 +99,11 @@ class Login
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws Exception
+     * @throws NoState
+     * @throws \Exception
+     * @throws BadRequest
+     * @throws \Throwable
      */
     public function loginuserpass(Request $request): Response
     {
@@ -143,6 +150,10 @@ class Login
      * @param \SimpleSAML\Module\core\Auth\UserPassBase|\SimpleSAML\Module\core\Auth\UserPassOrgBase $source
      * @param array $state
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws Exception
+     * @throws \Exception
+     * @throws ConfigurationError
+     * @throws \Throwable
      */
     private function handleLogin(Request $request, UserPassBase|UserPassOrgBase $source, array $state): Response
     {
@@ -361,6 +372,11 @@ class Login
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws Exception
+     * @throws NoState
+     * @throws \Exception
+     * @throws BadRequest
+     * @throws \Throwable
      */
     public function loginuserpassorg(Request $request): Response
     {
@@ -396,6 +412,7 @@ class Login
      * @param bool $raw        Whether this cookie must be sent without urlencoding
      * @param string $sameSite The value for the sameSite-flag
      * @return \Symfony\Component\HttpFoundation\Cookie
+     * @throws \InvalidArgumentException
      */
     private function renderCookie(
         string $name,
@@ -485,6 +502,10 @@ class Login
     /**
      * Searches for a valid and allowed ReturnTo URL parameter,
      * otherwise give the base installation page as a return point.
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     private function getReturnPath(Request $request): string
     {
@@ -505,6 +526,12 @@ class Login
      * This clears the user's IdP discovery choices.
      *
      * @param Request $request The request that lead to this login operation.
+     * @throws CannotSetCookie
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \SimpleSAML\Assert\AssertionFailedException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function cleardiscochoices(Request $request): RedirectResponse
     {

--- a/modules/core/src/Controller/Logout.php
+++ b/modules/core/src/Controller/Logout.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\core\Controller;
 
 use Exception as BuiltinException;
-use SimpleSAML\{Auth, Configuration, Error, IdP, Logger, Stats, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\BadRequest, Error\ConfigurationError, Error\CriticalConfigurationError, Error\Exception, Error\MetadataNotFound, Error\NoState, IdP, Logger, Stats, Utils};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\saml\Message;
 use SimpleSAML\SAML2\Binding;
@@ -72,6 +72,9 @@ class Logout
      * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \SimpleSAML\Error\CriticalConfigurationError
+     * @throws Exception
+     * @throws BuiltinException
+     * @throws \Throwable
      */
     public function logout(Request $request, string $as): Response
     {
@@ -84,6 +87,11 @@ class Logout
     /**
      * Searches for a valid and allowed ReturnTo URL parameter,
      * otherwise give the base installation page as a return point.
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     private function getReturnPath(Request $request): string
     {
@@ -105,6 +113,10 @@ class Logout
     /**
      * @param Request $request The request that lead to this logout operation.
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws NoState
+     * @throws BadRequest
+     * @throws BuiltinException
+     * @throws \Throwable
      */
     public function logoutIframeDone(Request $request): Response
     {
@@ -172,6 +184,11 @@ class Logout
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request The request that lead to this logout operation.
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws BuiltinException
+     * @throws Exception
+     * @throws MetadataNotFound
+     * @throws BadRequest
+     * @throws \Throwable
      */
     public function logoutIframePost(Request $request): Response
     {
@@ -240,6 +257,12 @@ class Logout
     /**
      * @param Request $request The request that lead to this logout operation.
      * @return \SimpleSAML\XHTML\Template
+     * @throws ConfigurationError
+     * @throws MetadataNotFound
+     * @throws NoState
+     * @throws BadRequest
+     * @throws BuiltinException
+     * @throws \Throwable
      */
     public function logoutIframe(Request $request): Template
     {
@@ -385,6 +408,10 @@ class Logout
 
     /**
      * @param Request $request The request that lead to this logout operation.
+     * @throws BuiltinException
+     * @throws NoState
+     * @throws BadRequest
+     * @throws \Throwable
      */
     public function resumeLogout(Request $request): Response
     {

--- a/modules/core/src/Controller/Redirection.php
+++ b/modules/core/src/Controller/Redirection.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\core\Controller;
 
 use Exception;
-use SimpleSAML\{Auth, Configuration, Error, Logger, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\ConfigurationError, Logger, Module, Session, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\XHTML\Template;
 use SimpleSAML\XMLSecurity\Alg\Encryption\AES;
@@ -46,9 +46,12 @@ class Redirection
      * This controller provides a way to create a redirect to a POST request
      *
      * @param Request $request The request that lead to this login operation.
-     * @throws \SimpleSAML\Error\BadRequest
      * @return \SimpleSAML\XHTML\Template|\Symfony\Component\HttpFoundation\RedirectResponse
      *   An HTML template or a redirection if we are not authenticated.
+     * @throws ConfigurationError
+     * @throws \SimpleSAML\Error\BadRequest
+     * @throws Error\Exception
+     * @throws Exception
      */
     public function postredirect(Request $request): Response
     {

--- a/modules/core/src/Stats/Output/File.php
+++ b/modules/core/src/Stats/Output/File.php
@@ -50,6 +50,7 @@ class File extends Stats\Output
      * Initialize the output.
      *
      * @param \SimpleSAML\Configuration $config  The configuration for this output.
+     * @throws Exception
      */
     public function __construct(Configuration $config)
     {
@@ -68,6 +69,7 @@ class File extends Stats\Output
      * Open a log file.
      *
      * @param string $date  The date for the log file.
+     * @throws Error\Exception
      */
     private function openLog(string $date): void
     {
@@ -94,6 +96,7 @@ class File extends Stats\Output
      * Write a stats event.
      *
      * @param array $data  The event.
+     * @throws Error\Exception
      */
     public function emit(array $data): void
     {

--- a/modules/cron/hooks/hook_configpage.php
+++ b/modules/cron/hooks/hook_configpage.php
@@ -10,6 +10,8 @@ use SimpleSAML\XHTML\Template;
  * Hook to add the cron module to the config page.
  *
  * @param \SimpleSAML\XHTML\Template &$template The template that we should alter in this hook.
+ * @throws \SimpleSAML\Error\CriticalConfigurationError
+ * @throws Exception
  */
 function cron_hook_configpage(Template &$template): void
 {

--- a/modules/cron/hooks/hook_cron.php
+++ b/modules/cron/hooks/hook_cron.php
@@ -9,6 +9,7 @@ use SimpleSAML\Configuration;
  * Hook to run a cron job.
  *
  * @param array &$croninfo  Output
+ * @throws Exception
  */
 function cron_hook_cron(array &$croninfo): void
 {

--- a/modules/cron/src/Controller/Cron.php
+++ b/modules/cron/src/Controller/Cron.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\cron\Controller;
 
 use PHPMailer\PHPMailer\Exception as PHPMailerException;
-use SimpleSAML\{Auth, Configuration, Error, Logger, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\ConfigurationError, Error\Exception, Logger, Module, Session, Utils};
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
 
@@ -66,6 +66,9 @@ class Cron
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response|\SimpleSAML\XHTML\Template
      *   An HTML template or a redirection if we are not authenticated.
+     * @throws ConfigurationError
+     * @throws Exception
+     * @throws \Throwable
      */
     public function info(/** @scrutinizer ignore-unused */Request $request): Response|Template
     {
@@ -113,6 +116,7 @@ class Cron
      * @return \SimpleSAML\XHTML\Template An HTML template.
      *
      * @throws \SimpleSAML\Error\Exception
+     * @throws \Exception
      */
     public function run(
         /** @scrutinizer ignore-unused */Request $request,

--- a/modules/cron/src/Cron.php
+++ b/modules/cron/src/Cron.php
@@ -23,9 +23,10 @@ class Cron
     private Configuration $cronconfig;
 
 
-    /*
+    /**
      * @param \SimpleSAML\Configuration $cronconfig The cron configuration to use. If not specified defaults
      * to `config/module_cron.php`
+     * @throws \Exception
      */
     public function __construct(?Configuration $cronconfig = null)
     {
@@ -67,6 +68,7 @@ class Cron
     /**
      * @param string $tag
      * @return bool
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function isValidTag(string $tag): bool
     {

--- a/modules/debugsp/src/Controller/Test.php
+++ b/modules/debugsp/src/Controller/Test.php
@@ -8,6 +8,8 @@ use SimpleSAML\Assert\Assert;
 use SimpleSAML\Auth;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error;
+use SimpleSAML\Error\ConfigurationError;
+use SimpleSAML\Error\NoState;
 use SimpleSAML\HTTP\RunnableResponse;
 use SimpleSAML\Module;
 use SimpleSAML\Session;
@@ -77,6 +79,8 @@ class Test
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string|null $as
      * @return \SimpleSAML\XHTML\Template|\SimpleSAML\HTTP\RunnableResponse
+     * @throws \Exception
+     * @throws ConfigurationError
      */
     private function makeSPList(Request $request, ?string $as = null): Response
     {
@@ -100,6 +104,10 @@ class Test
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string|null $as
      * @return \SimpleSAML\XHTML\Template|\SimpleSAML\HTTP\RunnableResponse
+     * @throws ConfigurationError
+     * @throws NoState
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function main(Request $request, ?string $as = null): Response
     {
@@ -169,6 +177,8 @@ class Test
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \SimpleSAML\XHTML\Template
+     * @throws ConfigurationError
+     * @throws \Exception
      */
     public function logout(Request $request): Template
     {

--- a/modules/exampleauth/src/Auth/Process/RedirectTest.php
+++ b/modules/exampleauth/src/Auth/Process/RedirectTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\exampleauth\Auth\Process;
 
-use SimpleSAML\{Auth, Module, Utils};
+use SimpleSAML\{Auth, Error\CriticalConfigurationError, Error\Exception, Module, Utils};
 use SimpleSAML\Assert\Assert;
 
 /**
@@ -17,6 +17,10 @@ class RedirectTest extends Auth\ProcessingFilter
      * Initialize processing of the redirect test.
      *
      * @param array &$state  The state we should update.
+     * @throws Exception
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function process(array &$state): void
     {

--- a/modules/exampleauth/src/Auth/Source/External.php
+++ b/modules/exampleauth/src/Auth/Source/External.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\exampleauth\Auth\Source;
 
-use SimpleSAML\{Auth, Error, Module, Utils};
+use SimpleSAML\{Auth, Error, Error\CriticalConfigurationError, Error\Exception, Module, Utils};
 use Symfony\Component\HttpFoundation\{Request, Response};
 
 use function session_id;
@@ -102,6 +102,10 @@ class External extends Auth\Source
      *
      * @param \Symfony\Component\HttpFoundation\Request $request  The current request
      * @param array &$state  Information about the current authentication.
+     * @throws Exception
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function authenticate(Request $request, array &$state): ?Response
     {
@@ -184,6 +188,8 @@ class External extends Auth\Source
      *
      * @throws \SimpleSAML\Error\BadRequest
      * @throws \SimpleSAML\Error\Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public static function resume(Request $request, Auth\State $authState): Response
     {

--- a/modules/exampleauth/src/Auth/Source/StaticSource.php
+++ b/modules/exampleauth/src/Auth/Source/StaticSource.php
@@ -30,6 +30,7 @@ class StaticSource extends Auth\Source
      *
      * @param array $info  Information about this authentication source.
      * @param array $config  Configuration.
+     * @throws Exception
      */
     public function __construct(array $info, array $config)
     {

--- a/modules/exampleauth/src/Auth/Source/UserPass.php
+++ b/modules/exampleauth/src/Auth/Source/UserPass.php
@@ -39,6 +39,7 @@ class UserPass extends UserPassBase
      *
      * @param array $info  Information about this authentication source.
      * @param array $config  Configuration.
+     * @throws Exception
      */
     public function __construct(array $info, array $config)
     {
@@ -92,6 +93,7 @@ class UserPass extends UserPassBase
      * @param string $username  The username the user wrote.
      * @param string $password  The password the user wrote.
      * @return array  Associative array with the users attributes.
+     * @throws Error\Error
      */
     protected function login(
         string $username,

--- a/modules/exampleauth/src/Controller/ExampleAuth.php
+++ b/modules/exampleauth/src/Controller/ExampleAuth.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\exampleauth\Controller;
 
-use SimpleSAML\{Auth, Configuration, Error, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\BadRequest, Error\ConfigurationError, Error\Exception, Error\NoState, Session, Utils};
 use SimpleSAML\Module\exampleauth\Auth\Source\External;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
@@ -63,6 +63,10 @@ class ExampleAuth
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \SimpleSAML\XHTML\Template|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @throws ConfigurationError
+     * @throws NoState
+     * @throws Exception
+     * @throws \Throwable
      */
     public function authpage(Request $request): Template|RedirectResponse
     {
@@ -158,6 +162,10 @@ class ExampleAuth
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws NoState
+     * @throws BadRequest
+     * @throws Exception
+     * @throws \Throwable
      */
     public function redirecttest(Request $request): Response
     {
@@ -180,6 +188,10 @@ class ExampleAuth
      * Resume testpage.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request The current request.
+     * @throws \SimpleSAML\Error\BadRequest
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function resume(Request $request): Response
     {

--- a/modules/multiauth/src/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/src/Auth/Source/MultiAuth.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Module\multiauth\Auth\Source;
 
 use SimpleSAML\SAML2\Exception\Protocol\NoAuthnContextException;
 use Exception;
-use SimpleSAML\{Auth, Configuration, Error, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\CannotSetCookie, Error\CriticalConfigurationError, Module, Session, Utils};
 use Symfony\Component\HttpFoundation\{Request, Response};
 
 use function array_intersect;
@@ -62,6 +62,7 @@ class MultiAuth extends Auth\Source
      *
      * @param array $info Information about this authentication source.
      * @param array $config Configuration.
+     * @throws Exception
      */
     public function __construct(array $info, array $config)
     {
@@ -95,6 +96,8 @@ class MultiAuth extends Auth\Source
      *
      * @param \Symfony\Component\HttpFoundation\Request $request  The current request
      * @param array &$state Information about the current authentication.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function authenticate(Request $request, array &$state): Response
     {
@@ -160,6 +163,7 @@ class MultiAuth extends Auth\Source
      * @param string $authId Selected authentication source
      * @param array $state Information about the current authentication.
      * @throws \Exception
+     * @throws \Throwable
      */
     public static function delegateAuthentication(string $authId, array $state): Response
     {
@@ -184,6 +188,9 @@ class MultiAuth extends Auth\Source
     /**
      * @param \SimpleSAML\Auth\Source $as
      * @param array $state
+     * @throws Error\Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function doAuthentication(Auth\Source $as, array $state): Response
     {
@@ -211,6 +218,9 @@ class MultiAuth extends Auth\Source
      * session and then call the logout method on it.
      *
      * @param array &$state Information about the current logout operation.
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function logout(array &$state): ?Response
     {
@@ -235,6 +245,9 @@ class MultiAuth extends Auth\Source
      * by storing its name in a cookie.
      *
      * @param string $source Name of the authentication source the user selected.
+     * @throws CannotSetCookie
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     public function setPreviousSource(string $source): void
     {

--- a/modules/multiauth/src/Controller/DiscoController.php
+++ b/modules/multiauth/src/Controller/DiscoController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\multiauth\Controller;
 
-use SimpleSAML\{Auth, Configuration, Error, Logger, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\BadRequest, Error\ConfigurationError, Error\Exception, Error\NoState, Logger, Module, Session, Utils};
 use SimpleSAML\Module\multiauth\Auth\Source\MultiAuth;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
@@ -82,6 +82,12 @@ class DiscoController
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \SimpleSAML\XHTML\Template|\Symfony\Component\HttpFoundation\Response
      *   An HTML template or a redirection if we are not authenticated.
+     * @throws ConfigurationError
+     * @throws \Exception
+     * @throws Exception
+     * @throws NoState
+     * @throws BadRequest
+     * @throws \Throwable
      */
     public function discovery(Request $request): Template|Response
     {

--- a/modules/saml/hooks/hook_sanitycheck.php
+++ b/modules/saml/hooks/hook_sanitycheck.php
@@ -7,6 +7,10 @@ use SimpleSAML\{Configuration, Utils};
 use SimpleSAML\Locale\Translate;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 
+/**
+ * @throws \SimpleSAML\Error\Exception
+ * @throws Exception
+ */
 function saml_hook_sanitycheck(array &$hookinfo): void
 {
     Assert::keyExists($hookinfo, 'errors');

--- a/modules/saml/src/Auth/Process/AttributeNameID.php
+++ b/modules/saml/src/Auth/Process/AttributeNameID.php
@@ -70,6 +70,7 @@ class AttributeNameID extends BaseNameIDGenerator
      *
      * @param array $state The state array.
      * @return string|null The NameID value.
+     * @throws \Exception
      */
     protected function getValue(array &$state): ?string
     {

--- a/modules/saml/src/Auth/Process/ExpectedAuthnContextClassRef.php
+++ b/modules/saml/src/Auth/Process/ExpectedAuthnContextClassRef.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\saml\Auth\Process;
 
-use SimpleSAML\{Auth, Error, Logger, Module, Utils};
+use SimpleSAML\{Auth, Error, Error\CriticalConfigurationError, Error\Exception, Logger, Module, Utils};
 use SimpleSAML\Assert\Assert;
 
 use function in_array;
@@ -50,6 +50,7 @@ class ExpectedAuthnContextClassRef extends Auth\ProcessingFilter
      * @param mixed $reserved For future use.
      *
      * @throws \SimpleSAML\Error\Exception if the mandatory 'accepted' configuration option is missing.
+     * @throws \Exception
      */
     public function __construct(array $config, $reserved)
     {
@@ -69,6 +70,10 @@ class ExpectedAuthnContextClassRef extends Auth\ProcessingFilter
 
     /**
      * @param array &$state The current request
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \SimpleSAML\Error\CriticalConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function process(array &$state): void
     {
@@ -93,6 +98,10 @@ class ExpectedAuthnContextClassRef extends Auth\ProcessingFilter
      * permission logic.
      *
      * @param array $state
+     * @throws Exception
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function unauthorized(array &$state): void
     {

--- a/modules/saml/src/Auth/Process/FilterScopes.php
+++ b/modules/saml/src/Auth/Process/FilterScopes.php
@@ -49,6 +49,7 @@ class FilterScopes extends Auth\ProcessingFilter
      * This method applies the filter, removing any values
      *
      * @param array &$state the current request
+     * @throws \Exception
      */
     public function process(array &$state): void
     {

--- a/modules/saml/src/Auth/Process/NameIDAttribute.php
+++ b/modules/saml/src/Auth/Process/NameIDAttribute.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\saml\Auth\Process;
 
-use SimpleSAML\{Auth, Error};
+use SimpleSAML\{Auth, Error, Error\Exception};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\XML\saml\NameID;
@@ -43,6 +43,7 @@ class NameIDAttribute extends Auth\ProcessingFilter
      *
      * @param array $config Configuration information about this filter.
      * @param mixed $reserved For future use.
+     * @throws Exception
      */
     public function __construct(array $config, $reserved)
     {

--- a/modules/saml/src/Auth/Process/PairwiseID.php
+++ b/modules/saml/src/Auth/Process/PairwiseID.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\saml\Auth\Process;
 
+use SimpleSAML\Error\CriticalConfigurationError;
 use SimpleSAML\SAML2\Constants as C;
 
 use function strtolower;
@@ -59,6 +60,8 @@ class PairwiseID extends SubjectID
      * Apply filter to add the Pairwise ID.
      *
      * @param array &$state  The current state.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function process(array &$state): void
     {

--- a/modules/saml/src/Auth/Process/PersistentNameID.php
+++ b/modules/saml/src/Auth/Process/PersistentNameID.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\saml\Auth\Process;
 
-use SimpleSAML\{Error, Logger, Utils};
+use SimpleSAML\{Error, Error\CriticalConfigurationError, Logger, Utils};
 use SimpleSAML\Module\saml\BaseNameIDGenerator;
 use SimpleSAML\SAML2\Constants as C;
 
@@ -56,6 +56,8 @@ class PersistentNameID extends BaseNameIDGenerator
      *
      * @param array $state The state array.
      * @return string|null The NameID value.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     protected function getValue(array &$state): ?string
     {

--- a/modules/saml/src/Auth/Process/PersistentNameID2TargetedID.php
+++ b/modules/saml/src/Auth/Process/PersistentNameID2TargetedID.php
@@ -59,6 +59,7 @@ class PersistentNameID2TargetedID extends Auth\ProcessingFilter
      * Store a NameID to attribute.
      *
      * @param array &$state The request state.
+     * @throws \Exception
      */
     public function process(array &$state): void
     {

--- a/modules/saml/src/Auth/Process/SQLPersistentNameID.php
+++ b/modules/saml/src/Auth/Process/SQLPersistentNameID.php
@@ -107,6 +107,7 @@ class SQLPersistentNameID extends BaseNameIDGenerator
      * @return string|null The NameID value.
      *
      * @throws \SimpleSAML\Module\saml\Error if the NameID creation policy is invalid.
+     * @throws \Exception
      */
     protected function getValue(array &$state): ?string
     {

--- a/modules/saml/src/Auth/Process/ScopedIssuer.php
+++ b/modules/saml/src/Auth/Process/ScopedIssuer.php
@@ -87,6 +87,8 @@ class ScopedIssuer extends Auth\ProcessingFilter
      * Apply filter to dynamically set the saml:Issuer.
      *
      * @param array &$state  The current state.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
+     * @throws \SAML2\Exception\ProtocolViolationException
      */
     public function process(array &$state): void
     {

--- a/modules/saml/src/Auth/Process/SubjectID.php
+++ b/modules/saml/src/Auth/Process/SubjectID.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\saml\Auth\Process;
 
-use SimpleSAML\{Auth, Logger, Utils};
+use SimpleSAML\{Auth, Error\CriticalConfigurationError, Logger, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\Exception\ProtocolViolationException;
@@ -136,6 +136,8 @@ class SubjectID extends Auth\ProcessingFilter
      * Apply filter to add the subject ID.
      *
      * @param array &$state  The current state.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function process(array &$state): void
     {
@@ -165,6 +167,7 @@ class SubjectID extends Auth\ProcessingFilter
      * @param array $state
      * @return string|null
      * @throws \SimpleSAML\Assert\AssertionFailedException if the pre-conditions are not met
+     * @throws \Exception
      */
     protected function getIdentifyingAttribute(array $state): ?string
     {
@@ -197,6 +200,7 @@ class SubjectID extends Auth\ProcessingFilter
      * @return string|null
      * @throws \SimpleSAML\Assert\AssertionFailedException if the scope is an empty string
      * @throws \SimpleSAML\SAML2\Exception\ProtocolViolationException if the pre-conditions are not met
+     * @throws \Exception
      */
     protected function getScopeAttribute(array $state): ?string
     {
@@ -235,6 +239,7 @@ class SubjectID extends Auth\ProcessingFilter
      * @param string $value
      * @return void
      * @throws \SimpleSAML\SAML2\Exception\ProtocolViolationException if the post-conditions are not met
+     * @throws \Exception
      */
     protected function validateGeneratedIdentifier(string $value): void
     {
@@ -255,6 +260,9 @@ class SubjectID extends Auth\ProcessingFilter
 
     /**
      * Calculate the hash for the unique part of the identifier.
+     * @throws CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     protected function calculateHash(string $input): string
     {

--- a/modules/saml/src/BaseNameIDGenerator.php
+++ b/modules/saml/src/BaseNameIDGenerator.php
@@ -87,6 +87,7 @@ abstract class BaseNameIDGenerator extends Auth\ProcessingFilter
      * Generate transient NameID.
      *
      * @param array &$state  The request state.
+     * @throws \Exception
      */
     public function process(array &$state): void
     {

--- a/modules/saml/src/Controller/Disco.php
+++ b/modules/saml/src/Controller/Disco.php
@@ -34,6 +34,8 @@ class Disco
      * Built-in IdP discovery service
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function disco(Request $request): Response
     {

--- a/modules/saml/src/Controller/Metadata.php
+++ b/modules/saml/src/Controller/Metadata.php
@@ -34,6 +34,7 @@ class Metadata
      * It initializes the global configuration for the controllers implemented here.
      *
      * @param \SimpleSAML\Configuration $config The configuration to use by the controllers.
+     * @throws Exception
      */
     public function __construct(
         protected Configuration $config,
@@ -65,6 +66,10 @@ class Metadata
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws Error\Error
+     * @throws Error\Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public function metadata(Request $request): Response
     {

--- a/modules/saml/src/Controller/Proxy.php
+++ b/modules/saml/src/Controller/Proxy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\saml\Controller;
 
 use Exception;
-use SimpleSAML\{Auth, Configuration, Error, IdP};
+use SimpleSAML\{Auth, Configuration, Error, Error\BadRequest, Error\ConfigurationError, Error\NoState, IdP};
 use SimpleSAML\Module\saml\Auth\Source\SP;
 use SimpleSAML\Module\saml\Error\NoAvailableIDP;
 use SimpleSAML\SAML2\Constants as C;
@@ -58,6 +58,12 @@ class Proxy
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \SimpleSAML\XHTML\Template|\Symfony\Component\HttpFoundation\Response
+     * @throws ConfigurationError
+     * @throws Error\Exception
+     * @throws NoState
+     * @throws BadRequest
+     * @throws Exception
+     * @throws \Throwable
      */
     public function invalidSession(Request $request): Template|Response
     {

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Module\saml\Controller;
 
 use Exception;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use SimpleSAML\{Auth, Configuration, Error, Logger, Metadata, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\AuthSource, Error\BadRequest, Error\ConfigurationError, Error\CriticalConfigurationError, Error\NoState, Logger, Metadata, Module, Session, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Module\saml\Auth\Source\SP;
 use SimpleSAML\SAML2\{Assertion, Binding, HTTPArtifact, HTTPRedirect, LogoutRequest, LogoutResponse, SOAP};
@@ -95,6 +95,8 @@ class ServiceProvider
      * @param string $sourceId
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      * @throws Error\Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public function login(Request $request, string $sourceId): RedirectResponse
     {
@@ -121,6 +123,7 @@ class ServiceProvider
      * @return string
      * @throws BadRequest
      * @throws Error\Exception
+     * @throws \Throwable
      */
     protected function loginHandler(
         Request $request,
@@ -201,6 +204,11 @@ class ServiceProvider
      * Handler for response from IdP discovery service.
      *
      * @param \Symfony\Component\HttpFoundation\Request|null $request
+     * @throws Error\Exception
+     * @throws Exception
+     * @throws NoState
+     * @throws BadRequest
+     * @throws \Throwable
      */
     public function discoResponse(Request $request): ?Response
     {
@@ -235,6 +243,8 @@ class ServiceProvider
 
     /**
      * @return \SimpleSAML\XHTML\Template
+     * @throws ConfigurationError
+     * @throws \Exception
      */
     public function wrongAuthnContextClassRef(): Template
     {
@@ -248,6 +258,12 @@ class ServiceProvider
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $sourceId
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws Error\Exception
+     * @throws CriticalConfigurationError
+     * @throws BadRequest
+     * @throws Exception
+     * @throws Error\Error
+     * @throws \Throwable
      */
     public function assertionConsumerService(Request $request, string $sourceId): Response
     {
@@ -523,6 +539,12 @@ class ServiceProvider
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $sourceId
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws BadRequest
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws NoState
+     * @throws Error\Error
+     * @throws \Throwable
      */
     public function singleLogoutService(Request $request, string $sourceId): Response
     {
@@ -674,6 +696,10 @@ class ServiceProvider
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $sourceId
      * @return \Symfony\Component\HttpFoundation\Response
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws AuthSource
+     * @throws \Throwable
      */
     public function metadata(Request $request, string $sourceId): Response
     {

--- a/modules/saml/src/Controller/SingleLogout.php
+++ b/modules/saml/src/Controller/SingleLogout.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\saml\Controller;
 
-use SimpleSAML\{Configuration, Error, IdP, Logger, Module, Utils};
+use SimpleSAML\{Configuration, Error, Error\BadRequest, Error\Exception, IdP, Logger, Module, Utils};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\SAML2\Exception\Protocol\UnsupportedBindingException;
 use Symfony\Component\HttpFoundation\{Request, Response};
@@ -34,6 +34,7 @@ class SingleLogout
      * It initializes the global configuration for the controllers implemented here.
      *
      * @param \SimpleSAML\Configuration $config The configuration to use by the controllers.
+     * @throws \Exception
      */
     public function __construct(
         protected Configuration $config,
@@ -69,6 +70,11 @@ class SingleLogout
      * and LogoutRequests and also receive LogoutResponses. It is implementing SLO at the SAML 2.0 IdP.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @throws Error\Error
+     * @throws BadRequest
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function singleLogout(Request $request): Response
     {
@@ -104,6 +110,10 @@ class SingleLogout
      * This endpoint will initialize the SLO flow at the SAML 2.0 IdP.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @throws Exception
+     * @throws Error\Error
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function initSingleLogout(Request $request): Response
     {

--- a/modules/saml/src/Controller/WebBrowserSingleSignOn.php
+++ b/modules/saml/src/Controller/WebBrowserSingleSignOn.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Module\saml\Controller;
 
 use Exception;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use SimpleSAML\{Configuration, Error, IdP, Logger, Metadata, Module};
+use SimpleSAML\{Configuration, Error, Error\BadRequest, Error\CriticalConfigurationError, Error\MetadataNotFound, IdP, Logger, Metadata, Module};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\{ArtifactResolve, ArtifactResponse, SOAP};
 use SimpleSAML\SAML2\Exception\Protocol\UnsupportedBindingException;
@@ -43,6 +43,10 @@ class WebBrowserSingleSignOn
      * And when the artifact is found, it sends a \SimpleSAML\SAML2\ArtifactResponse.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @throws MetadataNotFound
+     * @throws Exception
+     * @throws Error\Error
+     * @throws CriticalConfigurationError
      */
     public function artifactResolutionService(Request $request): Response
     {
@@ -113,6 +117,10 @@ class WebBrowserSingleSignOn
      * to the SP with an Authentication Response.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @throws Error\Error
+     * @throws BadRequest
+     * @throws Exception
+     * @throws \Throwable
      */
     public function singleSignOnService(Request $request): Response
     {

--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -11,7 +11,7 @@ use DOMNodeList;
 use Exception;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
-use SimpleSAML\{Auth, Configuration, Error, IdP, Logger, Module, Stats, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\MetadataNotFound, IdP, Logger, Module, Stats, Utils};
 use SimpleSAML\Assert\{Assert, AssertionFailedException};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\saml\Message;
@@ -62,6 +62,9 @@ class SAML2
      * Send a response to the SP.
      *
      * @param array $state The authentication state.
+     * @throws Error\Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function sendResponse(array $state): Response
     {
@@ -138,6 +141,8 @@ class SAML2
      * \SimpleSAML\Error\Exception $exception  The exception.
      *
      * @param array $state The error state.
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function handleAuthError(Error\Exception $exception, array $state): Response
     {
@@ -218,6 +223,7 @@ class SAML2
      * @param bool                      $authnRequestSigned Whether or not the authn request was signed.
      *
      * @return array|null  Array with the Location and Binding we should use for the response.
+     * @throws Exception
      */
     private static function getAssertionConsumerService(
         array $supportedBindings,
@@ -326,6 +332,10 @@ class SAML2
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param \SimpleSAML\IdP $idp The IdP we are receiving it for.
      * @throws \SimpleSAML\Error\BadRequest In case an error occurs when trying to receive the request.
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws MetadataNotFound
+     * @throws \Throwable
      */
     public static function receiveAuthnRequest(Request $request, IdP $idp): Response
     {
@@ -564,6 +574,8 @@ class SAML2
      * @param \SimpleSAML\IdP $idp The IdP we are sending a logout request from.
      * @param array           $association The association that should be terminated.
      * @param string|null     $relayState An id that should be carried across the logout.
+     * @throws Exception
+     * @throws MetadataNotFound
      */
     public static function sendLogoutRequest(IdP $idp, array $association, ?string $relayState = null): Response
     {
@@ -603,6 +615,8 @@ class SAML2
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param \SimpleSAML\IdP $idp The IdP we are sending a logout request from.
      * @param array           &$state The logout state array.
+     * @throws Exception
+     * @throws MetadataNotFound
      */
     public static function sendLogoutResponse(Request $request, IdP $idp, array $state): Response
     {
@@ -669,6 +683,10 @@ class SAML2
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param \SimpleSAML\IdP $idp The IdP we are receiving it for.
      * @throws \SimpleSAML\Error\BadRequest In case an error occurs while trying to receive the logout message.
+     * @throws Error\Exception
+     * @throws MetadataNotFound
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function receiveLogoutMessage(Request $request, IdP $idp): Response
     {
@@ -749,6 +767,8 @@ class SAML2
      * @param string|NULL     $relayState An id that should be carried across the logout.
      *
      * @return string The logout URL.
+     * @throws Exception
+     * @throws MetadataNotFound
      */
     public static function getLogoutURL(IdP $idp, array $association, ?string $relayState = null): string
     {
@@ -789,6 +809,7 @@ class SAML2
      * @param array           $association The SP association.
      *
      * @return \SimpleSAML\Configuration  Configuration object for the SP metadata.
+     * @throws Exception
      */
     public static function getAssociationConfig(IdP $idp, array $association): Configuration
     {
@@ -812,6 +833,7 @@ class SAML2
      * @throws \SimpleSAML\Error\CriticalConfigurationError
      * @throws \SimpleSAML\Error\Exception
      * @throws \SimpleSAML\Error\MetadataNotFound
+     * @throws Exception
      */
     public static function getHostedMetadata(string $entityid, ?MetaDataStorageHandler $handler = null): array
     {
@@ -1056,6 +1078,7 @@ class SAML2
      * @return array  The encoded attributes.
      *
      * @throws \SimpleSAML\Error\Exception In case an unsupported encoding is specified by configuration.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     private static function encodeAttributes(
         Configuration $idpMetadata,
@@ -1129,6 +1152,8 @@ class SAML2
      * @param \SimpleSAML\Configuration $spMetadata The metadata of the SP.
      *
      * @return string  The NameFormat.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     private static function getAttributeNameFormat(
         Configuration $idpMetadata,
@@ -1169,6 +1194,7 @@ class SAML2
      * @return \SimpleSAML\SAML2\Assertion  The assertion.
      *
      * @throws \SimpleSAML\Error\Exception In case an error occurs when creating a holder-of-key assertion.
+     * @throws Exception
      */
     private static function buildAssertion(
         Configuration $idpMetadata,
@@ -1340,6 +1366,7 @@ class SAML2
 
     /**
      * Helper for buildAssertion to decide on an NameID to set
+     * @throws Exception
      */
     private static function generateNameId(
         Configuration $idpMetadata,
@@ -1413,6 +1440,7 @@ class SAML2
      * @return \SimpleSAML\SAML2\Assertion|\SimpleSAML\SAML2\EncryptedAssertion  The assertion.
      *
      * @throws \SimpleSAML\Error\Exception In case the encryption key type is not supported.
+     * @throws Exception
      */
     private static function encryptAssertion(
         Configuration $idpMetadata,
@@ -1482,6 +1510,8 @@ class SAML2
      * @param string|null $relayState An id that should be carried across the logout.
      *
      * @return \SimpleSAML\SAML2\LogoutRequest The corresponding SAML2 logout request.
+     * @throws Error\Exception
+     * @throws Exception
      */
     private static function buildLogoutRequest(
         Configuration $idpMetadata,
@@ -1520,6 +1550,7 @@ class SAML2
      * @param string                    $consumerURL The Destination URL of the response.
      *
      * @return \SimpleSAML\SAML2\Response The SAML2 Response corresponding to the given data.
+     * @throws Exception
      */
     private static function buildResponse(
         Configuration $idpMetadata,

--- a/modules/saml/src/IdP/SQLNameID.php
+++ b/modules/saml/src/IdP/SQLNameID.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Module\saml\IdP;
 use Exception;
 use PDO;
 use PDOStatement;
-use SimpleSAML\{Configuration, Database, Error, Logger, Store};
+use SimpleSAML\{Configuration, Database, Error, Error\CriticalConfigurationError, Logger, Store};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Store\StoreFactory;
 
@@ -30,6 +30,8 @@ class SQLNameID
      * @param array $params Parameters
      * @param array $config
      * @return \PDOStatement object
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     private static function read(string $query, array $params = [], array $config = []): PDOStatement
     {
@@ -50,6 +52,8 @@ class SQLNameID
      * @param array $params Parameters
      * @param array $config
      * @return int|false The number of rows affected by the query or false on error.
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     private static function write(string $query, array $params = [], array $config = [])
     {
@@ -71,6 +75,7 @@ class SQLNameID
     /**
      * @param array $config
      * @return string
+     * @throws CriticalConfigurationError
      */
     private static function tableName(array $config = []): string
     {
@@ -82,6 +87,8 @@ class SQLNameID
 
     /**
      * @param array $config
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     private static function create(array $config = []): void
     {
@@ -105,6 +112,8 @@ class SQLNameID
      * @param array $params
      * @param array $config
      * @return \PDOStatement
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     private static function createAndRead(string $query, array $params = [], array $config = []): PDOStatement
     {
@@ -118,6 +127,8 @@ class SQLNameID
      * @param array $params
      * @param array $config
      * @return int|false The number of rows affected by the query or false on error.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     private static function createAndWrite(string $query, array $params = [], array $config = [])
     {
@@ -131,6 +142,8 @@ class SQLNameID
      *
      * @param string $table  The table name.
      * @param array $config
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     private static function createTable(string $table, array $config = []): void
     {
@@ -153,6 +166,8 @@ class SQLNameID
      * Retrieve the SQL datastore.
      *
      * @return \SimpleSAML\Store\SQLStore  SQL datastore.
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     private static function getStore(): Store\SQLStore
     {
@@ -179,6 +194,8 @@ class SQLNameID
      * @param string $user  The user's unique identificator (e.g. username).
      * @param string $value  The NameID value.
      * @param array $config
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public static function add(
         string $idpEntityId,
@@ -209,6 +226,8 @@ class SQLNameID
      * @param string $user  The user's unique identificator (e.g. username).
      * @param array $config
      * @return string|null $value  The NameID value, or NULL of no NameID value was found.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public static function get(
         string $idpEntityId,
@@ -243,6 +262,8 @@ class SQLNameID
      * @param string $spEntityId  The SP entityID.
      * @param string $user  The user's unique identificator (e.g. username).
      * @param array $config
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public static function delete(
         string $idpEntityId,
@@ -269,6 +290,8 @@ class SQLNameID
      * @param string $spEntityId  The SP entityID.
      * @param array $config
      * @return array  Array of userid => NameID.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public static function getIdentities(string $idpEntityId, string $spEntityId, array $config = []): array
     {

--- a/modules/saml/src/Message.php
+++ b/modules/saml/src/Message.php
@@ -46,6 +46,8 @@ class Message
      * @param \SimpleSAML\Configuration $srcMetadata The metadata of the sender.
      * @param \SimpleSAML\Configuration $dstMetadata The metadata of the recipient.
      * @param \SimpleSAML\SAML2\SignedElement $element The element we should add the data to.
+     * @throws Exception
+     * @throws SSP_Error\Exception
      */
     public static function addSign(
         Configuration $srcMetadata,
@@ -98,6 +100,9 @@ class Message
      * @param \SimpleSAML\Configuration $srcMetadata The metadata of the sender.
      * @param \SimpleSAML\Configuration $dstMetadata The metadata of the recipient.
      * @param \SAML2\Message $message The message we should add the data to.
+     * @throws SSP_Error\Exception
+     * @throws \SimpleSAML\Assert\AssertionFailedException
+     * @throws \Exception
      */
     private static function addRedirectSign(
         Configuration $srcMetadata,
@@ -205,6 +210,8 @@ class Message
      * @return bool Whether or not the message was validated.
      *
      * @throws \SimpleSAML\Error\Exception if message validation is enabled, but there is no signature in the message.
+     * @throws \Exception
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public static function validateMessage(
         Configuration $srcMetadata,
@@ -258,6 +265,8 @@ class Message
      *   The EncryptionMethod from the assertion.
      *
      * @return array Array of decryption keys.
+     * @throws Exception
+     * @throws SSP_Error\Exception
      */
     public static function getDecryptionKeys(
         Configuration $srcMetadata,
@@ -327,6 +336,8 @@ class Message
      * @param \SimpleSAML\Configuration $dstMetadata The metadata of the recipient.
      *
      * @return array  Array of blacklisted algorithms.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public static function getBlacklistedAlgorithms(
         Configuration $srcMetadata,
@@ -416,6 +427,7 @@ class Message
      *
      *
      * @throws \SimpleSAML\Error\Exception if we cannot get the decryption keys or decryption fails.
+     * @throws Exception
      */
     private static function decryptAttributes(
         Configuration $srcMetadata,
@@ -486,6 +498,7 @@ class Message
      * @param \SimpleSAML\Configuration $spMetadata The metadata of the service provider.
      * @param \SimpleSAML\Configuration $idpMetadata The metadata of the identity provider.
      * @return \SimpleSAML\SAML2\AuthnRequest An authentication request object.
+     * @throws SSP_Error\Exception
      */
     public static function buildAuthnRequest(
         Configuration $spMetadata,
@@ -555,6 +568,7 @@ class Message
      * @param \SimpleSAML\Configuration $srcMetadata The metadata of the sender.
      * @param \SimpleSAML\Configuration $dstMetadata The metadata of the recipient.
      * @return \SimpleSAML\SAML2\LogoutRequest A logout request object.
+     * @throws SSP_Error\Exception
      */
     public static function buildLogoutRequest(
         Configuration $srcMetadata,
@@ -578,6 +592,7 @@ class Message
      * @param \SimpleSAML\Configuration $srcMetadata The metadata of the sender.
      * @param \SimpleSAML\Configuration $dstMetadata The metadata of the recipient.
      * @return \SimpleSAML\SAML2\LogoutResponse A logout response object.
+     * @throws SSP_Error\Exception
      */
     public static function buildLogoutResponse(
         Configuration $srcMetadata,
@@ -895,6 +910,7 @@ class Message
      * @return \RobRichards\XMLSecLibs\XMLSecurityKey  The encryption key.
      *
      * @throws \SimpleSAML\Error\Exception if there is no supported encryption key in the metadata of this entity.
+     * @throws Exception
      */
     public static function getEncryptionKey(Configuration $metadata): XMLSecurityKey
     {

--- a/modules/saml/src/SP/LogoutStore.php
+++ b/modules/saml/src/SP/LogoutStore.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Module\saml\SP;
 
 use Exception;
 use PDO;
-use SimpleSAML\{Configuration, Logger, Session, Utils};
+use SimpleSAML\{Configuration, Error\CriticalConfigurationError, Logger, Session, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\XML\saml\NameID;
 use SimpleSAML\Store\{SQLStore, StoreFactory, StoreInterface};
@@ -29,6 +29,7 @@ class LogoutStore
      * Create logout table in SQL, if it is missing.
      *
      * @param \SimpleSAML\Store\SQLStore $store  The datastore.
+     * @throws Exception
      */
     private static function createLogoutTable(SQLStore $store): void
     {
@@ -147,6 +148,7 @@ class LogoutStore
      * Clean the logout table of expired entries.
      *
      * @param \SimpleSAML\Store\SQLStore $store  The datastore.
+     * @throws Exception
      */
     private static function cleanLogoutStore(SQLStore $store): void
     {
@@ -169,6 +171,7 @@ class LogoutStore
      * @param string $sessionIndex  The SessionIndex of the user.
      * @param int $expire Unix timestamp when this session expires.
      * @param string $sessionId
+     * @throws Exception
      */
     private static function addSessionSQL(
         SQLStore $store,
@@ -206,6 +209,7 @@ class LogoutStore
      * @param string $authId  The authsource ID.
      * @param string $nameId  The hash of the users NameID.
      * @return array  Associative array of SessionIndex =>  SessionId.
+     * @throws Exception
      */
     private static function getSessionsSQL(SQLStore $store, string $authId, string $nameId): array
     {
@@ -267,6 +271,9 @@ class LogoutStore
      * @param \SimpleSAML\SAML2\XML\saml\NameID $nameId The NameID of the user.
      * @param string|null $sessionIndex  The SessionIndex of the user.
      * @param int $expire  Unix timestamp when this session expires.
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function addSession(string $authId, NameID $nameId, ?string $sessionIndex, int $expire): void
     {
@@ -322,6 +329,8 @@ class LogoutStore
      * @param \SimpleSAML\SAML2\XML\saml\NameID $nameId The NameID of the user.
      * @param array $sessionIndexes  The SessionIndexes we should log out of. Logs out of all if this is empty.
      * @return int|false  Number of sessions logged out, or FALSE if not supported.
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     public static function logoutSessions(string $authId, NameID $nameId, array $sessionIndexes)
     {

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,8 @@
     reportMixedIssues="false"
     hideExternalErrors="true"
     allowStringToStandInForClass="true"
+    checkForThrowsDocblock="true"
+    checkForThrowsInGlobalScope="true"
 >
     <projectFiles>
         <directory name="config" />

--- a/src/SimpleSAML/Auth/AuthenticationFactory.php
+++ b/src/SimpleSAML/Auth/AuthenticationFactory.php
@@ -29,6 +29,8 @@ class AuthenticationFactory
      * file.
      *
      * @return \SimpleSAML\Auth\Simple
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function create(string $as): Simple
     {

--- a/src/SimpleSAML/Auth/ProcessingChain.php
+++ b/src/SimpleSAML/Auth/ProcessingChain.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Auth;
 
 use Exception;
-use SimpleSAML\{Configuration, Error, Logger, Module, Utils};
+use SimpleSAML\{Configuration, Error, Error\NoState, Logger, Module, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Exception\Protocol\NoPassiveException;
 use Symfony\Component\HttpFoundation\Response;
@@ -64,6 +64,7 @@ class ProcessingChain
      * @param array $idpMetadata  The metadata for the IdP.
      * @param array $spMetadata  The metadata for the SP.
      * @param string $mode
+     * @throws Exception
      */
     public function __construct(array $idpMetadata, array $spMetadata, string $mode = 'idp')
     {
@@ -121,6 +122,7 @@ class ProcessingChain
      *
      * @param array $filterSrc  Array with filter configuration.
      * @return array  Array of ProcessingFilter objects.
+     * @throws Exception
      */
     private static function parseFilterList(array $filterSrc): array
     {
@@ -152,6 +154,7 @@ class ProcessingChain
      * @param int $priority      The priority of the current filter, (not included in the filter
      *                           definition.)
      * @return \SimpleSAML\Auth\ProcessingFilter  The parsed filter.
+     * @throws Exception
      */
     private static function parseFilter(array $config, int $priority): ProcessingFilter
     {
@@ -233,6 +236,9 @@ class ProcessingChain
      * to whatever exception handler is defined in the state array.
      *
      * @param array $state  The state we are processing.
+     * @throws Error\Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function resumeProcessing(array $state): Response
     {
@@ -316,8 +322,10 @@ class ProcessingChain
      * Retrieve a state which has finished processing.
      *
      * @param string $id The state identifier.
-     * @see State::parseStateID()
      * @return array|null The state referenced by the $id parameter.
+     * @throws NoState
+     * @throws \Throwable
+     * @see State::parseStateID()
      */
     public static function fetchProcessedState(string $id): ?array
     {
@@ -329,6 +337,7 @@ class ProcessingChain
      * @param array $state
      * @psalm-param array{"\\\SimpleSAML\\\Auth\\\ProcessingChain.filters": array} $state
      * @param ProcessingFilter[] $authProcs
+     * @throws Exception
      */
     public static function insertFilters(array &$state, array $authProcs): void
     {
@@ -351,6 +360,7 @@ class ProcessingChain
      * @psalm-param array{"\\\SimpleSAML\\\Auth\\\ProcessingChain.filters": array} $state
      * @param array $authProcConfigs
      * @return \SimpleSAML\Auth\ProcessingFilter[]
+     * @throws Exception
      */
     public static function createAndInsertFilters(array &$state, array $authProcConfigs): array
     {

--- a/src/SimpleSAML/Auth/Simple.php
+++ b/src/SimpleSAML/Auth/Simple.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Auth;
 
-use SimpleSAML\{Configuration, Error, Module, Session, Utils};
+use SimpleSAML\{Configuration, Error, Error\AuthSource, Error\CriticalConfigurationError, Error\Exception, Module, Session, Utils};
 use SimpleSAML\Assert\Assert;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -37,6 +37,8 @@ class Simple
      * @param string $authSource The id of the authentication source.
      * @param \SimpleSAML\Configuration|null $config Optional configuration to use.
      * @param \SimpleSAML\Session|null $session Optional session to use.
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function __construct(
         protected string $authSource,
@@ -61,6 +63,8 @@ class Simple
      * @return \SimpleSAML\Auth\Source The authentication source.
      *
      * @throws \SimpleSAML\Error\AuthSource If the requested auth source is unknown.
+     * @throws Exception
+     * @throws \Exception
      */
     public function getAuthSource(): Source
     {
@@ -79,6 +83,7 @@ class Simple
      * 'default-authsource' option in 'config.php'.
      *
      * @return bool True if the user is authenticated, false if not.
+     * @throws \Exception
      */
     public function isAuthenticated(): bool
     {
@@ -98,6 +103,9 @@ class Simple
      * method for a description.
      *
      * @param array $params Various options to the authentication request. See the documentation.
+     * @throws AuthSource
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function requireAuth(array $params = []): ?Response
     {
@@ -121,6 +129,10 @@ class Simple
      *  - 'ReturnCallback': The function we should call after the user has finished authentication.
      *
      * @param array $params Various options to the authentication request.
+     * @throws AuthSource
+     * @throws Exception
+     * @throws CriticalConfigurationError
+     * @throws \Throwable
      */
     public function login(array $params = []): Response
     {
@@ -184,6 +196,9 @@ class Simple
      *
      * @param string|array|null $params Either the URL the user should be redirected to after logging out, or an array
      * with parameters for the logout. If this parameter is null, we will return to the current page.
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function logout(string|array|null $params = null): Response
     {
@@ -234,6 +249,9 @@ class Simple
      * This function never returns.
      *
      * @param array $state The state after the logout.
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public static function logoutCompleted(array $state): Response
     {
@@ -264,6 +282,7 @@ class Simple
      * authenticated, it will return an empty array.
      *
      * @return array The users attributes.
+     * @throws \Exception
      */
     public function getAttributes(): array
     {
@@ -283,6 +302,7 @@ class Simple
      * @param string $name The name of the parameter, e.g. 'Attributes', 'Expire' or 'saml:sp:IdP'.
      *
      * @return mixed|null The value of the parameter, or null if it isn't found or we are unauthenticated.
+     * @throws \Exception
      */
     public function getAuthData(string $name): mixed
     {
@@ -298,6 +318,7 @@ class Simple
      * Retrieve all authentication data.
      *
      * @return array|null All persistent authentication data, or null if we aren't authenticated.
+     * @throws \Exception
      */
     public function getAuthDataArray(): ?array
     {
@@ -316,6 +337,9 @@ class Simple
      * user will be returned to the current page.
      *
      * @return string A URL which is suitable for use in link-elements.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public function getLoginURL(?string $returnTo = null): string
     {
@@ -339,6 +363,9 @@ class Simple
      * user will be returned to the current page.
      *
      * @return string A URL which is suitable for use in link-elements.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public function getLogoutURL(?string $returnTo = null): string
     {
@@ -364,6 +391,9 @@ class Simple
      * server.
      *
      * @return string The URL modified according to the precedence rules.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     protected function getProcessedURL(?string $url = null): string
     {

--- a/src/SimpleSAML/Auth/Source.php
+++ b/src/SimpleSAML/Auth/Source.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Auth;
 
-use SimpleSAML\{Configuration, Error, Logger, Module, Session, Utils};
+use SimpleSAML\{Configuration, Error, Error\CannotSetCookie, Error\Exception, Error\NoState, Logger, Module, Session, Utils};
 use SimpleSAML\Assert\Assert;
 use Symfony\Component\HttpFoundation\{Request, Response};
 
@@ -120,6 +120,9 @@ abstract class Source
      * interact with the user even in the case when the user is already authenticated.
      *
      * @param array &$state Information about the current authentication.
+     * @throws NoState
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function reauthenticate(array &$state): void
     {
@@ -146,6 +149,8 @@ abstract class Source
      * but should instead be passed to the top-level exception handler.
      *
      * @param array &$state Information about the current authentication.
+     * @throws \Exception
+     * @throws \Throwable
      */
     public static function completeAuth(array &$state): Response
     {
@@ -172,6 +177,8 @@ abstract class Source
      * check it by calling \SimpleSAML\Utils\HTTP::checkURLAllowed().
      * @param array $params Extra information about the login. Different authentication requestors may provide different
      * information. Optional, will default to an empty array.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function initLogin(string|array $return, ?string $errorURL = null, array $params = []): Response
     {
@@ -214,6 +221,9 @@ abstract class Source
      * Called when a login operation has finished.
      *
      * @param array $state The state after the login has completed.
+     * @throws CannotSetCookie
+     * @throws \Exception
+     * @throws \Throwable
      */
     public static function loginCompleted(array $state): Response
     {
@@ -269,6 +279,8 @@ abstract class Source
      * but should instead be passed to the top-level exception handler.
      *
      * @param array &$state Information about the current authentication.
+     * @throws \Exception
+     * @throws \Throwable
      */
     public static function completeLogout(array &$state): Response
     {
@@ -346,6 +358,7 @@ abstract class Source
      * @return \SimpleSAML\Auth\Source|null The AuthSource object, or NULL if no authentication
      *     source with the given identifier is found.
      * @throws \SimpleSAML\Error\Exception If no such authentication source is found or it is invalid.
+     * @throws \Exception
      */
     public static function getById(string $authId, ?string $type = null): ?Source
     {
@@ -381,6 +394,8 @@ abstract class Source
      * Called when the authentication source receives an external logout request.
      *
      * @param array $state State array for the logout operation.
+     * @throws \Exception
+     * @throws \Throwable
      */
     public static function logoutCallback(array $state): void
     {
@@ -411,6 +426,8 @@ abstract class Source
      *
      * @param string $assoc The identifier for this logout association.
      * @param array  $state The state array passed to the authenticate-function.
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function addLogoutCallback(string $assoc, array $state): void
     {
@@ -452,6 +469,8 @@ abstract class Source
      * This function always returns.
      *
      * @param string $assoc The logout association which should be called.
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function callLogoutCallback(string $assoc): ?Response
     {
@@ -485,6 +504,7 @@ abstract class Source
      * Retrieve list of authentication sources.
      *
      * @return array The id of all authentication sources.
+     * @throws \Exception
      */
     public static function getSources(): array
     {

--- a/src/SimpleSAML/Auth/State.php
+++ b/src/SimpleSAML/Auth/State.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Auth;
 
 use Exception;
-use SimpleSAML\{Configuration, Error, Logger, Session, Utils};
+use SimpleSAML\{Configuration, Error, Error\NoState, Logger, Session, Utils};
 use SimpleSAML\Assert\Assert;
 
 use function array_key_exists;
@@ -192,6 +192,7 @@ class State
      * Retrieve state timeout.
      *
      * @return integer  State timeout.
+     * @throws Exception
      */
     private static function getStateTimeout(): int
     {
@@ -215,6 +216,8 @@ class State
      * @param bool   $rawId Return a raw ID, without a restart URL.
      *
      * @return string  Identifier which can be used to retrieve the state later.
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function saveState(array &$state, string $stage, bool $rawId = false): string
     {
@@ -243,6 +246,7 @@ class State
      * @param array $state The original request state.
      *
      * @return array  Cloned state data.
+     * @throws Exception
      */
     public static function cloneState(array $state): array
     {
@@ -274,6 +278,7 @@ class State
      *
      * @throws \SimpleSAML\Error\NoState If we couldn't find the state and there's no URL defined to redirect to.
      * @throws \Exception If the stage of the state is invalid and there's no URL defined to redirect to.
+     * @throws \Throwable
      *
      * @return array|null  State information, or NULL if the state is missing and $allowMissing is true.
      * @psalm-return ($allowMissing is true ? array|null : array)
@@ -337,6 +342,8 @@ class State
      * This function deletes the given state to prevent the user from reusing it later.
      *
      * @param array &$state The state which should be deleted.
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function deleteState(array &$state): void
     {
@@ -359,6 +366,8 @@ class State
      * @param \SimpleSAML\Error\Exception $exception The exception.
      *
      * @throws \SimpleSAML\Error\Exception If there is no exception handler defined, it will just throw the $exception.
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function throwException(array $state, Error\Exception $exception): void
     {
@@ -397,6 +406,8 @@ class State
      * @param string|null $id The exception id. Can be NULL, in which case it will be retrieved from the request.
      *
      * @return array|null  The state array with the exception, or NULL if no exception was thrown.
+     * @throws NoState
+     * @throws \Throwable
      */
     public static function loadExceptionState(?string $id = null): ?array
     {

--- a/src/SimpleSAML/Command/SspCacheClearCommand.php
+++ b/src/SimpleSAML/Command/SspCacheClearCommand.php
@@ -33,6 +33,9 @@ class SspCacheClearCommand extends Command
 
     private array $enabledModules;
 
+    /**
+     * @throws \Symfony\Component\Console\Exception\LogicException
+     */
     public function __construct(CacheClearerInterface $cacheClearer, ?Filesystem $filesystem = null)
     {
         parent::__construct();
@@ -41,6 +44,9 @@ class SspCacheClearCommand extends Command
         $this->filesystem = $filesystem ?? new Filesystem();
     }
 
+    /**
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
+     */
     protected function configure(): void
     {
         $this
@@ -60,6 +66,7 @@ EOF,);
 
     /**
      * @throws ExceptionInterface
+     * @throws \Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -266,6 +273,9 @@ EOF,);
         return false;
     }
 
+    /**
+     * @throws \LogicException
+     */
     private function warmup(string $warmupDir, string $realBuildDir): void
     {
         // create a temporary kernel

--- a/src/SimpleSAML/Command/UnusedTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UnusedTranslatableStringsCommand.php
@@ -9,6 +9,7 @@ use Gettext\Scanner\PhpScanner;
 use Gettext\Translation;
 use Gettext\Translations;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Module;
 use SimpleSAML\TestUtils\ArrayLogger;
 use SimpleSAML\Utils;
@@ -35,6 +36,7 @@ class UnusedTranslatableStringsCommand extends Command
 
 
     /**
+     * @throws \Exception
      */
     protected function configure(): void
     {
@@ -75,6 +77,8 @@ class UnusedTranslatableStringsCommand extends Command
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return int
+     * @throws Exception
+     * @throws \Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -11,6 +11,7 @@ use Gettext\Scanner\PhpScanner;
 use Gettext\Translation;
 use Gettext\Translations;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Module;
 use SimpleSAML\TestUtils\ArrayLogger;
 use SimpleSAML\Utils;
@@ -41,6 +42,7 @@ class UpdateTranslatableStringsCommand extends Command
 
 
     /**
+     * @throws \Exception
      */
     protected function configure(): void
     {
@@ -103,6 +105,8 @@ class UpdateTranslatableStringsCommand extends Command
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return int
+     * @throws \Exception
+     * @throws Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/SimpleSAML/Compat/Logger.php
+++ b/src/SimpleSAML/Compat/Logger.php
@@ -17,6 +17,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function emergency(string|Stringable $message, array $context = []): void
     {
@@ -32,6 +33,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function alert(string|Stringable $message, array $context = []): void
     {
@@ -46,6 +48,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function critical(string|Stringable $message, array $context = []): void
     {
@@ -59,6 +62,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function error(string|Stringable $message, array $context = []): void
     {
@@ -74,6 +78,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function warning(string|Stringable $message, array $context = []): void
     {
@@ -86,6 +91,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function notice(string|Stringable $message, array $context = []): void
     {
@@ -100,6 +106,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function info(string|Stringable $message, array $context = []): void
     {
@@ -112,6 +119,7 @@ class Logger implements LoggerInterface
      *
      * @param string|\Stringable $message
      * @param array $context
+     * @throws \Exception
      */
     public function debug(string|Stringable $message, array $context = []): void
     {
@@ -127,6 +135,7 @@ class Logger implements LoggerInterface
      * @param array $context
      *
      * @throws \SimpleSAML\Assert\AssertionFailedException if assertions are false
+     * @throws \Exception
      */
     public function log($level, string|Stringable $message, array $context = []): void
     {

--- a/src/SimpleSAML/Compat/SspContainer.php
+++ b/src/SimpleSAML/Compat/SspContainer.php
@@ -53,6 +53,9 @@ class SspContainer extends AbstractContainer
      * {@inheritdoc}
      * @param mixed $message
      * @param string $type
+     * @throws \DOMException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function debugMessage($message, string $type): void
     {
@@ -65,6 +68,8 @@ class SspContainer extends AbstractContainer
      * {@inheritdoc}
      * @param string $url
      * @param array $data
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \Throwable
      */
     public function getPOSTRedirectURL(string $url, array $data = []): string
     {
@@ -89,6 +94,9 @@ class SspContainer extends AbstractContainer
      * @param string $filename
      * @param string $date
      * @param int|null $mode
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \Random\RandomException
+     * @throws \InvalidArgumentException
      */
     public function writeFile(string $filename, string $data, ?int $mode = null): void
     {

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -466,6 +466,7 @@ class Configuration implements Utils\ClearableState
      * @return string The absolute path where SimpleSAMLphp can be reached in the web server.
      *
      * @throws \SimpleSAML\Error\CriticalConfigurationError If the format of 'baseurlpath' is incorrect.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function getBasePath(): string
     {
@@ -517,6 +518,7 @@ class Configuration implements Utils\ClearableState
      *
      * @return string|null $path if $path is an absolute path, or $path prepended with the base directory of this
      * SimpleSAMLphp installation. We will return NULL if $path is null.
+     * @throws Exception
      */
     public function resolvePath(?string $path): ?string
     {
@@ -542,6 +544,7 @@ class Configuration implements Utils\ClearableState
      * not specified.
      *
      * @return string|null The path configuration option with name $name, or $default if the option was not found.
+     * @throws Exception
      */
     public function getPathValue(string $name, ?string $default = null): ?string
     {
@@ -588,6 +591,8 @@ class Configuration implements Utils\ClearableState
      *
      * @return string The absolute path to the base directory for this SimpleSAMLphp installation. This path will
      * always end with a slash.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function getBaseDir(): string
     {
@@ -983,6 +988,8 @@ class Configuration implements Utils\ClearableState
      * @param string $name The name of the option.
      *
      * @return array The option with the given name.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function getArrayize(string $name): array
     {
@@ -1007,6 +1014,7 @@ class Configuration implements Utils\ClearableState
      *
      * @return array|null The option with the given name.
      * @psalm-return      ($default is null ? array|null : array)
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function getOptionalArrayize(string $name, $default): ?array
     {

--- a/src/SimpleSAML/Console/Application.php
+++ b/src/SimpleSAML/Console/Application.php
@@ -12,6 +12,8 @@ class Application extends BaseApplication
 {
     /**
      * @param \SimpleSAML\Kernel $kernel
+     * @throws \Symfony\Component\Console\Exception\LogicException
+     * @throws \Symfony\Component\Console\Exception\InvalidArgumentException
      */
     public function __construct(Kernel $kernel)
     {

--- a/src/SimpleSAML/Database.php
+++ b/src/SimpleSAML/Database.php
@@ -65,6 +65,7 @@ class Database
      * @param \SimpleSAML\Configuration|null $altConfig Optional: Instance of a \SimpleSAML\Configuration class
      *
      * @return \SimpleSAML\Database The shared database connection.
+     * @throws Exception
      */
     public static function getInstance(?Configuration $altConfig = null): Database
     {
@@ -86,6 +87,7 @@ class Database
      * Private constructor that restricts instantiation to getInstance().
      *
      * @param \SimpleSAML\Configuration $config Instance of the \SimpleSAML\Configuration class
+     * @throws Exception
      */
     private function __construct(Configuration $config)
     {
@@ -122,6 +124,8 @@ class Database
      * @param \SimpleSAML\Configuration $config Configuration class
      *
      * @return string $instanceId
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     private static function generateInstanceId(Configuration $config): string
     {
@@ -260,6 +264,7 @@ class Database
      * @param array  $params Parameters
      *
      * @return int|false The number of rows affected by the query or false on error.
+     * @throws Exception
      */
     public function write(string $stmt, array $params = []): int|bool
     {
@@ -274,6 +279,7 @@ class Database
      * @param array  $params Parameters
      *
      * @return \PDOStatement object
+     * @throws Exception
      */
     public function read(string $stmt, array $params = []): PDOStatement
     {

--- a/src/SimpleSAML/Error/Error.php
+++ b/src/SimpleSAML/Error/Error.php
@@ -205,6 +205,8 @@ class Error extends Exception
      * Save an error report.
      *
      * @return array  The array with the error report data.
+     * @throws \Exception
+     * @throws Throwable
      */
     protected function saveError(): array
     {
@@ -250,6 +252,9 @@ class Error extends Exception
      *
      * @param int $logLevel  The log-level for this exception
      * @param bool $suppressReport  Whether or not sending an error report is an option
+     * @throws \Exception
+     * @throws ConfigurationError
+     * @throws Throwable
      */
     public function show(int $logLevel = Logger::ERR, bool $suppressReport = false): void
     {

--- a/src/SimpleSAML/Error/ErrorHandler.php
+++ b/src/SimpleSAML/Error/ErrorHandler.php
@@ -15,14 +15,15 @@ use function is_null;
  */
 class ErrorHandler
 {
-   /**
-    * @param int $errno
-    * @param string $errstr
-    * @param string|null $errfile
-    * @param int $errline
-    * @param string|null $errcontext
-    * @return false
-    */
+    /**
+     * @param int $errno
+     * @param string $errstr
+     * @param string|null $errfile
+     * @param int $errline
+     * @param string|null $errcontext
+     * @return false
+     * @throws \Exception
+     */
     public function customErrorHandler(
         int $errno,
         string $errstr,

--- a/src/SimpleSAML/Error/Exception.php
+++ b/src/SimpleSAML/Error/Exception.php
@@ -153,6 +153,7 @@ class Exception extends \Exception
      * @param boolean $anonymize Whether the resulting messages should be anonymized or not.
      *
      * @return string[] Log lines that should be written out.
+     * @throws \Exception
      */
     public function format(bool $anonymize = false): array
     {
@@ -171,6 +172,7 @@ class Exception extends \Exception
      * @param boolean $anonymize Whether the resulting messages should be anonymized or not.
      *
      * @return string[] All lines of the backtrace, properly formatted.
+     * @throws \Exception
      */
     public function formatBacktrace(bool $anonymize = false): array
     {
@@ -202,6 +204,7 @@ class Exception extends \Exception
     /**
      * Print the backtrace to the log if the 'debug' option is enabled in the configuration.
      * @param int $level
+     * @throws \Exception
      */
     protected function logBacktrace(int $level = Logger::DEBUG): void
     {
@@ -251,6 +254,7 @@ class Exception extends \Exception
      * Print the exception to the log with log level error.
      *
      * This function will write this exception to the log, including a full backtrace.
+     * @throws \Exception
      */
     public function logError(): void
     {
@@ -263,6 +267,7 @@ class Exception extends \Exception
      * Print the exception to the log with log level warning.
      *
      * This function will write this exception to the log, including a full backtrace.
+     * @throws \Exception
      */
     public function logWarning(): void
     {
@@ -275,6 +280,7 @@ class Exception extends \Exception
      * Print the exception to the log with log level info.
      *
      * This function will write this exception to the log, including a full backtrace.
+     * @throws \Exception
      */
     public function logInfo(): void
     {
@@ -287,6 +293,7 @@ class Exception extends \Exception
      * Print the exception to the log with log level debug.
      *
      * This function will write this exception to the log, including a full backtrace.
+     * @throws \Exception
      */
     public function logDebug(): void
     {

--- a/src/SimpleSAML/Error/ExceptionHandler.php
+++ b/src/SimpleSAML/Error/ExceptionHandler.php
@@ -19,10 +19,12 @@ use function class_exists;
  */
 class ExceptionHandler
 {
-   /**
-    * @param \Throwable $exception
-    * @return void
-    */
+    /**
+     * @param \Throwable $exception
+     * @return void
+     * @throws Exception
+     * @throws Throwable
+     */
     public function customExceptionHandler(Throwable $exception): void
     {
         Module::callHooks('exception_handler', $exception);

--- a/src/SimpleSAML/Error/NotFound.php
+++ b/src/SimpleSAML/Error/NotFound.php
@@ -21,6 +21,8 @@ class NotFound extends Error
      * Create a new NotFound error
      *
      * @param string $reason  Optional description of why the given page could not be found.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function __construct(
         private ?string $reason = null,

--- a/src/SimpleSAML/HTTP/RunnableResponse.php
+++ b/src/SimpleSAML/HTTP/RunnableResponse.php
@@ -25,6 +25,7 @@ class RunnableResponse extends Response
      *
      * @param callable $callable A callable that we should run as part of this response.
      * @param array $args An array of arguments to be passed to the callable. Note that each element of the array
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         callable $callable,

--- a/src/SimpleSAML/IdP.php
+++ b/src/SimpleSAML/IdP.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML;
 
 use Exception;
-use SimpleSAML\{Auth, Configuration, Error, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\AuthSource, Error\MetadataNotFound, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\IdP\{IFrameLogoutHandler, LogoutHandlerInterface, TraditionalLogoutHandler};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
@@ -82,6 +82,8 @@ class IdP
      * @param string $id The identifier of this IdP.
      *
      * @throws \SimpleSAML\Error\Exception If the IdP is disabled or no such auth source was found.
+     * @throws Exception
+     * @throws \Throwable
      */
     private function __construct(Configuration $config, string $id)
     {
@@ -142,6 +144,8 @@ class IdP
      * @param string $id The identifier of the IdP.
      *
      * @return \SimpleSAML\IdP The IdP.
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public static function getById(Configuration $config, string $id): IdP
     {
@@ -162,6 +166,8 @@ class IdP
      * @param array &$state The state array.
      *
      * @return \SimpleSAML\IdP The IdP.
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public static function getByState(Configuration $config, array &$state): IdP
     {
@@ -190,6 +196,8 @@ class IdP
      * @param string $assocId The association identifier.
      *
      * @return array|null The name of the SP, as an associative array of language => text, or null if this isn't an SP.
+     * @throws MetadataNotFound
+     * @throws Exception
      */
     public function getSPName(string $assocId): ?array
     {
@@ -225,6 +233,8 @@ class IdP
      * Add an SP association.
      *
      * @param array $association The SP association.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function addAssociation(array $association): void
     {
@@ -242,6 +252,8 @@ class IdP
      * Retrieve list of SP associations.
      *
      * @return array List of SP associations.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function getAssociations(): array
     {
@@ -254,6 +266,8 @@ class IdP
      * Remove an SP association.
      *
      * @param string $assocId The association id.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function terminateAssociation(string $assocId): void
     {
@@ -266,6 +280,7 @@ class IdP
      * Is the current user authenticated?
      *
      * @return boolean True if the user is authenticated, false otherwise.
+     * @throws Exception
      */
     public function isAuthenticated(): bool
     {
@@ -277,6 +292,8 @@ class IdP
      * Called after authproc has run.
      *
      * @param array $state The authentication request state array.
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function postAuthProc(array $state): Response
     {
@@ -304,6 +321,8 @@ class IdP
      * @param array $state The authentication request state array.
      *
      * @throws \SimpleSAML\Error\Exception If we are not authenticated.
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function postAuth(array $state): Response
     {
@@ -351,6 +370,11 @@ class IdP
      * @param array &$state The authentication request state.
      *
      * @throws \SimpleSAML\Module\saml\Error\NoPassive If we were asked to do passive authentication.
+     * @throws AuthSource
+     * @throws \SimpleSAML\SAML2\Exception\Protocol\NoPassiveException
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \SimpleSAML\Error\CriticalConfigurationError
+     * @throws \Throwable
      */
     private function authenticate(array &$state): Response
     {
@@ -373,6 +397,7 @@ class IdP
      * @param array &$state The authentication request state.
      *
      * @throws \Exception If there is no auth source defined for this IdP.
+     * @throws \Throwable
      */
     private function reauthenticate(array &$state): void
     {
@@ -385,6 +410,9 @@ class IdP
      * Process authentication requests.
      *
      * @param array &$state The authentication request state.
+     * @throws Exception
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function handleAuthenticationRequest(array &$state): Response
     {
@@ -477,6 +505,8 @@ class IdP
      * @param array       &$state The logout request state.
      * @param string|null $assocId The association we received the logout request from, or null if there was no
      * association.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function handleLogoutRequest(array &$state, ?string $assocId): Response
     {
@@ -509,6 +539,8 @@ class IdP
      * @param string                 $assocId The association that is terminated.
      * @param string|null            $relayState The RelayState from the start of the logout.
      * @param \SimpleSAML\Error\Exception|null $error  The error that occurred during session termination (if any).
+     * @throws Exception
+     * @throws \Throwable
      */
     public function handleLogoutResponse(string $assocId, ?string $relayState, ?Error\Exception $error = null): Response
     {
@@ -529,6 +561,8 @@ class IdP
      * This function never returns.
      *
      * @param string $url The URL the user should be returned to after logout.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function doLogoutRedirect(string $url): Response
     {
@@ -547,6 +581,9 @@ class IdP
      * This function never returns.
      *
      * @param array    &$state The logout state from doLogoutRedirect().
+     * @throws Error\Exception
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public static function finishLogoutRedirect(array $state): RedirectResponse
     {

--- a/src/SimpleSAML/IdP/IFrameLogoutHandler.php
+++ b/src/SimpleSAML/IdP/IFrameLogoutHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\IdP;
 
-use SimpleSAML\{Auth, Configuration, Error, IdP, Module, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\ConfigurationError, IdP, Module, Utils};
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -37,6 +37,8 @@ class IFrameLogoutHandler implements LogoutHandlerInterface
      *
      * @param array &$state The logout state.
      * @param string|null $assocId The SP we are logging out from.
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function startLogout(array &$state, ?string $assocId): Response
     {
@@ -83,6 +85,9 @@ class IFrameLogoutHandler implements LogoutHandlerInterface
      * @param string $assocId The association that is terminated.
      * @param string|null $relayState The RelayState from the start of the logout.
      * @param \SimpleSAML\Error\Exception|null $error The error that occurred during session termination (if any).
+     * @throws ConfigurationError
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function onResponse(string $assocId, ?string $relayState, ?Error\Exception $error = null): Response
     {

--- a/src/SimpleSAML/IdP/TraditionalLogoutHandler.php
+++ b/src/SimpleSAML/IdP/TraditionalLogoutHandler.php
@@ -36,6 +36,8 @@ class TraditionalLogoutHandler implements LogoutHandlerInterface
      * This function never returns.
      *
      * @param array &$state The logout state.
+     * @throws Exception
+     * @throws \Throwable
      */
     private function logoutNextSP(array &$state): Response
     {
@@ -70,6 +72,8 @@ class TraditionalLogoutHandler implements LogoutHandlerInterface
      *
      * @param array  &$state The logout state.
      * @param string|null $assocId The association that started the logout.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function startLogout(array &$state, /** @scrutinizer ignore-unused */ ?string $assocId): Response
     {
@@ -87,6 +91,8 @@ class TraditionalLogoutHandler implements LogoutHandlerInterface
      * @param \SimpleSAML\Error\Exception|null $error The error that occurred during session termination (if any).
      *
      * @throws \SimpleSAML\Error\Exception If the RelayState was lost during logout.
+     * @throws Exception
+     * @throws \Throwable
      */
     public function onResponse(string $assocId, ?string $relayState, ?Error\Exception $error = null): Response
     {

--- a/src/SimpleSAML/Kernel.php
+++ b/src/SimpleSAML/Kernel.php
@@ -47,6 +47,7 @@ class Kernel extends BaseKernel
 
     /**
      * @return string
+     * @throws \Exception
      */
     public function getCacheDir(): string
     {
@@ -64,6 +65,7 @@ class Kernel extends BaseKernel
 
     /**
      * @return string
+     * @throws \Exception
      */
     public function getLogDir(): string
     {
@@ -106,6 +108,7 @@ class Kernel extends BaseKernel
      *
      * @param ContainerBuilder $container
      * @param LoaderInterface $loader
+     * @throws \Exception
      */
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
@@ -129,6 +132,7 @@ class Kernel extends BaseKernel
      * Import routes.
      *
      * @param RoutingConfigurator  $routes
+     * @throws \Exception
      */
     protected function configureRoutes(RoutingConfigurator $routes): void
     {

--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Locale;
 
-use SimpleSAML\{Configuration, Logger, Utils};
+use SimpleSAML\{Configuration, Error\CannotSetCookie, Logger, Utils};
 use Symfony\Component\Intl\Locales;
 
 use function array_fill_keys;
@@ -92,6 +92,8 @@ class Language
      * Constructor
      *
      * @param \SimpleSAML\Configuration $configuration Configuration object
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function __construct(
         private Configuration $configuration,
@@ -114,6 +116,7 @@ class Language
      * Filter configured (available) languages against installed languages.
      *
      * @return string[] The set of languages both in 'language.available' and  Locales::getNames().
+     * @throws \Exception
      */
     private function getInstalledLanguages(): array
     {
@@ -174,6 +177,8 @@ class Language
      *
      * @param string  $language Language code for the language to set.
      * @param boolean $setLanguageCookie Whether to set the language cookie or not. Defaults to true.
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function setLanguage(string $language, bool $setLanguageCookie = true): void
     {
@@ -193,6 +198,7 @@ class Language
      *
      * @return string The language selected by the user according to the processing rules specified, or the default
      * language in any other case.
+     * @throws \Exception
      */
     public function getLanguage(): string
     {
@@ -233,6 +239,7 @@ class Language
      * @param string $code The ISO 639-2 code of the language.
      *
      * @return string|null The localized name of the language.
+     * @throws \Exception
      */
     public function getLanguageLocalizedName(string $code): ?string
     {
@@ -330,6 +337,7 @@ class Language
      *
      * @return array An array holding all the languages available as the keys of the array. The value for each key is
      * true in case that the language specified by that key is currently active, or false otherwise.
+     * @throws \Exception
      */
     public function getLanguageList(): array
     {
@@ -344,6 +352,7 @@ class Language
      * Check whether a language is written from the right to the left or not.
      *
      * @return boolean True if the language is right-to-left, false otherwise.
+     * @throws \Exception
      */
     public function isLanguageRTL(): bool
     {
@@ -354,6 +363,7 @@ class Language
      * Returns the list of languages in order of preference. This is useful
      * to search e.g. an array of entity names for first the current language,
      * if not present the default language, if not present the fallback language.
+     * @throws \Exception
      */
     public function getPreferredLanguages(): array
     {
@@ -365,6 +375,7 @@ class Language
      * Retrieve the user-selected language from a cookie.
      *
      * @return string|null The selected language or null if unset.
+     * @throws \Exception
      */
     public static function getLanguageCookie(): ?string
     {
@@ -387,6 +398,8 @@ class Language
      * specified is not in the list of available languages, or the headers have already been sent to the browser.
      *
      * @param string $language The language set by the user.
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public static function setLanguageCookie(string $language): void
     {

--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -73,6 +73,7 @@ class Localization
      * Constructor
      *
      * @param \SimpleSAML\Configuration $configuration Configuration object
+     * @throws Exception
      */
     public function __construct(
         private Configuration $configuration,
@@ -112,6 +113,7 @@ class Localization
      * @param string $domain Name of module/domain
      *
      * @return string
+     * @throws Exception
      */
     public function getDomainLocaleDir(string $domain): string
     {
@@ -129,6 +131,7 @@ class Localization
      * @param string $module Module name
      * @param string $localeDir Absolute path if the module is housed elsewhere
      * @param string $domain Translation domain within module; defaults to module name
+     * @throws Exception
      */
     public function addModuleDomain(string $module, ?string $localeDir = null, ?string $domain = null): void
     {
@@ -153,6 +156,7 @@ class Localization
      *
      * @param string $localeDir Location of translations
      * @param string $domain Domain at location
+     * @throws Exception
      */
     public function addDomain(string $localeDir, string $domain): void
     {
@@ -294,6 +298,7 @@ class Localization
 
     /**
      * Set up L18N
+     * @throws Exception
      */
     private function setupL10N(): void
     {
@@ -319,6 +324,7 @@ class Localization
     /**
      * Add translation domains specifically used for translating attributes names:
      * the default in attributes.po and any attributes.po in the enabled theme.
+     * @throws Exception
      */
     public function addAttributeDomains(): void
     {

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Locale;
 
 use Gettext\{Translator, TranslatorFunctions};
-use SimpleSAML\{Configuration, Logger, Module};
+use SimpleSAML\{Configuration, Error\CannotSetCookie, Logger, Module};
 
 use function array_slice;
 use function func_get_args;
@@ -39,6 +39,8 @@ class Translate
      * Constructor
      *
      * @param \SimpleSAML\Configuration $configuration Configuration object
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function __construct(
         private Configuration $configuration,

--- a/src/SimpleSAML/Logger.php
+++ b/src/SimpleSAML/Logger.php
@@ -178,6 +178,7 @@ class Logger
      * Log an emergency message.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function emergency(string $string): void
     {
@@ -189,6 +190,7 @@ class Logger
      * Log a critical message.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function critical(string $string): void
     {
@@ -200,6 +202,7 @@ class Logger
      * Log an alert.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function alert(string $string): void
     {
@@ -211,6 +214,7 @@ class Logger
      * Log an error.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function error(string $string): void
     {
@@ -222,6 +226,7 @@ class Logger
      * Log a warning.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function warning(string $string): void
     {
@@ -232,6 +237,7 @@ class Logger
      * Log a warning about deprecated code.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function deprecated(string $string): void
     {
@@ -242,6 +248,7 @@ class Logger
      * We reserve the notice level for statistics, so do not use this level for other kind of log messages.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function notice(string $string): void
     {
@@ -253,6 +260,7 @@ class Logger
      * Info messages are a bit less verbose than debug messages. This is useful to trace a session.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function info(string $string): void
     {
@@ -265,6 +273,7 @@ class Logger
      * system.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function debug(string $string): void
     {
@@ -276,6 +285,7 @@ class Logger
      * Statistics.
      *
      * @param string $string The message to log.
+     * @throws Exception
      */
     public static function stats(string $string): void
     {
@@ -317,6 +327,7 @@ class Logger
      * Set the track identifier to use in all logs.
      *
      * @param string $trackId The track identifier to use during this session.
+     * @throws Exception
      */
     public static function setTrackId(string $trackId): void
     {
@@ -328,6 +339,7 @@ class Logger
     /**
      * Flush any pending log messages to the logging handler.
      *
+     * @throws Exception
      */
     public static function flush(): void
     {
@@ -344,6 +356,8 @@ class Logger
      * This method is intended to be registered as a shutdown handler, so that any pending messages that weren't sent
      * to the logging handler at that point, can still make it. It is therefore not intended to be called manually.
      *
+     * @throws Exception
+     * @throws \Throwable
      */
     public static function shutdown(): void
     {
@@ -521,6 +535,7 @@ class Logger
      * @param int $level
      * @param string $string
      * @param bool $statsLog
+     * @throws Exception
      */
     private static function log(int $level, string $string, bool $statsLog = false): void
     {

--- a/src/SimpleSAML/Logger/ErrorLogLoggingHandler.php
+++ b/src/SimpleSAML/Logger/ErrorLogLoggingHandler.php
@@ -48,6 +48,7 @@ class ErrorLogLoggingHandler implements LoggingHandlerInterface
      * ErrorLogLoggingHandler constructor.
      *
      * @param \SimpleSAML\Configuration $config The configuration object for this handler.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function __construct(Configuration $config)
     {

--- a/src/SimpleSAML/Logger/FileLoggingHandler.php
+++ b/src/SimpleSAML/Logger/FileLoggingHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Logger;
 
 use DateTimeImmutable;
-use SimpleSAML\{Configuration, Logger, Utils};
+use SimpleSAML\{Configuration, Error\Exception, Logger, Utils};
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\Exception\CannotWriteFileException;
 use Symfony\Component\HttpFoundation\File\File;
@@ -63,6 +63,8 @@ class FileLoggingHandler implements LoggingHandlerInterface
     /**
      * Build a new logging handler based on files.
      * @param \SimpleSAML\Configuration $config
+     * @throws Exception
+     * @throws \Exception
      */
     public function __construct(Configuration $config)
     {
@@ -111,6 +113,7 @@ class FileLoggingHandler implements LoggingHandlerInterface
      *
      * @param int    $level The log level.
      * @param string $string The formatted message to log.
+     * @throws \Symfony\Component\Filesystem\Exception\IOException
      */
     public function log(int $level, string $string): void
     {

--- a/src/SimpleSAML/Logger/StandardErrorLoggingHandler.php
+++ b/src/SimpleSAML/Logger/StandardErrorLoggingHandler.php
@@ -22,6 +22,7 @@ class StandardErrorLoggingHandler extends FileLoggingHandler
      * It runs the parent constructor and sets the log file to be the standard error descriptor.
      *
      * @param \SimpleSAML\Configuration $config
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function __construct(Configuration $config)
     {

--- a/src/SimpleSAML/Logger/SyslogLoggingHandler.php
+++ b/src/SimpleSAML/Logger/SyslogLoggingHandler.php
@@ -29,6 +29,7 @@ class SyslogLoggingHandler implements LoggingHandlerInterface
     /**
      * Build a new logging handler based on syslog.
      * @param \SimpleSAML\Configuration $config
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function __construct(Configuration $config)
     {

--- a/src/SimpleSAML/Memcache.php
+++ b/src/SimpleSAML/Memcache.php
@@ -54,6 +54,8 @@ class Memcache
      * @param string $key The key of the data.
      *
      * @return mixed The data stored with the given key, or null if no data matching the key was found.
+     * @throws Error\Exception
+     * @throws Exception
      */
     public static function get(string $key): mixed
     {
@@ -158,6 +160,7 @@ class Memcache
      * @param string       $key The key of the data.
      * @param mixed        $value The value of the data.
      * @param integer|null $expire The expiration timestamp of the data.
+     * @throws Exception
      */
     public static function set(string $key, mixed $value, ?int $expire = null): void
     {
@@ -184,6 +187,7 @@ class Memcache
      * Delete a key-value pair from the memcache servers.
      *
      * @param string $key The key we should delete.
+     * @throws Exception
      */
     public static function delete(string $key): void
     {
@@ -449,6 +453,7 @@ class Memcache
      * all server groups.
      *
      * @return array An array with the extended stats output for each server group.
+     * @throws Exception
      */
     public static function getRawStats(): array
     {

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Metadata;
 
 use Exception;
-use SimpleSAML\{Configuration, Error, Logger, Utils};
+use SimpleSAML\{Configuration, Error, Error\MetadataNotFound, Logger, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\Utils\ClearableState;
@@ -55,6 +55,7 @@ class MetaDataStorageHandler implements ClearableState
      * to this function.
      *
      * @return MetaDataStorageHandler The current metadata handler instance.
+     * @throws Exception
      */
     public static function getMetadataHandler(Configuration $config): MetaDataStorageHandler
     {
@@ -69,6 +70,7 @@ class MetaDataStorageHandler implements ClearableState
     /**
      * This constructor initializes this metadata storage handler. It will load and
      * parse the configuration, and initialize the metadata source list.
+     * @throws Exception
      */
     protected function __construct(Configuration $globalConfig)
     {
@@ -151,6 +153,7 @@ class MetaDataStorageHandler implements ClearableState
      * @param bool $showExpired A boolean specifying whether expired entities should be returned
      *
      * @return array An associative array with the metadata from from the given set.
+     * @throws Exception
      */
     public function getList(string $set = 'saml20-idp-remote', bool $showExpired = false): array
     {
@@ -189,6 +192,8 @@ class MetaDataStorageHandler implements ClearableState
      * @param string $set The set we want metadata from.
      *
      * @return array An associative array with the metadata.
+     * @throws MetadataNotFound
+     * @throws \Exception
      */
     public function getMetaDataCurrent(string $set): array
     {
@@ -274,6 +279,7 @@ class MetaDataStorageHandler implements ClearableState
      * @param string[] $entityIds The entity ids to load
      * @param string $set The set we want to get metadata from.
      * @return array An associative array with the metadata for the requested entities, if found.
+     * @throws Exception
      */
     public function getMetaDataForEntities(array $entityIds, string $set): array
     {
@@ -363,6 +369,7 @@ class MetaDataStorageHandler implements ClearableState
      *
      * @return \SimpleSAML\Configuration The configuration object representing the metadata.
      * @throws \SimpleSAML\Error\MetadataNotFound If no metadata for the entity specified can be found.
+     * @throws \Exception
      */
     public function getMetaDataConfig(string $entityId, string $set): Configuration
     {

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerDirectory.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerDirectory.php
@@ -48,6 +48,7 @@ class MetaDataStorageHandlerDirectory extends MetaDataStorageSource
      *                set in the 'metadatadir' configuration option in 'config.php'.
      *
      * @param array $config An associative array with the configuration for this handler.
+     * @throws Exception
      */
     protected function __construct(Configuration $globalConfig, array $config)
     {
@@ -149,6 +150,7 @@ class MetaDataStorageHandlerDirectory extends MetaDataStorageSource
      *
      * @return array An associative array with the metadata. Each element in the array is an entity, and the
      *         key is the entity id.
+     * @throws Exception
      */
     public function getMetadataSet(string $set): array
     {

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
@@ -54,6 +54,7 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
      * - 'file': full path to load metadata from. This is used by the MetaDataStorageHandlerDirectory class.
      *
      * @param array $config An associative array with the configuration for this handler.
+     * @throws Exception
      */
     protected function __construct(Configuration $globalConfig, array $config)
     {
@@ -122,6 +123,7 @@ class MetaDataStorageHandlerFlatFile extends MetaDataStorageSource
      *
      * @return array An associative array with the metadata. Each element in the array is an entity, and the
      *         key is the entity id.
+     * @throws Exception
      */
     public function getMetadataSet(string $set): array
     {

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -66,6 +66,7 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
      * - 'password':                Password for the database user.
      *
      * @param array $config An associative array with the configuration for this handler.
+     * @throws Exception
      */
     public function __construct(
         /** @scrutinizer ignore-unused */ Configuration $globalConfig,
@@ -127,6 +128,8 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
      * @param string $set The set we are looking for metadata in.
      *
      * @return array $metadata An associative array with all the metadata for the given set.
+     * @throws Error\Exception
+     * @throws \Exception
      */
     public function getMetadataSet(string $set): array
     {
@@ -156,6 +159,8 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
      *
      * @return array|null An associative array with metadata for the given entity, or NULL if we are unable to
      *         locate the entity.
+     * @throws Error\Exception
+     * @throws Exception
      */
     public function getMetaData(string $entityId, string $set): ?array
     {
@@ -215,6 +220,7 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
      * @param array  $entityData Metadata
      *
      * @return bool True/False if entry was successfully added
+     * @throws Exception
      */
     public function addEntry(string $index, string $set, array $entityData): bool
     {
@@ -261,6 +267,7 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
      * @param string $set The set to remove the metadata from.
      *
      * @return bool True/False if entry was successfully deleted
+     * @throws Exception
      */
     public function removeEntry(string $entityId, string $set): bool
     {
@@ -297,6 +304,7 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
      * Initialize the configured database
      *
      * @return int|false The number of SQL statements successfully executed, false if some error occurred.
+     * @throws Exception
      */
     public function initDatabase(): int|false
     {

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerSerialize.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Metadata;
 
-use SimpleSAML\{Configuration, Logger, Utils};
+use SimpleSAML\{Configuration, Error\CriticalConfigurationError, Logger, Utils};
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
@@ -49,6 +49,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
      * Parses configuration.
      *
      * @param array $config The configuration for this metadata handler.
+     * @throws \Exception
      */
     public function __construct(Configuration $globalConfig, array $config)
     {
@@ -83,6 +84,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
      * Retrieve a list of all available metadata sets.
      *
      * @return array An array with the available sets.
+     * @throws \Exception
      */
     public function getMetadataSets(): array
     {
@@ -114,6 +116,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
      * @param string $set The set we are looking for metadata in.
      *
      * @return array An associative array with all the metadata for the given set.
+     * @throws \Exception
      */
     public function getMetadataSet(string $set): array
     {
@@ -156,6 +159,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
      *
      * @return array|null An associative array with metadata for the given entity, or NULL if we are unable to
      *         locate the entity.
+     * @throws \Exception
      */
     public function getMetaData(string $entityId, string $set): ?array
     {
@@ -195,6 +199,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
      * @param array $metadata The metadata.
      *
      * @return bool True if successfully saved, false otherwise.
+     * @throws \Exception
      */
     public function saveMetadata(string $entityId, string $set, array $metadata): bool
     {
@@ -241,6 +246,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
      *
      * @param string $entityId The entityId of the metadata entry.
      * @param string $set The metadata set this metadata entry belongs to.
+     * @throws \Exception
      */
     public function deleteMetadata(string $entityId, string $set): void
     {
@@ -272,6 +278,7 @@ class MetaDataStorageHandlerSerialize extends MetaDataStorageSource
      * @param array $entityIds The entity ids to load
      * @param string $set The set we want to get metadata from.
      * @return array An associative array with the metadata for the requested entities, if found.
+     * @throws CriticalConfigurationError
      */
     public function getMetaDataForEntities(array $entityIds, string $set): array
     {

--- a/src/SimpleSAML/Metadata/MetaDataStorageSource.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Metadata;
 
 use Exception;
-use SimpleSAML\{Configuration, Error, Module, Utils};
+use SimpleSAML\{Configuration, Error, Error\CriticalConfigurationError, Module, Utils};
 use Symfony\Component\Filesystem\Filesystem;
 
 use function array_flip;
@@ -247,6 +247,8 @@ abstract class MetaDataStorageSource
      *
      * @return array|null An associative array with metadata for the given entity, or NULL if we are unable to
      *         locate the entity.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function getMetaData(string $entityId, string $set): ?array
     {
@@ -269,6 +271,7 @@ abstract class MetaDataStorageSource
      * @param string[] $entityIds The entity ids to load
      * @param string $set The set we want to get metadata from.
      * @return array An associative array with the metadata for the requested entities, if found.
+     * @throws CriticalConfigurationError
      */
     public function getMetaDataForEntities(array $entityIds, string $set): array
     {
@@ -290,6 +293,8 @@ abstract class MetaDataStorageSource
      * @param string[] $entityIds The entity ids to load
      * @param string $set The set we want to get metadata from.
      * @return array An associative array with the metadata for the requested entities, if found.
+     * @throws CriticalConfigurationError
+     * @see MetaDataStorageSource::getMetaDataForEntities()
      */
     protected function getMetaDataForEntitiesIndividually(array $entityIds, string $set): array
     {
@@ -311,6 +316,8 @@ abstract class MetaDataStorageSource
      * @param string $entityId
      * @param array $metadataSet the already loaded metadata set
      * @return mixed|null
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     protected function lookupIndexFromEntityId(string $entityId, array $metadataSet): mixed
     {

--- a/src/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/src/SimpleSAML/Metadata/SAMLBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Metadata;
 
 use DOMElement;
-use SimpleSAML\{Configuration, Module, Logger, Utils};
+use SimpleSAML\{Configuration, Error\Exception, Module, Logger, Utils};
 use SimpleSAML\Assert\{Assert, AssertionFailedException};
 use SimpleSAML\Module\adfs\SAML2\XML\fed\SecurityTokenServiceType;
 use SimpleSAML\SAML2\Constants as C;
@@ -60,6 +60,7 @@ class SAMLBuilder
      * @param int|null $maxCache The maximum time in seconds the metadata should be cached. Defaults to null
      * @param int|null $maxDuration The maximum time in seconds this metadata should be considered valid. Defaults
      * to null.
+     * @throws \Exception
      */
     public function __construct(
         string $entityId,
@@ -95,6 +96,7 @@ class SAMLBuilder
      * Retrieve the EntityDescriptor element which is generated for this entity.
      *
      * @return \DOMElement The EntityDescriptor element of this entity.
+     * @throws \Exception
      */
     public function getEntityDescriptor(): DOMElement
     {
@@ -113,6 +115,7 @@ class SAMLBuilder
      * @param bool $formatted Whether the returned EntityDescriptor should be formatted first.
      *
      * @return string The serialized EntityDescriptor.
+     * @throws \Exception
      */
     public function getEntityDescriptorText(bool $formatted = true): string
     {
@@ -132,6 +135,7 @@ class SAMLBuilder
      * Add a SecurityTokenServiceType for ADFS metadata.
      *
      * @param array $metadata The metadata with the information about the SecurityTokenServiceType.
+     * @throws \Exception
      */
     public function addSecurityTokenServiceType(array $metadata): void
     {
@@ -156,6 +160,7 @@ class SAMLBuilder
      * @param \SimpleSAML\Configuration    $metadata The metadata to get extensions from.
      * @param \SimpleSAML\SAML2\XML\md\RoleDescriptor $e Reference to the element where the
      *   Extensions element should be included.
+     * @throws \Exception
      */
     private function addExtensions(Configuration $metadata, RoleDescriptor $e): void
     {
@@ -233,6 +238,7 @@ class SAMLBuilder
      * Add an Organization element based on metadata array.
      *
      * @param array $metadata The metadata we should extract the organization information from.
+     * @throws \Exception
      */
     public function addOrganizationInfo(array $metadata): void
     {
@@ -310,6 +316,7 @@ class SAMLBuilder
      *
      * @param \SimpleSAML\SAML2\XML\md\SPSSODescriptor $spDesc The SPSSODescriptor element.
      * @param \SimpleSAML\Configuration     $metadata The metadata.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     private function addAttributeConsumingService(
         SPSSODescriptor $spDesc,
@@ -372,6 +379,7 @@ class SAMLBuilder
      *
      * @param string $set The metadata set this metadata comes from.
      * @param array  $metadata The metadata.
+     * @throws \Exception
      */
     public function addMetadata(string $set, array $metadata): void
     {
@@ -398,6 +406,7 @@ class SAMLBuilder
      *
      * @param array $metadata The metadata.
      * @param string[] $protocols The protocols supported. Defaults to \SimpleSAML\SAML2\Constants::NS_SAMLP.
+     * @throws \Exception
      */
     public function addMetadataSP20(array $metadata, array $protocols = [C::NS_SAMLP]): void
     {
@@ -459,6 +468,7 @@ class SAMLBuilder
      * Add metadata of a SAML 2.0 identity provider.
      *
      * @param array $metadata The metadata.
+     * @throws \Exception
      */
     public function addMetadataIdP20(array $metadata): void
     {
@@ -531,6 +541,7 @@ class SAMLBuilder
      *
      * @param array $metadata The AttributeAuthorityDescriptor, in the format returned by
      * \SimpleSAML\Metadata\SAMLParser.
+     * @throws \Exception
      */
     public function addAttributeAuthority(array $metadata): void
     {
@@ -614,6 +625,7 @@ class SAMLBuilder
      *
      * @param \SimpleSAML\SAML2\XML\md\RoleDescriptor $rd The RoleDescriptor the certificate should be added to.
      * @param \SimpleSAML\Configuration    $metadata The metadata of the entity.
+     * @throws Exception
      */
     private function addCertificate(RoleDescriptor $rd, Configuration $metadata): void
     {

--- a/src/SimpleSAML/Metadata/SAMLParser.php
+++ b/src/SimpleSAML/Metadata/SAMLParser.php
@@ -161,6 +161,7 @@ class SAMLParser
      *     NULL if unknown.
      * @param array                         $validators An array of parent elements that may validate this element.
      * @param array                         $parentExtensions An optional array of extensions from the parent element.
+     * @throws Exception
      */
     private function __construct(
         EntityDescriptor $entityElement,
@@ -257,6 +258,7 @@ class SAMLParser
      * @param \DOMDocument $document The \DOMDocument which contains the EntityDescriptor element.
      *
      * @return SAMLParser An instance of this class with the metadata loaded.
+     * @throws Exception
      */
     public static function parseDocument(DOMDocument $document): SAMLParser
     {
@@ -274,6 +276,7 @@ class SAMLParser
      *   object which represents a EntityDescriptor element.
      *
      * @return SAMLParser An instance of this class with the metadata loaded.
+     * @throws Exception
      */
     public static function parseElement(EntityDescriptor $entityElement): SAMLParser
     {
@@ -373,6 +376,7 @@ class SAMLParser
      * @param array                 $parentExtensions An optional array of extensions from the parent element.
      *
      * @return SAMLParser[] Array of SAMLParser instances.
+     * @throws Exception
      */
     private static function processDescriptorsElement(
         SignedElementHelper $element,
@@ -705,6 +709,7 @@ class SAMLParser
      *                             NULL if unknown.
      *
      * @return array An associative array with metadata we have extracted from this element.
+     * @throws Exception
      */
     private static function parseRoleDescriptorType(RoleDescriptor $element, ?int $expireTime): array
     {
@@ -754,6 +759,7 @@ class SAMLParser
      *                             NULL if unknown.
      *
      * @return array An associative array with metadata we have extracted from this element.
+     * @throws Exception
      */
     private static function parseSSODescriptor(SSODescriptorType $element, ?int $expireTime): array
     {
@@ -781,6 +787,7 @@ class SAMLParser
      * @param \SimpleSAML\SAML2\XML\md\SPSSODescriptor $element The element which should be parsed.
      * @param int|null                     $expireTime The unix timestamp for when this element should expire, or
      *                             NULL if unknown.
+     * @throws Exception
      */
     private function processSPSSODescriptor(SPSSODescriptor $element, ?int $expireTime): void
     {
@@ -815,6 +822,7 @@ class SAMLParser
      * @param \SimpleSAML\SAML2\XML\md\IDPSSODescriptor $element The element which should be parsed.
      * @param int|null                      $expireTime The unix timestamp for when this element should expire, or
      *                             NULL if unknown.
+     * @throws Exception
      */
     private function processIDPSSODescriptor(IDPSSODescriptor $element, ?int $expireTime): void
     {
@@ -839,6 +847,7 @@ class SAMLParser
      * @param \SimpleSAML\SAML2\XML\md\AttributeAuthorityDescriptor $element The element which should be parsed.
      * @param int|null                                  $expireTime The unix timestamp for when this element should
      *     expire, or NULL if unknown.
+     * @throws Exception
      */
     private function processAttributeAuthorityDescriptor(
         AttributeAuthorityDescriptor $element,
@@ -864,6 +873,7 @@ class SAMLParser
      * @param array $parentExtensions An optional array of extensions from the parent element.
      *
      * @return array An associative array with the extensions parsed.
+     * @throws Exception
      */
     private static function processExtensions(mixed $element, array $parentExtensions = []): array
     {

--- a/src/SimpleSAML/Metadata/Signer.php
+++ b/src/SimpleSAML/Metadata/Signer.php
@@ -166,6 +166,7 @@ class Signer
      * algorithms to use, respectively.
      *
      * @throws \SimpleSAML\Error\CriticalConfigurationError
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     private static function getMetadataSigningAlgorithm(
         Configuration $config,

--- a/src/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/src/SimpleSAML/Metadata/Sources/MDQ.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Metadata\Sources;
 
 use Exception;
-use SimpleSAML\{Configuration, Error, Logger, Utils};
+use SimpleSAML\{Configuration, Error, Error\ConfigurationError, Error\CriticalConfigurationError, Logger, Utils};
 use SimpleSAML\Metadata\MetaDataStorageSource;
 use SimpleSAML\Metadata\SAMLParser;
 use Symfony\Component\HttpFoundation\File\File;
@@ -122,6 +122,7 @@ class MDQ extends MetaDataStorageSource
      * @param string $entityId The entity id of this entity.
      *
      * @return string  The full path to the cache file.
+     * @throws ConfigurationError
      */
     private function getCacheFilename(string $set, string $entityId): string
     {
@@ -230,6 +231,7 @@ class MDQ extends MetaDataStorageSource
      *
      * @return array|null  The associative array with the metadata, or NULL if no metadata for
      *                     the given set was found.
+     * @throws Exception
      */
     private static function getParsedSet(SAMLParser $entity, string $set): ?array
     {
@@ -353,6 +355,7 @@ class MDQ extends MetaDataStorageSource
      * @param string[] $entityIds The entity ids to load
      * @param string $set The set we want to get metadata from.
      * @return array An associative array with the metadata for the requested entities, if found.
+     * @throws CriticalConfigurationError
      */
     public function getMetaDataForEntities(array $entityIds, string $set): array
     {

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML;
 
 use Exception;
-use SimpleSAML\{Kernel, Utils};
+use SimpleSAML\{Error\CriticalConfigurationError, Kernel, Utils};
 use SimpleSAML\Assert\Assert;
 use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 use Symfony\Component\Filesystem\{Filesystem, Path};
@@ -155,6 +155,8 @@ class Module
      * @return Response|BinaryFileResponse Returns a Response object that can be sent to the browser.
      * @throws Error\BadRequest In case the request URI is malformed.
      * @throws Error\NotFound In case the request URI is invalid or the resource it points to cannot be found.
+     * @throws Exception
+     * @throws CriticalConfigurationError
      */
     public static function process(?Request $request = null): Response
     {
@@ -347,6 +349,7 @@ class Module
      * @param string $module
      * @param array $mod_config
      * @return bool
+     * @throws Exception
      */
     private static function isModuleEnabledWithConf(string $module, array $mod_config): bool
     {
@@ -478,6 +481,7 @@ class Module
      * @param string|null $subclass The class should be a subclass of this class. Optional.
      *
      * @return the new object
+     * @throws Exception
      */
     public static function createObject(string $className, ?string $subclass = null): object
     {
@@ -502,6 +506,9 @@ class Module
      * @param array  $parameters Extra parameters which should be added to the URL. Optional.
      *
      * @return string The absolute URL to the given resource.
+     * @throws CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public static function getModuleURL(string $resource, array $parameters = []): string
     {
@@ -524,6 +531,9 @@ class Module
      * @return array An array with the hooks available for this module. Each element is an array with two keys: 'file'
      * points to the file that contains the hook, and 'func' contains the name of the function implementing that hook.
      * When there are no hooks defined, an empty array is returned.
+     *
+     * @throws \Symfony\Component\Finder\Exception\DirectoryNotFoundException
+     * @throws \LogicException
      */
     public static function getModuleHooks(string $module): array
     {
@@ -559,6 +569,7 @@ class Module
      * @param mixed  &$data The data which should be passed to each hook. Will be passed as a reference.
      *
      * @throws \SimpleSAML\Error\Exception If an invalid hook is found in a module.
+     * @throws Exception
      */
     public static function callHooks(string $hook, mixed &$data = null): void
     {
@@ -601,6 +612,8 @@ class Module
      * @param Request $request The request to process by this controller method.
      *
      * @return RedirectResponse A redirection to the URI specified in the request, but with a trailing slash.
+     *
+     * @throws \InvalidArgumentException
      */
     public static function addTrailingSlash(Request $request): RedirectResponse
     {
@@ -618,6 +631,8 @@ class Module
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      *   A redirection to the URI specified in the request, but without the trailing slash.
+     *
+     * @throws \InvalidArgumentException
      */
     public static function removeTrailingSlash(Request $request): RedirectResponse
     {

--- a/src/SimpleSAML/Session.php
+++ b/src/SimpleSAML/Session.php
@@ -6,7 +6,7 @@ namespace SimpleSAML;
 
 use DOMNodeList;
 use Exception;
-use SimpleSAML\{Error, Utils};
+use SimpleSAML\{Error, Error\CannotSetCookie, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\SAML2\XML\saml\AttributeValue;
 
@@ -166,6 +166,8 @@ class Session implements Utils\ClearableState
      * getSession() for a specific one.
      *
      * @param boolean $transient Whether to create a transient session or not.
+     * @throws CannotSetCookie
+     * @throws Exception
      */
     private function __construct(bool $transient = false)
     {
@@ -235,6 +237,7 @@ class Session implements Utils\ClearableState
      * be serializable in its original form (e.g.: DOM objects).
      *
      * @param array $serialized The serialized representation of a session that we want to restore.
+     * @throws Exception
      */
     public function __unserialize($serialized): void
     {
@@ -265,6 +268,7 @@ class Session implements Utils\ClearableState
      *
      * @return \SimpleSAML\Session The current session.
      * @throws \Exception When session couldn't be initialized and the session fallback is disabled by configuration.
+     * @throws \Throwable
      */
     public static function getSessionFromRequest(): Session
     {
@@ -343,6 +347,7 @@ class Session implements Utils\ClearableState
      *
      * @return \SimpleSAML\Session|null The session that is stored in the session handler,
      *   or null if the session wasn't found.
+     * @throws Exception
      */
     public static function getSession(?string $sessionId = null): ?Session
     {
@@ -411,6 +416,7 @@ class Session implements Utils\ClearableState
      *
      * @param \SimpleSAML\Session $session The session to load.
      * @return \SimpleSAML\Session The session we just loaded, just for convenience.
+     * @throws Exception
      */
     private static function load(Session $session): Session
     {
@@ -426,6 +432,7 @@ class Session implements Utils\ClearableState
      * Create a session that should not be saved at the end of the request.
      * Subsequent calls to getInstance() will return this transient session.
      *
+     * @throws Exception
      */
     public static function useTransientSession(): void
     {
@@ -458,6 +465,7 @@ class Session implements Utils\ClearableState
      * WARNING: please do not use this method directly unless you really need to and know what you are doing. Use
      * markDirty() instead.
      *
+     * @throws Exception
      */
     public function save(): void
     {
@@ -492,6 +500,7 @@ class Session implements Utils\ClearableState
      * Use this method if you are using PHP sessions in your application *and* in SimpleSAMLphp, *after* you are done
      * using SimpleSAMLphp and before trying to access your application's session again.
      *
+     * @throws Exception
      */
     public function cleanup(): void
     {
@@ -530,6 +539,7 @@ class Session implements Utils\ClearableState
      *
      * Destructor for this class. It will save the session to the session handler
      * in case the session has been marked as dirty. Do nothing otherwise.
+     * @throws Exception
      */
     public function __destruct()
     {
@@ -586,6 +596,9 @@ class Session implements Utils\ClearableState
      * Set remember me expire time.
      *
      * @param int $lifetime Number of seconds after when remember me session cookies expire.
+     * @throws CannotSetCookie
+     * @throws \Exception
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function setRememberMeExpire(?int $lifetime = null): void
     {
@@ -608,6 +621,7 @@ class Session implements Utils\ClearableState
      * @param array      $data The authentication data for this authority.
      *
      * @throws Error\CannotSetCookie If the authentication token cannot be set for some reason.
+     * @throws Exception
      */
     public function doLogin(string $authority, array $data = []): void
     {
@@ -700,6 +714,7 @@ class Session implements Utils\ClearableState
      * This function will call any registered logout handlers before marking the user as logged out.
      *
      * @param string $authority The authentication source we are logging out of.
+     * @throws Exception
      */
     public function doLogout(string $authority): void
     {
@@ -764,6 +779,7 @@ class Session implements Utils\ClearableState
      * @param string $authority The authentication source that the user should be authenticated with.
      *
      * @return bool True if the user has a valid session, false if not.
+     * @throws Exception
      */
     public function isValid(string $authority): bool
     {
@@ -790,6 +806,8 @@ class Session implements Utils\ClearableState
      * Update session cookies.
      *
      * @param array $params The parameters for the cookies.
+     * @throws CannotSetCookie
+     * @throws Exception
      */
     public function updateSessionCookies(array $params = []): void
     {
@@ -816,6 +834,7 @@ class Session implements Utils\ClearableState
      *
      * @param string $authority The authentication source we are setting expire time for.
      * @param int    $expire The number of seconds authentication source is valid.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public function setAuthorityExpire(string $authority, ?int $expire = null): void
     {
@@ -1046,6 +1065,7 @@ class Session implements Utils\ClearableState
      * This function will only return false if is is certain that the cookie isn't set.
      *
      * @return bool  true if it was set, false if not.
+     * @throws Exception
      */
     public function hasSessionCookie(): bool
     {
@@ -1161,6 +1181,7 @@ class Session implements Utils\ClearableState
      * this session.
      *
      * @return string[] An array containing every authority currently valid. Empty if none available.
+     * @throws Exception
      */
     public function getAuthorities(): array
     {

--- a/src/SimpleSAML/SessionHandler.php
+++ b/src/SimpleSAML/SessionHandler.php
@@ -153,6 +153,7 @@ abstract class SessionHandler
      * Get the cookie parameters that should be used for session cookies.
      *
      * @return array An array with the cookie parameters.
+     * @throws \Exception
      * @link http://www.php.net/manual/en/function.session-get-cookie-params.php
      */
     public function getCookieParams(): array

--- a/src/SimpleSAML/SessionHandlerCookie.php
+++ b/src/SimpleSAML/SessionHandlerCookie.php
@@ -45,6 +45,7 @@ abstract class SessionHandlerCookie extends SessionHandler
     /**
      * This constructor initializes the session id based on what we receive in a cookie. We create a new session id and
      * set a cookie with this id if we don't have a session id.
+     * @throws \Exception
      */
     protected function __construct()
     {
@@ -159,6 +160,7 @@ abstract class SessionHandlerCookie extends SessionHandler
      * @param array|null $cookieParams Additional parameters to use for the session cookie.
      *
      * @throws \SimpleSAML\Error\CannotSetCookie If we can't set the cookie.
+     * @throws \Exception
      */
     public function setCookie(string $sessionName, ?string $sessionID, ?array $cookieParams = null): void
     {

--- a/src/SimpleSAML/SessionHandlerPHP.php
+++ b/src/SimpleSAML/SessionHandlerPHP.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML;
 
-use SimpleSAML\{Error, Utils};
+use SimpleSAML\{Error, Error\CriticalConfigurationError, Error\Exception, Utils};
 use SimpleSAML\Assert\Assert;
 
 use function array_key_exists;
@@ -57,6 +57,8 @@ class SessionHandlerPHP extends SessionHandler
     /**
      * Initialize the PHP session handling. This constructor is protected because it should only be called from
      * \SimpleSAML\SessionHandler::createSessionHandler(...).
+     * @throws Exception
+     * @throws \Exception
      */
     protected function __construct()
     {
@@ -154,6 +156,7 @@ class SessionHandlerPHP extends SessionHandler
      * Create a new session id.
      *
      * @return string The new session id.
+     * @throws \Exception
      */
     public function newSessionId(): string
     {
@@ -245,6 +248,7 @@ class SessionHandlerPHP extends SessionHandler
      * @return \SimpleSAML\Session|null The session object, or null if it doesn't exist.
      *
      * @throws \SimpleSAML\Error\Exception If it wasn't possible to disable session cookies or we are trying to load a
+     * @throws \Exception
      * PHP session with a specific identifier and it doesn't match with the current session identifier.
      */
     public function loadSession(?string $sessionId = null): ?Session
@@ -297,7 +301,8 @@ class SessionHandlerPHP extends SessionHandler
      * @link http://www.php.net/manual/en/function.session-get-cookie-params.php
      *
      * @throws \SimpleSAML\Error\Exception If both 'session.phpsession.limitedpath' and 'session.cookie.path' options
-     * are set at the same time in the configuration.
+     *  are set at the same time in the configuration.
+     * @throws \Exception
      */
     public function getCookieParams(): array
     {
@@ -330,6 +335,7 @@ class SessionHandlerPHP extends SessionHandler
      * @param array|null $cookieParams Additional parameters to use for the session cookie.
      *
      * @throws \SimpleSAML\Error\CannotSetCookie If we can't set the cookie.
+     * @throws CriticalConfigurationError
      */
     public function setCookie(string $sessionName, ?string $sessionID, ?array $cookieParams = null): void
     {

--- a/src/SimpleSAML/SessionHandlerStore.php
+++ b/src/SimpleSAML/SessionHandlerStore.php
@@ -29,6 +29,7 @@ class SessionHandlerStore extends SessionHandlerCookie
      * Initialize the session.
      *
      * @param \SimpleSAML\Store\StoreInterface $store The store to use.
+     * @throws \Exception
      */
     protected function __construct(StoreInterface $store)
     {
@@ -69,6 +70,7 @@ class SessionHandlerStore extends SessionHandlerCookie
      * Save a session to the data store.
      *
      * @param \SimpleSAML\Session $session The session object we should save.
+     * @throws \Exception
      */
     public function saveSession(Session $session): void
     {

--- a/src/SimpleSAML/Stats.php
+++ b/src/SimpleSAML/Stats.php
@@ -43,6 +43,7 @@ class Stats
      * @param \SimpleSAML\Configuration $config The configuration.
      *
      * @return mixed A new instance of the configured class.
+     * @throws \Exception
      */
     private static function createOutput(Configuration $config): mixed
     {
@@ -57,6 +58,7 @@ class Stats
     /**
      * Initialize the outputs.
      *
+     * @throws \Exception
      */
     private static function initOutputs(): void
     {
@@ -77,6 +79,7 @@ class Stats
      * @param array  $data Event data. Optional.
      *
      * @return false|null
+     * @throws \Exception
      */
     public static function log(string $event, array $data = []): bool|null
     {

--- a/src/SimpleSAML/Store/MemcacheStore.php
+++ b/src/SimpleSAML/Store/MemcacheStore.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Store;
 
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\{Configuration, Memcache};
+use SimpleSAML\{Configuration, Error\Exception, Memcache};
 
 /**
  * A memcache based data store.
@@ -24,6 +24,7 @@ class MemcacheStore implements StoreInterface
 
     /**
      * This function implements the constructor for this class. It loads the Memcache configuration.
+     * @throws \Exception
      */
     public function __construct()
     {
@@ -38,6 +39,8 @@ class MemcacheStore implements StoreInterface
      * @param string $type The data type.
      * @param string $key The key.
      * @return mixed|null The value.
+     * @throws Exception
+     * @throws \Exception
      */
     public function get(string $type, string $key): mixed
     {
@@ -52,6 +55,7 @@ class MemcacheStore implements StoreInterface
      * @param string $key The key.
      * @param mixed $value The value.
      * @param int|null $expire The expiration time (unix timestamp), or NULL if it never expires.
+     * @throws \Exception
      */
     public function set(string $type, string $key, mixed $value, ?int $expire = null): void
     {
@@ -70,6 +74,7 @@ class MemcacheStore implements StoreInterface
      *
      * @param string $type The data type.
      * @param string $key The key.
+     * @throws \Exception
      */
     public function delete(string $type, string $key): void
     {

--- a/src/SimpleSAML/Store/RedisStore.php
+++ b/src/SimpleSAML/Store/RedisStore.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Store;
 
 use Predis\Client;
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\{Configuration, Error, Utils};
+use SimpleSAML\{Configuration, Error, Error\CriticalConfigurationError, Utils};
 
 use function class_exists;
 use function serialize;
@@ -27,6 +27,8 @@ class RedisStore implements StoreInterface
     /**
      * Initialize the Redis data store.
      * @param \Predis\Client|null $redis
+     * @throws \Exception
+     * @throws CriticalConfigurationError
      */
     public function __construct(?Client $redis = null)
     {

--- a/src/SimpleSAML/Store/SQLStore.php
+++ b/src/SimpleSAML/Store/SQLStore.php
@@ -8,7 +8,7 @@ use Exception;
 use PDO;
 use PDOException;
 use SimpleSAML\Assert\Assert;
-use SimpleSAML\{Configuration, Logger, Utils};
+use SimpleSAML\{Configuration, Error\CriticalConfigurationError, Logger, Utils};
 
 use function array_keys;
 use function count;
@@ -62,6 +62,7 @@ class SQLStore implements StoreInterface
 
     /**
      * Initialize the SQL data store.
+     * @throws Exception
      */
     public function __construct()
     {
@@ -92,6 +93,7 @@ class SQLStore implements StoreInterface
 
     /**
      * Initialize the table-version table.
+     * @throws Exception
      */
     private function initTableVersionTable(): void
     {
@@ -198,6 +200,7 @@ class SQLStore implements StoreInterface
 
     /**
      * Initialize key-value table.
+     * @throws Exception
      */
     private function initKVTable(): void
     {
@@ -335,6 +338,7 @@ class SQLStore implements StoreInterface
 
     /**
      * Clean the key-value table of expired entries.
+     * @throws Exception
      */
     private function cleanKVStore(): void
     {
@@ -355,6 +359,9 @@ class SQLStore implements StoreInterface
      * @param string $key The key to retrieve.
      *
      * @return mixed|null The value associated with that key, or null if there's no such key.
+     * @throws CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function get(string $type, string $key): mixed
     {
@@ -399,6 +406,8 @@ class SQLStore implements StoreInterface
      * @param string $key The key to insert.
      * @param mixed $value The value itself.
      * @param int|null $expire The expiration time (unix timestamp), or null if it never expires.
+     * @throws CriticalConfigurationError
+     * @throws Exception
      */
     public function set(string $type, string $key, mixed $value, ?int $expire = null): void
     {
@@ -439,6 +448,9 @@ class SQLStore implements StoreInterface
      *
      * @param string $type The type of the data
      * @param string $key The key to delete.
+     * @throws CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function delete(string $type, string $key): void
     {
@@ -466,6 +478,9 @@ class SQLStore implements StoreInterface
      *
      * @param string $data
      * @return string The hashed data.
+     * @throws CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     private function hashData(string $data): string
     {

--- a/src/SimpleSAML/Store/StoreFactory.php
+++ b/src/SimpleSAML/Store/StoreFactory.php
@@ -31,6 +31,7 @@ abstract class StoreFactory implements Utils\ClearableState
      * @return \SimpleSAML\Store\StoreInterface|false The data store, or false if it isn't enabled.
      *
      * @throws \SimpleSAML\Error\CriticalConfigurationError
+     * @throws Exception
      */
     public static function getInstance(string $storeType)
     {

--- a/src/SimpleSAML/Utils/Auth.php
+++ b/src/SimpleSAML/Utils/Auth.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Utils;
 
-use SimpleSAML\{Auth as Authentication, Error, Module, Session};
+use SimpleSAML\{Auth as Authentication, Error, Error\CriticalConfigurationError, Module, Session};
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -21,6 +21,9 @@ class Auth
      *
      * @return string A URL which can be used for logging out.
      * @throws \InvalidArgumentException If $returnTo is neither a string nor null.
+     * @throws CriticalConfigurationError
+     * @throws \Throwable
+     * @throws \Exception
      */
     public function getAdminLogoutURL(?string $returnTo = null): string
     {
@@ -34,6 +37,8 @@ class Auth
      *
      * @return boolean True if the current user is an admin user, false otherwise.
      *
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function isAdmin(): bool
     {
@@ -49,6 +54,8 @@ class Auth
      * a login page if the current user doesn't have admin access.
      *
      * @throws \SimpleSAML\Error\Exception If no "admin" authentication source was configured.
+     * @throws \Exception
+     * @throws \Throwable
      *
      */
     public function requireAdmin(): ?Response

--- a/src/SimpleSAML/Utils/Config.php
+++ b/src/SimpleSAML/Utils/Config.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Utils;
 
-use SimpleSAML\{Configuration, Error};
+use SimpleSAML\{Configuration, Error, Error\CriticalConfigurationError};
 
 use function dirname;
 use function getenv;
@@ -25,6 +25,7 @@ class Config
      *
      * @return string  The file path.
      * @throws \InvalidArgumentException If $path is not a string.
+     * @throws \Exception
      *
      */
     public function getCertPath(string $path): string
@@ -48,6 +49,8 @@ class Config
      *
      * @return string The secret salt.
      * @throws \InvalidArgumentException If the secret salt hasn't been configured.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      *
      */
     public function getSecretSalt(): string
@@ -74,6 +77,7 @@ class Config
      * $simplesamldir/config directory.
      *
      * @return string The path to the configuration directory.
+     * @throws CriticalConfigurationError
      */
     public function getConfigDir(): string
     {

--- a/src/SimpleSAML/Utils/Config/Metadata.php
+++ b/src/SimpleSAML/Utils/Config/Metadata.php
@@ -128,6 +128,8 @@ class Metadata
 
     /**
      * This method parses the different possible values of the NameIDPolicy metadata configuration.
+     *
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     public static function parseNameIdPolicy(?array $nameIdPolicy = null): ?NameIDPolicy
     {

--- a/src/SimpleSAML/Utils/Crypto.php
+++ b/src/SimpleSAML/Utils/Crypto.php
@@ -66,6 +66,7 @@ class Crypto
      * @return array|NULL Extracted private key, or NULL if no private key is present.
      * @throws \InvalidArgumentException If $required is not boolean or $prefix is not a string.
      * @throws Error\Exception If no private key is found in the metadata, or it was not possible to load
+     * @throws Exception
      *     it.
      *
      */
@@ -124,7 +125,7 @@ class Crypto
      *     boolean or $prefix is not a string.
      * @throws Error\Exception If no public key is found in the metadata, or it was not possible to load
      *     it.
-     *
+     * @throws Exception
      */
     public function loadPublicKey(Configuration $metadata, bool $required = false, string $prefix = ''): ?array
     {
@@ -203,6 +204,7 @@ class Crypto
      *
      * @return string The certificate or private key, or null if not found
      *
+     * @throws Exception
      */
     private function retrieveCertOrKey(string $data_type, string $location, bool $full_path): ?string
     {
@@ -279,6 +281,7 @@ class Crypto
      *
      * @return string The certificate or null if not found
      *
+     * @throws Exception
      */
     public function retrieveCertificate(string $location, bool $full_path = false): ?string
     {
@@ -295,6 +298,7 @@ class Crypto
      *
      * @return string The private key or null if not found
      *
+     * @throws Exception
      */
     public function retrieveKey(string $location, bool $full_path = false): ?string
     {

--- a/src/SimpleSAML/Utils/EMail.php
+++ b/src/SimpleSAML/Utils/EMail.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Utils;
 use Exception;
 use InvalidArgumentException;
 use PHPMailer\PHPMailer\PHPMailer;
-use SimpleSAML\{Configuration, Logger};
+use SimpleSAML\{Configuration, Error\ConfigurationError, Logger};
 use SimpleSAML\XHTML\Template;
 
 use function array_map;
@@ -47,6 +47,7 @@ class EMail
      * @param string $html_template The template to use for html messages
      *
      * @throws \PHPMailer\PHPMailer\Exception
+     * @throws Exception
      */
     public function __construct(
         string $subject,
@@ -73,6 +74,7 @@ class EMail
      * which is na@example.org.
      *
      * @return string Default mail address
+     * @throws Exception
      */
     public function getDefaultMailAddress(): string
     {
@@ -126,6 +128,7 @@ class EMail
      * Add a Reply-To address to the mail
      *
      * @param string $address Reply-To e-mail address
+     * @throws \PHPMailer\PHPMailer\Exception
      */
     public function addReplyTo(string $address): void
     {
@@ -139,6 +142,8 @@ class EMail
      * @param bool $plainTextOnly Do not send HTML payload
      *
      * @throws \PHPMailer\PHPMailer\Exception
+     * @throws ConfigurationError
+     * @throws Exception
      */
     public function send(bool $plainTextOnly = false): void
     {
@@ -259,6 +264,8 @@ class EMail
      * @param string $template The name of the template to use
      *
      * @return string The body of the e-mail
+     * @throws Exception
+     * @throws ConfigurationError
      */
     public function generateBody(string $template): string
     {

--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Utils;
 
 use InvalidArgumentException;
-use SimpleSAML\{Configuration, Error, Logger, Module, Session};
+use SimpleSAML\{Configuration, Error, Error\CriticalConfigurationError, Error\Exception, Logger, Module, Session};
 use SimpleSAML\XHTML\Template;
 use SimpleSAML\XMLSecurity\Alg\Encryption\AES;
 use SimpleSAML\XMLSecurity\Constants as C;
@@ -114,7 +114,10 @@ class HTTP
      * @param string $destination The destination URL.
      * @param array  $data An associative array containing the data to be posted to $destination.
      *
+     * @throws \Exception
      * @throws Error\Exception If the current session is transient.
+     * @throws \Throwable
+     *
      * @return string  A URL which allows to securely post a form to $destination.
      *
      */
@@ -258,6 +261,7 @@ class HTTP
      *
      * @throws \InvalidArgumentException If $url is not a string or is empty, or $parameters is not an array.
      * @throws \SimpleSAML\Error\Exception If $url is not a valid HTTP URL.
+     * @throws \Exception
      *
      */
     private function redirect(string $url, array $parameters = []): RedirectResponse
@@ -291,6 +295,7 @@ class HTTP
      *
      * @return string A random identifier that can be used to retrieve the data from the current session.
      *
+     * @throws \Exception
      */
     private function savePOSTData(Session $session, string $destination, array $data): string
     {
@@ -350,6 +355,8 @@ class HTTP
      *
      *     page telling about the missing cookie.
      * @throws \InvalidArgumentException If $retryURL is neither a string nor null.
+     * @throws \Exception
+     * @throws \Throwable
      *
      */
     public function checkSessionCookie(?string $retryURL = null): void
@@ -381,6 +388,7 @@ class HTTP
      * defined by the empty() function.
      * @throws \InvalidArgumentException If the URL is malformed.
      * @throws Error\Exception If the URL is not allowed by configuration.
+     * @throws \Exception
      *
      */
     public function checkURLAllowed(string $url, ?array $trustedSites = null): string
@@ -470,6 +478,7 @@ class HTTP
      *  otherwise.
      * @throws \InvalidArgumentException If the input parameters are invalid.
      * @throws Error\Exception If the file or URL cannot be retrieved.
+     * @throws \Exception
      *
      */
     public function fetch(string $url, array $context = [], bool $getHeaders = false)
@@ -654,6 +663,7 @@ class HTTP
      *
      * @return string The absolute base URL for the SimpleSAMLphp installation.
      * @throws \SimpleSAML\Error\CriticalConfigurationError If 'baseurlpath' has an invalid format.
+     * @throws \Exception
      *
      */
     public function getBaseURL(): string
@@ -704,6 +714,9 @@ class HTTP
      *
      * @return string  A URL which can be accessed to post the data.
      * @throws \InvalidArgumentException If $destination is not a string or $data is not an array.
+     * @throws \Exception
+     * @throws Exception
+     * @throws \Throwable
      *
      */
     public function getPOSTRedirectURL(string $destination, array $data): string
@@ -732,6 +745,8 @@ class HTTP
      *
      * @return string The current host.
      *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function getSelfHost(): string
     {
@@ -749,6 +764,8 @@ class HTTP
      * @return string The current host, followed by a colon and the port number, in case the port is not standard for
      * the protocol.
      *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function getSelfHostWithNonStandardPort(): string
     {
@@ -769,6 +786,8 @@ class HTTP
      *
      * @return string The current host (with non-default ports included) plus the URL path.
      *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function getSelfHostWithPath(): string
     {
@@ -790,6 +809,8 @@ class HTTP
      *
      * @return string The current URL, including query parameters.
      *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function getSelfURL(): string
     {
@@ -850,6 +871,8 @@ class HTTP
      *
      * @return string The current URL without path or query parameters.
      *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function getSelfURLHost(): string
     {
@@ -868,6 +891,8 @@ class HTTP
      *
      * @return string The current URL, not including query parameters.
      *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function getSelfURLNoQuery(): string
     {
@@ -885,6 +910,8 @@ class HTTP
      *
      * @return boolean True if the HTTPS is used, false otherwise.
      *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function isHTTPS(): bool
     {
@@ -900,7 +927,8 @@ class HTTP
      *
      * @return string An absolute URL for the given relative URL.
      * @throws \InvalidArgumentException If $url is not a string or a valid URL.
-     *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function normalizeURL(string $url): string
     {
@@ -968,7 +996,8 @@ class HTTP
      * name, without a value.
      *
      * @throws \InvalidArgumentException If $url is not a string or $parameters is not an array.
-     *
+     * @throws Exception
+     * @throws \Exception
      */
     public function redirectTrustedURL(string $url, array $parameters = []): RedirectResponse
     {
@@ -994,7 +1023,8 @@ class HTTP
      * name, without a value.
      *
      * @throws \InvalidArgumentException If $url is not a string or $parameters is not an array.
-     *
+     * @throws Exception
+     * @throws \Exception
      */
     public function redirectUntrustedURL(string $url, array $parameters = []): RedirectResponse
     {
@@ -1020,7 +1050,8 @@ class HTTP
      * @return string An absolute URL for the given relative URL.
      * @throws \InvalidArgumentException If the base URL cannot be parsed into a valid URL, or the given parameters
      *     are not strings.
-     *
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function resolveURL(string $url, ?string $base = null): string
     {
@@ -1094,6 +1125,8 @@ class HTTP
      *
      * @throws \InvalidArgumentException If any parameter has an incorrect type.
      * @throws \SimpleSAML\Error\CannotSetCookie If the headers were already sent and the cookie cannot be set.
+     * @throws \Exception
+     * @throws CriticalConfigurationError
      *
      *
      */
@@ -1191,6 +1224,8 @@ class HTTP
      *
      * @throws \InvalidArgumentException If $destination is not a string or $data is not an array.
      * @throws \SimpleSAML\Error\Exception If $destination is not a valid HTTP URL.
+     * @throws \Exception
+     * @throws \Throwable
      *
      */
     public function submitPOSTData(string $destination, array $data): RedirectResponse|Template

--- a/src/SimpleSAML/Utils/System.php
+++ b/src/SimpleSAML/Utils/System.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Utils;
 
 use SimpleSAML\{Configuration, Error};
 
+use Random\RandomException;
 use function chmod;
 use function dirname;
 use function error_get_last;
@@ -89,6 +90,7 @@ class System
      *
      * @return string Path to a temporary directory, without a trailing directory separator.
      * @throws Error\Exception If the temporary directory cannot be created or it exists and cannot be written
+     * @throws \Exception
      * to by the current user.
      *
      */
@@ -142,6 +144,7 @@ class System
      *
      * @return string An absolute path referring to $path.
      *
+     * @throws \Exception
      */
     public function resolvePath(string $path, ?string $base = null): string
     {
@@ -204,6 +207,7 @@ class System
      *
      * @throws \InvalidArgumentException If any of the input parameters doesn't have the proper types.
      * @throws Error\Exception If the file cannot be saved, permissions cannot be changed or it is not
+     * @throws RandomException
      *     possible to write to the target file.
      *
      */

--- a/src/SimpleSAML/Utils/Time.php
+++ b/src/SimpleSAML/Utils/Time.php
@@ -54,6 +54,7 @@ class Time
      *
      *
      * @throws \SimpleSAML\Error\Exception If the timezone set in the configuration is invalid.
+     * @throws \Exception
      */
     public function initTimezone(): void
     {

--- a/src/SimpleSAML/Utils/Translate.php
+++ b/src/SimpleSAML/Utils/Translate.php
@@ -6,6 +6,8 @@ namespace SimpleSAML\Utils;
 
 use Gettext\Scanner\PhpScanner;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\ConfigurationError;
+use SimpleSAML\Error\CriticalConfigurationError;
 use SimpleSAML\Error\Exception;
 use SimpleSAML\Module;
 use SimpleSAML\XHTML\Template;
@@ -28,13 +30,19 @@ class Translate
     protected string $baseDir;
 
 
+    /**
+     * @throws \SimpleSAML\Assert\AssertionFailedException
+     */
     public function __construct(
         protected Configuration $configuration,
     ) {
         $this->baseDir = $configuration->getBaseDir();
     }
 
-
+    /**
+     * @throws \LogicException
+     * @throws \Symfony\Component\Finder\Exception\DirectoryNotFoundException
+     */
     public function getTranslationsFromPhp(string $module, PhpScanner $phpScanner): PhpScanner
     {
         $moduleDir = $this->baseDir . ($module === '' ? '' : 'modules/' . $module . '/');
@@ -54,6 +62,12 @@ class Translate
     }
 
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \Exception
+     */
     public function getTranslationsFromTwig(string $module, bool $includeThemes = false): array
     {
         $twigTranslations = [];

--- a/src/SimpleSAML/Utils/XML.php
+++ b/src/SimpleSAML/Utils/XML.php
@@ -47,6 +47,7 @@ class XML
      * @throws \InvalidArgumentException If $message is not a string or $type is not a string containing one of the
      *     values allowed.
      * @throws \SimpleSAML\Error\Exception If $message contains a doctype declaration.
+     * @throws Exception
      *
      *
      */
@@ -99,6 +100,8 @@ class XML
      *      - 'encrypt': for encrypted messages.
      *
      * @throws \InvalidArgumentException If $type is not a string or $message is neither a string nor a \DOMElement.
+     * @throws DOMException
+     * @throws Exception
      *
      *
      */
@@ -323,6 +326,7 @@ class XML
      *
      * @return bool|string Returns a string with errors found if validation fails. True if validation passes ok.
      * @throws \InvalidArgumentException If $schema is not a string, or $xml is neither a string nor a \DOMDocument.
+     * @throws Exception
      *
      */
     public function isValid(string|DOMDocument $xml, string $schema)

--- a/src/SimpleSAML/XHTML/IdPDisco.php
+++ b/src/SimpleSAML/XHTML/IdPDisco.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\XHTML;
 
 use Exception;
-use SimpleSAML\{Configuration, Logger, Session, Utils};
+use SimpleSAML\{Configuration, Error\CannotSetCookie, Error\ConfigurationError, Error\CriticalConfigurationError, Logger, Session, Utils};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use Symfony\Component\HttpFoundation\{Request, Response};
 
@@ -110,6 +110,7 @@ class IdPDisco
      * @param string $instance The name of this instance of the discovery service.
      *
      * @throws \Exception If the request is invalid.
+     * @throws \Throwable
      */
     public function __construct(
         protected Request $request,
@@ -175,6 +176,7 @@ class IdPDisco
      * discovery service type.
      *
      * @param string $message The message which should be logged.
+     * @throws Exception
      */
     protected function log(string $message): void
     {
@@ -211,6 +213,10 @@ class IdPDisco
      *
      * @param string $name The name of the cookie.
      * @param string $value The value of the cookie.
+     * @throws CannotSetCookie
+     * @throws CriticalConfigurationError
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     protected function setCookie(string $name, string $value): void
     {
@@ -238,6 +244,7 @@ class IdPDisco
      * @param string|null $idp The entity id we want to validate. This can be null, in which case we will return null.
      *
      * @return string|null The entity id if it is valid, null if not.
+     * @throws Exception
      */
     protected function validateIdP(?string $idp): ?string
     {
@@ -271,6 +278,7 @@ class IdPDisco
      * This function finds out which IdP the user has manually chosen, if any.
      *
      * @return string|null The entity id of the IdP the user has chosen, or null if the user has made no choice.
+     * @throws Exception
      */
     protected function getSelectedIdP(): ?string
     {
@@ -307,6 +315,7 @@ class IdPDisco
      * Retrieve the users saved choice of IdP.
      *
      * @return string|null The entity id of the IdP the user has saved, or null if the user hasn't saved any choice.
+     * @throws Exception
      */
     protected function getSavedIdP(): ?string
     {
@@ -333,6 +342,7 @@ class IdPDisco
      * Retrieve the previous IdP the user used.
      *
      * @return string|null The entity id of the previous IdP the user used, or null if this is the first time.
+     * @throws Exception
      */
     protected function getPreviousIdP(): ?string
     {
@@ -369,6 +379,7 @@ class IdPDisco
      * hasn't chosen an IdP before, it will look at the IP address.
      *
      * @return string|null The entity id of the IdP the user should most likely use.
+     * @throws Exception
      */
     protected function getRecommendedIdP(): ?string
     {
@@ -393,6 +404,7 @@ class IdPDisco
      * Save the current IdP choice to a cookie.
      *
      * @param string $idp The entityID of the IdP.
+     * @throws Exception
      */
     protected function setPreviousIdP(string $idp): void
     {
@@ -405,6 +417,7 @@ class IdPDisco
      * Determine whether the choice of IdP should be saved.
      *
      * @return boolean True if the choice should be saved, false otherwise.
+     * @throws \SimpleSAML\Assert\AssertionFailedException
      */
     protected function saveIdP(): bool
     {
@@ -425,6 +438,7 @@ class IdPDisco
      * Determine which IdP the user should go to, if any.
      *
      * @return string|null The entity id of the IdP the user should be sent to, or null if the user should choose.
+     * @throws Exception
      */
     protected function getTargetIdP(): ?string
     {
@@ -461,6 +475,7 @@ class IdPDisco
      * Retrieve the list of IdPs which are stored in the metadata.
      *
      * @return array An array with entityid => metadata mappings.
+     * @throws Exception
      */
     protected function getIdPList(): array
     {
@@ -512,6 +527,8 @@ class IdPDisco
 
     /**
      * Check if an IdP is set or if the request is passive, and redirect accordingly.
+     * @throws \SimpleSAML\Error\Exception
+     * @throws Exception
      */
     protected function start(): ?Response
     {
@@ -551,6 +568,8 @@ class IdPDisco
      * Handles a request to this discovery service.
      *
      * The IdP disco parameters should be set before calling this function.
+     * @throws ConfigurationError
+     * @throws Exception
      */
     public function handleRequest(): Response
     {

--- a/src/SimpleSAML/XHTML/Template.php
+++ b/src/SimpleSAML/XHTML/Template.php
@@ -12,7 +12,7 @@ namespace SimpleSAML\XHTML;
 
 use Exception;
 use InvalidArgumentException;
-use SimpleSAML\{Configuration, Error, Logger, Module, Utils};
+use SimpleSAML\{Configuration, Error, Error\ConfigurationError, Error\CriticalConfigurationError, Logger, Module, Utils};
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Locale\{Language, Localization, Translate, TwigTranslator};
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\Response;
-use Twig\{Environment, TwigFilter, TwigFunction};
+use Twig\{Environment, Error\LoaderError, TwigFilter, TwigFunction};
 use Twig\Error\RuntimeError;
 use Twig\Extension\DebugExtension;
 use Twig\Extra\Intl\IntlExtension;
@@ -120,6 +120,9 @@ class Template extends Response
      *
      * @param \SimpleSAML\Configuration $configuration Configuration object
      * @param string                   $template Which template file to load
+     * @throws Exception
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
      */
     public function __construct(
         private Configuration $configuration,
@@ -172,6 +175,10 @@ class Template extends Response
      * @param string|null $module
      * @param bool $tag
      * @return string
+     * @throws CriticalConfigurationError
+     * @throws \Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function asset(string $asset, ?string $module = null, bool $tag = true): string
     {
@@ -242,6 +249,7 @@ class Template extends Response
      *
      * @return TemplateLoader The twig template loader or false if the template does not exist.
      * @throws \Twig\Error\LoaderError In case a failure occurs.
+     * @throws Exception
      */
     private function setupTwigTemplatepaths(): TemplateLoader
     {
@@ -378,6 +386,7 @@ class Template extends Response
      * Add overriding templates from the configured theme.
      *
      * @return array An array of module => templatedir lookups.
+     * @throws Exception
      */
     private function findThemeTemplateDirs(): array
     {
@@ -424,6 +433,7 @@ class Template extends Response
      * @return string The templates directory of a module
      *
      * @throws \InvalidArgumentException If the module is not enabled or it has no templates directory.
+     * @throws Exception
      */
     private function getModuleTemplateDir(string $module): string
     {
@@ -448,6 +458,8 @@ class Template extends Response
      *
      * @param string $module The module where we need to search for templates.
      * @throws \InvalidArgumentException If the module is not enabled or it has no templates directory.
+     * @throws LoaderError
+     * @throws Exception
      */
     public function addTemplatesFromModule(string $module): void
     {
@@ -463,6 +475,7 @@ class Template extends Response
      * containing their localized names and the URL that should be used in order to change to that language.
      *
      * @return array|null The array containing information of all available languages.
+     * @throws Exception
      */
     private function generateLanguageBar(): ?array
     {
@@ -494,6 +507,7 @@ class Template extends Response
 
     /**
      * Set some default context
+     * @throws Exception
      */
     private function twigDefaultContext(): void
     {
@@ -529,6 +543,10 @@ class Template extends Response
      * Helper function for locale extraction: just compile but not display
      * this template. This is not generally useful, getContents() will normally
      * compile and display the template in one step.
+     *
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function compile(): void
     {
@@ -623,6 +641,7 @@ class Template extends Response
      * Wraps Language->getLanguageList
      *
      * @return string[]
+     * @throws Exception
      */
     private function getLanguageList(): array
     {
@@ -634,6 +653,7 @@ class Template extends Response
      * Wrap Language->isLanguageRTL
      *
      * @return bool
+     * @throws Exception
      */
     private function isLanguageRTL(): bool
     {
@@ -646,6 +666,7 @@ class Template extends Response
      * language and fallback language for the DisplayName, name, OrganizationDisplayName
      * and OrganizationName; the first one found is considered the best match.
      * If nothing found, will return the entityId.
+     * @throws Exception
      */
     public function getEntityDisplayName(array $data): string
     {
@@ -673,6 +694,7 @@ class Template extends Response
      * returns null.
      *
      * @return string|array|null
+     * @throws Exception
      */
     public function getEntityPropertyTranslation(string $property, array $data): string|array|null
     {

--- a/src/SimpleSAML/XHTML/TemplateLoader.php
+++ b/src/SimpleSAML/XHTML/TemplateLoader.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\XHTML;
 use InvalidArgumentException;
 use SimpleSAML\Module;
 
+use Twig\Error\LoaderError;
 use function explode;
 use function in_array;
 use function is_dir;
@@ -32,6 +33,8 @@ class TemplateLoader extends \Twig\Loader\FilesystemLoader
      * @return string|null
      *
      * NOTE: cannot typehint due to upstream restrictions
+     * @throws LoaderError
+     * @throws \Exception
      */
     protected function findTemplate(string $name, bool $throw = true)
     {
@@ -70,6 +73,7 @@ class TemplateLoader extends \Twig\Loader\FilesystemLoader
      * @return string The templates directory of a module.
      *
      * @throws \InvalidArgumentException If the module is not enabled or it has no templates directory.
+     * @throws \Exception
      */
     public static function getModuleTemplateDir(string $module): string
     {

--- a/src/SimpleSAML/XML/Parser.php
+++ b/src/SimpleSAML/XML/Parser.php
@@ -23,6 +23,7 @@ class Parser
 
     /**
      * @param string $xml
+     * @throws Exception
      */
     public function __construct(string $xml)
     {
@@ -36,6 +37,7 @@ class Parser
     /**
      * @param \SimpleXMLElement $element
      * @return \SimpleSAML\XML\Parser
+     * @throws Exception
      */
     public static function fromSimpleXMLElement(SimpleXMLElement $element): Parser
     {

--- a/src/SimpleSAML/XML/Signer.php
+++ b/src/SimpleSAML/XML/Signer.php
@@ -67,6 +67,7 @@ class Signer
      *  - id               The name of the ID attribute.
      *
      * @param array $options  Associative array with options for the constructor. Defaults to an empty array.
+     * @throws Exception
      */
     public function __construct(array $options = [])
     {
@@ -106,6 +107,7 @@ class Signer
      * by \SimpleSAML\Utils\Crypto::loadPrivateKey(...).
      *
      * @param array $privatekey  The private key.
+     * @throws Exception
      */
     public function loadPrivateKeyArray(array $privatekey): void
     {

--- a/src/_autoload_modules.php
+++ b/src/_autoload_modules.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  * Autoload function for SimpleSAMLphp modules following PSR-4.
  *
  * @param string $className Name of the class.
+ * @throws Exception
  */
 function sspmodAutoloadPSR4(string $className): void
 {

--- a/tests/SigningTestCase.php
+++ b/tests/SigningTestCase.php
@@ -214,6 +214,7 @@ NOWDOC;
 
 
     /**
+     * @throws \ReflectionException
      */
     public function tearDown(): void
     {
@@ -225,6 +226,7 @@ NOWDOC;
      * @param \SimpleSAML\Configuration $service
      * @param class-string $className
      * @param mixed $value
+     * @throws \ReflectionException
      */
     protected function clearInstance(Configuration $service, string $className, mixed $value = null): void
     {

--- a/tests/Utils/SpTester.php
+++ b/tests/Utils/SpTester.php
@@ -20,6 +20,7 @@ class SpTester extends SP
     /**
      * @param array $info
      * @param array $config
+     * @throws \Exception
      */
     public function __construct(array $info, array $config)
     {
@@ -28,6 +29,7 @@ class SpTester extends SP
 
 
     /**
+     * @throws \ReflectionException
      */
     public function startSSO2Test(Configuration $idpMetadata, array $state): void
     {
@@ -40,6 +42,7 @@ class SpTester extends SP
 
     /**
      * override the method that sends the request to avoid sending anything
+     * @throws ExitTestException
      */
     public function sendSAML2AuthnRequest(Binding $binding, AuthnRequest $ar): Response
     {
@@ -55,6 +58,7 @@ class SpTester extends SP
 
     /**
      * override the method that sends the request to avoid sending anything
+     * @throws ExitTestException
      */
     public function sendSAML2LogoutRequest(Binding $binding, LogoutRequest $lr): Response
     {

--- a/tests/modules/admin/src/Controller/ConfigTest.php
+++ b/tests/modules/admin/src/Controller/ConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Test\Module\admin\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\{Configuration, Session, Utils};
 use SimpleSAML\Module\admin\Controller;
@@ -30,6 +31,8 @@ class ConfigTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws Exception
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -110,6 +113,8 @@ class ConfigTest extends TestCase
 
 
     /**
+     * @throws \SimpleSAML\Error\Exception
+     * @throws \Throwable
      */
     public function testPhpinfo(): void
     {

--- a/tests/modules/admin/src/Controller/FederationTest.php
+++ b/tests/modules/admin/src/Controller/FederationTest.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Module\admin\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Auth, Configuration, Module, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error\Exception, Module, Session, Utils};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\admin\Controller;
 use SimpleSAML\Module\saml\Auth\Source\SP;
@@ -14,6 +14,7 @@ use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{Cookie, Request, Response};
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use Symfony\Component\VarExporter\Exception\ExceptionInterface;
 use function file_get_contents;
 
 /**
@@ -59,6 +60,7 @@ class FederationTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -99,6 +101,10 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws ExceptionInterface
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testMain(): void
     {
@@ -184,6 +190,9 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function testMetadataConverterFileUpload(): void
     {
@@ -214,6 +223,9 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function testMetadataConverterData(): void
     {
@@ -233,6 +245,9 @@ class FederationTest extends TestCase
     }
 
     /**
+     * @throws \Exception
+     * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function testMetadataConverterSkipsExpires(): void
     {
@@ -253,6 +268,9 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function testMetadataConverterInvalidMetadataShowsError(): void
     {
@@ -274,6 +292,9 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function testMetadataConverterEmptyInput(): void
     {
@@ -296,6 +317,8 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDownloadCertSP(): void
     {
@@ -348,6 +371,8 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDownloadCertFile(): void
     {
@@ -387,6 +412,9 @@ class FederationTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function testShowRemoteEntity(): void
     {

--- a/tests/modules/admin/src/Controller/SandboxTest.php
+++ b/tests/modules/admin/src/Controller/SandboxTest.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Module\admin\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Session};
+use SimpleSAML\{Configuration, Error\ConfigurationError, Session};
 use SimpleSAML\Module\admin\Controller;
 use SimpleSAML\XHTML\Template;
 
@@ -27,6 +27,8 @@ class SandboxTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function setUp(): void
     {
@@ -45,6 +47,7 @@ class SandboxTest extends TestCase
 
 
     /**
+     * @throws ConfigurationError
      */
     public function testSandbox(): void
     {

--- a/tests/modules/admin/src/Controller/TestTest.php
+++ b/tests/modules/admin/src/Controller/TestTest.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Module\admin\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Auth, Configuration, Error, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\ConfigurationError, Session, Utils};
 use SimpleSAML\Module\admin\Controller\Test as TestController;
 use SimpleSAML\SAML2\XML\saml\NameID;
 use SimpleSAML\XHTML\Template;
@@ -32,6 +32,8 @@ class TestTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function setUp(): void
     {
@@ -110,6 +112,7 @@ class TestTest extends TestCase
 
 
     /**
+     * @throws ConfigurationError
      */
     public function testLogoutReturnsTemplate(): void
     {

--- a/tests/modules/core/src/Auth/Process/AttributeAddTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeAddTest.php
@@ -21,6 +21,7 @@ class AttributeAddTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -32,6 +33,7 @@ class AttributeAddTest extends TestCase
 
     /**
      * Test the most basic functionality.
+     * @throws Exception
      */
     public function testBasic(): void
     {
@@ -50,6 +52,7 @@ class AttributeAddTest extends TestCase
 
     /**
      * Test that existing attributes are left unmodified.
+     * @throws Exception
      */
     public function testExistingNotModified(): void
     {
@@ -75,6 +78,7 @@ class AttributeAddTest extends TestCase
 
     /**
      * Test single string as attribute value.
+     * @throws Exception
      */
     public function testStringValue(): void
     {
@@ -93,6 +97,7 @@ class AttributeAddTest extends TestCase
 
     /**
      * Test adding multiple attributes in one config.
+     * @throws Exception
      */
     public function testAddMultiple(): void
     {
@@ -114,6 +119,7 @@ class AttributeAddTest extends TestCase
 
     /**
      * Test behavior when appending attribute values.
+     * @throws Exception
      */
     public function testAppend(): void
     {
@@ -133,6 +139,7 @@ class AttributeAddTest extends TestCase
 
     /**
      * Test replacing attribute values.
+     * @throws Exception
      */
     public function testReplace(): void
     {

--- a/tests/modules/core/src/Auth/Process/AttributeAlterTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeAlterTest.php
@@ -21,6 +21,7 @@ class AttributeAlterTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws \SimpleSAML\Error\Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -32,6 +33,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test the most basic functionality.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testBasic(): void
     {
@@ -56,6 +58,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test the most basic functionality.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testWithTarget(): void
     {
@@ -83,6 +86,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test the most basic functionality with merging strategy.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMergeWithTarget(): void
     {
@@ -111,6 +115,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Module is a no op if subject attribute is not present.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testNomatch(): void
     {
@@ -139,6 +144,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test replacing attribute value.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testReplaceMatch(): void
     {
@@ -161,6 +167,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test replacing attribute value.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testReplaceMatchWithTarget(): void
     {
@@ -185,6 +192,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test replacing attribute value with merging strategy.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testReplaceMergeMatchWithTarget(): void
     {
@@ -210,6 +218,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test replacing attribute values.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testReplaceNoMatch(): void
     {
@@ -236,6 +245,7 @@ class AttributeAlterTest extends TestCase
      * Test removing attribute values.
      * Note that removing a value does not renumber the attributes array.
      * Also ensure unrelated attributes are not touched.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testRemoveMatch(): void
     {
@@ -259,6 +269,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test removing attribute values, resulting in an empty attribute.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testRemoveMatchAll(): void
     {
@@ -281,6 +292,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test for exception with illegal config.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testWrongConfig(): void
     {
@@ -301,6 +313,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test for exception with illegal config.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testIncompleteConfig(): void
     {
@@ -319,6 +332,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test for exception with illegal config.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testIncompleteConfig2(): void
     {
@@ -339,6 +353,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test for exception with illegal config.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testIncompleteConfig3(): void
     {
@@ -361,6 +376,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test for exception with illegal config.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testIncompleteConfig4(): void
     {
@@ -383,6 +399,7 @@ class AttributeAlterTest extends TestCase
 
     /**
      * Test for exception with illegal config.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testIncompleteConfig5(): void
     {

--- a/tests/modules/core/src/Auth/Process/AttributeCopyTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeCopyTest.php
@@ -21,6 +21,7 @@ class AttributeCopyTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -32,6 +33,7 @@ class AttributeCopyTest extends TestCase
 
     /**
      * Test the most basic functionality.
+     * @throws Exception
      */
     public function testBasic(): void
     {
@@ -51,6 +53,7 @@ class AttributeCopyTest extends TestCase
 
     /**
      * Test the most basic functionality.
+     * @throws Exception
      */
     public function testArray(): void
     {
@@ -72,6 +75,7 @@ class AttributeCopyTest extends TestCase
 
     /**
      * Test that existing attributes are left unmodified.
+     * @throws Exception
      */
     public function testExistingNotModified(): void
     {
@@ -98,6 +102,7 @@ class AttributeCopyTest extends TestCase
 
     /**
      * Test copying multiple attributes
+     * @throws Exception
      */
     public function testCopyMultiple(): void
     {
@@ -119,6 +124,7 @@ class AttributeCopyTest extends TestCase
 
     /**
      * Test behaviour when target attribute exists (should be replaced).
+     * @throws Exception
      */
     public function testCopyClash(): void
     {

--- a/tests/modules/core/src/Auth/Process/AttributeLimitTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeLimitTest.php
@@ -29,6 +29,7 @@ class AttributeLimitTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws \SimpleSAML\Error\Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -40,6 +41,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test reading IdP Attributes.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testIdPAttrs(): void
     {
@@ -86,6 +88,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Tests when no attributes are in metadata.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testNULLMetadataAttrs(): void
     {
@@ -169,6 +172,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test the most basic functionality.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testBasic(): void
     {
@@ -186,6 +190,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test defaults with metadata available.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testDefaultWithMetadata(): void
     {
@@ -203,6 +208,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test defaults with attributes and metadata
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testDefaultWithAttrs(): void
     {
@@ -224,6 +230,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test for exception with illegal config.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testInvalidConfig(): void
     {
@@ -238,6 +245,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test for invalid attribute name
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testInvalidAttributeName(): void
     {
@@ -252,6 +260,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test for attribute matching using regular expresssion support
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMatchAttributeRegex(): void
     {
@@ -324,6 +333,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test for attribute value matching
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMatchAttributeValues(): void
     {
@@ -367,6 +377,7 @@ class AttributeLimitTest extends TestCase
 
 
     /**
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testBadOptionsNotTreatedAsValidValues(): void
     {
@@ -384,6 +395,7 @@ class AttributeLimitTest extends TestCase
     /**
      * Verify that the true value for ignoreCase doesn't get converted into a string ('1') by
      * php and matched against an attribute value of '1'
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testThatIgnoreCaseOptionNotMatchBooleanAsStringValue(): void
     {
@@ -405,6 +417,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test for attribute value matching ignore case
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMatchAttributeValuesIgnoreCase(): void
     {
@@ -448,6 +461,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test for attribute value matching
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMatchAttributeValuesRegex(): void
     {
@@ -552,6 +566,7 @@ class AttributeLimitTest extends TestCase
      *
      * This test is very unlikely and would require malformed metadata processing.
      * Cannot be generated via config options.
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMatchAttributeValuesNotArray(): void
     {
@@ -581,6 +596,7 @@ class AttributeLimitTest extends TestCase
 
     /**
      * Test attributes not intersecting
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testNoIntersection(): void
     {

--- a/tests/modules/core/src/Auth/Process/AttributeMapTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeMapTest.php
@@ -21,6 +21,7 @@ class AttributeMapTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -31,6 +32,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testBasic(): void
     {
@@ -54,6 +56,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testDuplicate(): void
     {
@@ -79,6 +82,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testMultiple(): void
     {
@@ -103,6 +107,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testMultipleDuplicate(): void
     {
@@ -129,6 +134,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testCircular(): void
     {
@@ -155,6 +161,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testMissingMap(): void
     {
@@ -234,6 +241,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testOverwrite(): void
     {
@@ -258,6 +266,7 @@ class AttributeMapTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testOverwriteReversed(): void
     {

--- a/tests/modules/core/src/Auth/Process/AttributeValueMapTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeValueMapTest.php
@@ -21,6 +21,8 @@ class AttributeValueMapTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws \SimpleSAML\Error\Exception
+     * @throws Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -33,6 +35,7 @@ class AttributeValueMapTest extends TestCase
     /**
      * Test the most basic functionality.
      *
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testBasic(): void
     {
@@ -62,6 +65,7 @@ class AttributeValueMapTest extends TestCase
     /**
      * Test basic functionality, remove duplicates
      *
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testNoDuplicates(): void
     {
@@ -92,6 +96,7 @@ class AttributeValueMapTest extends TestCase
     /**
      * Test the %replace functionality.
      *
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testReplace(): void
     {
@@ -123,6 +128,7 @@ class AttributeValueMapTest extends TestCase
     /**
      * Test the %keep functionality.
      *
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testKeep(): void
     {
@@ -154,6 +160,7 @@ class AttributeValueMapTest extends TestCase
     /**
      * Test unknown flag Exception
      *
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testUnknownFlag(): void
     {
@@ -182,6 +189,7 @@ class AttributeValueMapTest extends TestCase
     /**
      * Test missing Source attribute
      *
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMissingSourceAttribute(): void
     {
@@ -206,6 +214,7 @@ class AttributeValueMapTest extends TestCase
     /**
      * Test missing Target attribute
      *
+     * @throws \SimpleSAML\Error\Exception
      */
     public function testMissingTargetAttribute(): void
     {

--- a/tests/modules/core/src/Auth/Process/CardinalityTest.php
+++ b/tests/modules/core/src/Auth/Process/CardinalityTest.php
@@ -27,6 +27,8 @@ class CardinalityTest extends TestCase
      * @param  array $config The filter configuration.
      * @param  array $request The request state.
      * @return array  The state array after processing.
+     * @throws SspException
+     * @throws \Throwable
      */
     private function processFilter(array $config, array $request): array
     {
@@ -53,6 +55,8 @@ class CardinalityTest extends TestCase
 
     /**
      * Test where a minimum is set but no maximum
+     * @throws SspException
+     * @throws \Throwable
      */
     public function testMinNoMax(): void
     {
@@ -73,6 +77,8 @@ class CardinalityTest extends TestCase
 
     /**
      * Test where a maximum is set but no minimum
+     * @throws SspException
+     * @throws \Throwable
      */
     public function testMaxNoMin(): void
     {
@@ -93,6 +99,8 @@ class CardinalityTest extends TestCase
 
     /**
      * Test in bounds within a maximum an minimum
+     * @throws SspException
+     * @throws \Throwable
      */
     public function testMaxMin(): void
     {
@@ -113,6 +121,8 @@ class CardinalityTest extends TestCase
 
     /**
      * Test maximum is out of bounds results in redirect
+     * @throws SspException
+     * @throws \Throwable
      */
     #[DoesNotPerformAssertions]
     public function testMaxOutOfBounds(): void
@@ -136,6 +146,8 @@ class CardinalityTest extends TestCase
 
     /**
      * Test minimum is out of bounds results in redirect
+     * @throws SspException
+     * @throws \Throwable
      */
     #[DoesNotPerformAssertions]
     public function testMinOutOfBounds(): void
@@ -159,6 +171,8 @@ class CardinalityTest extends TestCase
 
     /**
      * Test missing attribute results in redirect
+     * @throws SspException
+     * @throws \Throwable
      */
     #[DoesNotPerformAssertions]
     public function testMissingAttribute(): void
@@ -185,6 +199,7 @@ class CardinalityTest extends TestCase
 
     /**
      * Test invalid minimum values
+     * @throws \Throwable
      */
     public function testMinInvalid(): void
     {
@@ -204,6 +219,7 @@ class CardinalityTest extends TestCase
 
     /**
      * Test invalid minimum values
+     * @throws \Throwable
      */
     public function testMinNegative(): void
     {
@@ -223,6 +239,7 @@ class CardinalityTest extends TestCase
 
     /**
      * Test invalid maximum values
+     * @throws \Throwable
      */
     public function testMaxInvalid(): void
     {
@@ -242,6 +259,7 @@ class CardinalityTest extends TestCase
 
     /**
      * Test maximum < minimum
+     * @throws \Throwable
      */
     public function testMinGreaterThanMax(): void
     {
@@ -261,6 +279,7 @@ class CardinalityTest extends TestCase
 
     /**
      * Test invalid attribute name
+     * @throws \Throwable
      */
     public function testInvalidAttributeName(): void
     {

--- a/tests/modules/core/src/Auth/Process/PHPTest.php
+++ b/tests/modules/core/src/Auth/Process/PHPTest.php
@@ -23,6 +23,7 @@ class PHPTest extends TestCase
      * @param array $request The request state.
      *
      * @return array The state array after processing.
+     * @throws Error\Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -48,6 +49,7 @@ class PHPTest extends TestCase
 
     /**
      * Check that defining the code works as expected.
+     * @throws Error\Exception
      */
     public function testCodeDefined(): void
     {
@@ -69,6 +71,7 @@ class PHPTest extends TestCase
 
     /**
      * Check that the incoming attributes are also available after processing
+     * @throws Error\Exception
      */
     public function testPreserveIncomingAttributes(): void
     {
@@ -99,6 +102,7 @@ class PHPTest extends TestCase
     /**
      * Check that throwing an Exception inside the PHP code of the
      * filter (a documented use case) works.
+     * @throws Error\Exception
      */
     public function testThrowExceptionFromFilter(): void
     {
@@ -124,6 +128,7 @@ class PHPTest extends TestCase
 
     /**
      * Check that the entire state can be adjusted.
+     * @throws Error\Exception
      */
     public function testStateCanBeModified(): void
     {

--- a/tests/modules/core/src/Auth/Process/ScopeFromAttributeTest.php
+++ b/tests/modules/core/src/Auth/Process/ScopeFromAttributeTest.php
@@ -20,6 +20,7 @@ class ScopeFromAttributeTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws \Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -31,6 +32,7 @@ class ScopeFromAttributeTest extends TestCase
 
     /**
      * Test the most basic functionality.
+     * @throws \Exception
      */
     public function testBasic(): void
     {
@@ -52,6 +54,7 @@ class ScopeFromAttributeTest extends TestCase
 
     /**
      * If scope already set, module must not overwrite.
+     * @throws \Exception
      */
     public function testNoOverwrite(): void
     {
@@ -73,6 +76,7 @@ class ScopeFromAttributeTest extends TestCase
 
     /**
      * If source attribute not set, nothing happens
+     * @throws \Exception
      */
     public function testNoSourceAttribute(): void
     {
@@ -93,6 +97,7 @@ class ScopeFromAttributeTest extends TestCase
 
     /**
      * When multiple @ signs in attribute, should use first one.
+     * @throws \Exception
      */
     public function testMultiAt(): void
     {
@@ -113,6 +118,7 @@ class ScopeFromAttributeTest extends TestCase
 
     /**
      * When the source attribute doesn't have a scope, a warning is emitted
+     * @throws \Exception
      */
     public function testNoAt(): void
     {

--- a/tests/modules/core/src/Auth/Process/TargetedIDTest.php
+++ b/tests/modules/core/src/Auth/Process/TargetedIDTest.php
@@ -47,6 +47,7 @@ class TargetedIDTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws Exception
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -59,6 +60,7 @@ class TargetedIDTest extends TestCase
 
     /**
      * Test the most basic functionality
+     * @throws Exception
      */
     public function testBasic(): void
     {
@@ -76,6 +78,7 @@ class TargetedIDTest extends TestCase
     /**
      * Test with src and dst entityIds.
      * Make sure to overwrite any present eduPersonTargetedId
+     * @throws Exception
      */
     public function testWithSrcDst(): void
     {
@@ -105,6 +108,7 @@ class TargetedIDTest extends TestCase
 
     /**
      * Test with nameId config option set.
+     * @throws Exception
      */
     public function testNameIdGeneration(): void
     {
@@ -150,6 +154,7 @@ class TargetedIDTest extends TestCase
 
     /**
      * Test the outcome to make sure the algorithm remains unchanged
+     * @throws Exception
      */
     public function testOutcome(): void
     {
@@ -166,6 +171,7 @@ class TargetedIDTest extends TestCase
 
     /**
      * Test the outcome when multiple values are given
+     * @throws Exception
      */
     public function testOutcomeMultipleValues(): void
     {
@@ -182,6 +188,7 @@ class TargetedIDTest extends TestCase
 
     /**
      * Test that Id is the same for subsequent invocations with same input.
+     * @throws Exception
      */
     public function testIdIsPersistent(): void
     {
@@ -215,6 +222,7 @@ class TargetedIDTest extends TestCase
 
     /**
      * Test that Id is different for two different usernames and two different sp's
+     * @throws Exception
      */
     public function testIdIsUnique(): void
     {

--- a/tests/modules/core/src/Auth/Source/RequestedAuthnContextSelectorTest.php
+++ b/tests/modules/core/src/Auth/Source/RequestedAuthnContextSelectorTest.php
@@ -29,6 +29,7 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function setUp(): void
     {
@@ -82,6 +83,9 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
     /**
      * No RequestedAuthnContext
+     * @throws \Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testAuthenticationVariant1(): void
     {
@@ -99,6 +103,9 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
     /**
      * Specific RequestedAuthnContext
+     * @throws \Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testAuthenticationVariant2(): void
     {
@@ -117,6 +124,9 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
     /**
      * Specific RequestedAuthnContext with comparison=exact
+     * @throws \Exception
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testAuthenticationVariant3(): void
     {
@@ -140,6 +150,8 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
     /**
      * Array-syntax
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testArraySyntaxWorks(): void
     {
@@ -199,6 +211,7 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
     /**
      * Missing source
+     * @throws \Exception
      */
     public function testIncompleteConfigurationThrowsExceptionVariant1(): void
     {
@@ -229,6 +242,7 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
     /**
      * Missing identifier
+     * @throws \Exception
      */
     public function testIncompleteConfigurationThrowsExceptionVariant2(): void
     {
@@ -259,6 +273,8 @@ class RequestedAuthnContextSelectorTest extends TestCase
 
     /**
      * Missing default
+     * @throws Exception
+     * @throws \Exception
      */
     public function testIncompleteConfigurationThrowsExceptionVariant3(): void
     {
@@ -289,6 +305,7 @@ class RequestedAuthnContextSelectorTest extends TestCase
     /**
      * @param array $requestedAuthnContext  The RequestedAuthnContext
      * @param string $expected  The expected authsource
+     * @throws \Exception
      */
     #[DataProvider('provideRequestedAuthnContext')]
     public function testSelectAuthSource(array $requestedAuthnContext, string $expected): void

--- a/tests/modules/core/src/Auth/Source/SourceIPSelectorTest.php
+++ b/tests/modules/core/src/Auth/Source/SourceIPSelectorTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Assert\AssertionFailedException;
-use SimpleSAML\{Auth, Configuration};
+use SimpleSAML\{Auth, Configuration, Error\NotFound};
 use SimpleSAML\Error\Exception;
 use SimpleSAML\Module\core\Auth\Source\AbstractSourceSelector;
 use SimpleSAML\Module\core\Auth\Source\SourceIPSelector;
@@ -28,6 +28,7 @@ class SourceIPSelectorTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function setUp(): void
     {
@@ -80,6 +81,8 @@ class SourceIPSelectorTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Exception
      */
     public function testDefaultZoneIsRequired(): void
     {
@@ -102,6 +105,8 @@ class SourceIPSelectorTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testAuthentication(): void
     {
@@ -145,6 +150,7 @@ class SourceIPSelectorTest extends TestCase
     /**
      * @param string $ip  The client IP
      * @param string $expected  The expected authsource
+     * @throws NotFound
      */
     #[DataProvider('provideClientIP')]
     public function testSelectAuthSource(string $ip, string $expected): void
@@ -168,6 +174,7 @@ class SourceIPSelectorTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testIncompleteConfigurationThrowsExceptionVariant1(): void
     {
@@ -201,6 +208,7 @@ class SourceIPSelectorTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testIncompleteConfigurationThrowsExceptionVariant2(): void
     {

--- a/tests/modules/core/src/Auth/UserPassBaseTest.php
+++ b/tests/modules/core/src/Auth/UserPassBaseTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Error\Error as SspError;
 use SimpleSAML\Error\ErrorCodes;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Module\core\Auth\UserPassBase;
 use SimpleSAML\SAML2\Constants as C;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,6 +19,9 @@ use Symfony\Component\HttpFoundation\Request;
 class UserPassBaseTest extends TestCase
 {
     /**
+     * @throws SspError
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testAuthenticateECPCallsLoginAndSetsAttributes(): void
     {
@@ -48,6 +52,8 @@ class UserPassBaseTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testAuthenticateECPMissingUsername(): void
     {
@@ -72,6 +78,8 @@ class UserPassBaseTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testAuthenticateECPMissingPassword(): void
     {
@@ -96,6 +104,9 @@ class UserPassBaseTest extends TestCase
 
 
     /**
+     * @throws SspError
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testAuthenticateECPCallsLoginWithForcedUsername(): void
     {

--- a/tests/modules/core/src/Controller/ErrorReportTest.php
+++ b/tests/modules/core/src/Controller/ErrorReportTest.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Module\core\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Error, Session};
+use SimpleSAML\{Configuration, Error, Error\Exception, Session};
 use SimpleSAML\Module\core\Controller;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request};
@@ -28,6 +28,8 @@ class ErrorReportTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function setUp(): void
     {
@@ -50,6 +52,8 @@ class ErrorReportTest extends TestCase
 
     /**
      * Test that we are presented with an 'error was reported' page
+     * @throws Exception
+     * @throws \PHPMailer\PHPMailer\Exception
      */
     public function testErrorReportSent(): void
     {
@@ -90,6 +94,8 @@ class ErrorReportTest extends TestCase
 
     /**
      * Test that we are presented with an 'error was reported' page
+     * @throws Exception
+     * @throws \PHPMailer\PHPMailer\Exception
      */
     public function testErrorReport(): void
     {

--- a/tests/modules/core/src/Controller/ExceptionTest.php
+++ b/tests/modules/core/src/Controller/ExceptionTest.php
@@ -35,6 +35,8 @@ class ExceptionTest extends TestCase
 
     /**
      * Set up before running the test-suite.
+     * @throws \Exception
+     * @throws \Throwable
      */
     public static function setUpBeforeClass(): void
     {
@@ -68,6 +70,7 @@ class ExceptionTest extends TestCase
     /**
      * @param string $code
      * Test that we are presented with an 'error was reported' page
+     * @throws \Exception
      */
     #[DataProvider('codeProvider')]
     public function testErrorURL(string $code, string $ts, string $rp, string $tid, string $ctx): void
@@ -141,6 +144,7 @@ class ExceptionTest extends TestCase
 
     /**
      * Test that an exception was thrown when an invalid error code was used.
+     * @throws \Exception
      */
     public function testErrorURLInvalidCode(): void
     {

--- a/tests/modules/core/src/Controller/LoginTest.php
+++ b/tests/modules/core/src/Controller/LoginTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Test\Module\core\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use SimpleSAML\{Auth, Configuration, Error};
+use SimpleSAML\{Auth, Configuration, Error, Error\Exception};
 use SimpleSAML\Module\core\Controller;
 use SimpleSAML\Module\core\Auth\{UserPassBase, UserPassOrgBase};
 use SimpleSAML\TestUtils\ClearStateTestCase;
@@ -32,6 +32,7 @@ class LoginTest extends ClearStateTestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -53,6 +54,7 @@ class LoginTest extends ClearStateTestCase
 
     /**
      * Test that we are presented with a regular page if we go to the landing page.
+     * @throws \Exception
      */
     public function testWelcome(): void
     {
@@ -67,6 +69,7 @@ class LoginTest extends ClearStateTestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testClearDiscoChoicesReturnToDisallowedUrlRejected(): void
     {
@@ -87,6 +90,8 @@ class LoginTest extends ClearStateTestCase
 
 
     /**
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testLoginUserPass(): void
     {
@@ -137,6 +142,9 @@ class LoginTest extends ClearStateTestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testLoginUserPassOrgNoState(): void
     {

--- a/tests/modules/core/src/Controller/LogoutTest.php
+++ b/tests/modules/core/src/Controller/LogoutTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Test\Module\core\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use SimpleSAML\{Auth, Configuration, Error};
+use SimpleSAML\{Auth, Configuration, Error, Error\CriticalConfigurationError, Error\Exception};
 use SimpleSAML\Module\core\Controller;
 use SimpleSAML\TestUtils\ClearStateTestCase;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request};
@@ -30,6 +30,7 @@ class LogoutTest extends ClearStateTestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -51,6 +52,9 @@ class LogoutTest extends ClearStateTestCase
     /**
      * Test basic operation of the logout controller.
      * @TODO check if the passed auth source is correctly used
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testLogout(): void
     {

--- a/tests/modules/core/src/Storage/SQLPermanentStorageTest.php
+++ b/tests/modules/core/src/Storage/SQLPermanentStorageTest.php
@@ -25,6 +25,7 @@ class SQLPermanentStorageTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public static function setUpBeforeClass(): void
     {
@@ -46,6 +47,7 @@ class SQLPermanentStorageTest extends TestCase
 
     /**
      *
+     * @throws \Exception
      */
     public function testMissingDatadirThrowsException(): void
     {

--- a/tests/modules/cron/src/Controller/CronTest.php
+++ b/tests/modules/cron/src/Controller/CronTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test\Module\cron\Controller;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Error, Session, Utils};
+use SimpleSAML\{Configuration, Error, Error\Exception, Session, Utils};
 use SimpleSAML\Module\cron\Controller;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{Request, Response};
@@ -32,6 +32,8 @@ class CronTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function setUp(): void
     {
@@ -74,6 +76,8 @@ class CronTest extends TestCase
 
 
     /**
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testInfo(): void
     {
@@ -100,6 +104,8 @@ class CronTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Exception
      */
     public function testRun(): void
     {
@@ -122,6 +128,8 @@ class CronTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Exception
      */
     #[DataProvider('provideStupidSecret')]
     public function testRunWithStupidSecretThrowsException(string $secret): void
@@ -139,6 +147,8 @@ class CronTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Exception
      */
     #[DataProvider('provideStupidSecret')]
     public function testRunWithConfiguredStupidSecretThrowsException(string $secret): void

--- a/tests/modules/exampleauth/src/Controller/ExampleAuthTest.php
+++ b/tests/modules/exampleauth/src/Controller/ExampleAuthTest.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Module\exampleauth\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Auth, Configuration, Error, Session};
+use SimpleSAML\{Auth, Configuration, Error, Error\BadRequest, Error\Exception, Session};
 use SimpleSAML\Module\exampleauth\Controller;
 use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request};
@@ -26,6 +26,8 @@ class ExampleAuthTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function setUp(): void
     {
@@ -61,6 +63,8 @@ class ExampleAuthTest extends TestCase
      * Test that accessing the authpage-endpoint without ReturnTo parameter throws an exception
      *
      * @return void
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testAuthpageNoReturnTo(): void
     {
@@ -83,6 +87,8 @@ class ExampleAuthTest extends TestCase
      * Test that accessing the authpage-endpoint without a valid ReturnTo parameter throws an exception
      *
      * @return void
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testAuthpageInvalidReturnTo(): void
     {
@@ -105,6 +111,8 @@ class ExampleAuthTest extends TestCase
      * Test that accessing the authpage-endpoint without ReturnTo parameter
      *
      * @return void
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testAuthpageMissingReturnTo(): void
     {
@@ -131,6 +139,9 @@ class ExampleAuthTest extends TestCase
      * Test that accessing the authpage-endpoint using POST-method and using the correct password triggers a redirect
      *
      * @return void
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testAuthpagePostMethodCorrectPassword(): void
     {
@@ -161,6 +172,9 @@ class ExampleAuthTest extends TestCase
      * an incorrect password shows the login-screen again
      *
      * @return void
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testAuthpagePostMethodIncorrectPassword(): void
     {
@@ -225,6 +239,9 @@ class ExampleAuthTest extends TestCase
      * Test that accessing the redirecttest-endpoint leads to a redirect
      *
      * @return void
+     * @throws BadRequest
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testRedirect(): void
     {
@@ -255,6 +272,8 @@ class ExampleAuthTest extends TestCase
      * Test that accessing the redirecttest-endpoint without StateId leads to an exception
      *
      * @return void
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testRedirectMissingStateId(): void
     {

--- a/tests/modules/multiauth/src/Auth/Source/MultiAuthTest.php
+++ b/tests/modules/multiauth/src/Auth/Source/MultiAuthTest.php
@@ -25,6 +25,7 @@ class MultiAuthTest extends ClearStateTestCase
 
 
     /**
+     * @throws Exception
      */
     public function setUp(): void
     {
@@ -142,6 +143,8 @@ class MultiAuthTest extends ClearStateTestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testPreselectIsOptional(): void
     {
@@ -198,6 +201,8 @@ class MultiAuthTest extends ClearStateTestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testPreselectCanBeConfigured(): void
     {
@@ -217,6 +222,8 @@ class MultiAuthTest extends ClearStateTestCase
 
 
     /**
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testStatePreselectHasPriority(): void
     {

--- a/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
+++ b/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Test\Module\multiauth\Controller;
 
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Error, Session};
+use SimpleSAML\{Configuration, Error, Error\BadRequest, Session};
 use SimpleSAML\Auth\{Source, State};
 use SimpleSAML\Module\multiauth\Auth\Source\MultiAuth;
 use SimpleSAML\Module\multiauth\Controller;
@@ -32,6 +32,8 @@ class DiscoControllerTest extends TestCase
     /**
      * Set up for each test.
      * @return void
+     * @throws \Exception
+     * @throws \Throwable
      */
     protected function setUp(): void
     {
@@ -86,6 +88,8 @@ class DiscoControllerTest extends TestCase
      * Test that a missing AuthState results in a BadRequest-error
      * @return void
      * @throws \SimpleSAML\Error\BadRequest
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDiscoveryMissingState(): void
     {
@@ -106,6 +110,9 @@ class DiscoControllerTest extends TestCase
     /**
      * Test that a valid requests results in a Twig template
      * @return void
+     * @throws BadRequest
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDiscoveryFallthru(): void
     {
@@ -144,6 +151,9 @@ class DiscoControllerTest extends TestCase
     /**
      * Test that a valid requests results in a Twig template
      * @return void
+     * @throws BadRequest
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDiscoveryFallthruWithSource(): void
     {
@@ -183,6 +193,9 @@ class DiscoControllerTest extends TestCase
     /**
      * Test that a valid requests results in a RedirectResponse
      * @return void
+     * @throws BadRequest
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDiscoveryDelegateAuth1(): void
     {
@@ -224,6 +237,9 @@ class DiscoControllerTest extends TestCase
     /**
      * Test that a valid request results in a RedirectResponse
      * @return void
+     * @throws BadRequest
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDiscoveryDelegateAuth1WithPreviousSource(): void
     {
@@ -265,6 +281,9 @@ class DiscoControllerTest extends TestCase
     /**
      * Test that a valid request results in a RedirectResponse
      * @return void
+     * @throws BadRequest
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDiscoveryDelegateAuth2(): void
     {

--- a/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/AttributeNameIDTest.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Test\Module\saml\Auth\Process;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Module\saml\Auth\Process\AttributeNameID;
 use SimpleSAML\SAML2\Constants as C;
 
@@ -23,6 +24,8 @@ class AttributeNameIDTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws Exception
+     * @throws \Exception
      */
     private function processFilter(array $config, array $request): array
     {
@@ -34,6 +37,7 @@ class AttributeNameIDTest extends TestCase
 
     /**
      * Test minimal configuration.
+     * @throws Exception
      */
     public function testMinimalConfig(): void
     {
@@ -69,6 +73,7 @@ class AttributeNameIDTest extends TestCase
 
     /**
      * Test third element in chain
+     * @throws Exception
      */
     public function testSuccessInThirdElement(): void
     {
@@ -104,6 +109,7 @@ class AttributeNameIDTest extends TestCase
 
     /**
      * Test attributes in list not found.
+     * @throws Exception
      */
     public function testNotFound(): void
     {

--- a/tests/modules/saml/src/Auth/Process/FilterScopesTest.php
+++ b/tests/modules/saml/src/Auth/Process/FilterScopesTest.php
@@ -22,6 +22,7 @@ class FilterScopesTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws \Exception
      */
     private function processFilter(array $config, array $request): array
     {
@@ -33,6 +34,7 @@ class FilterScopesTest extends TestCase
 
     /**
      * Test valid scopes.
+     * @throws \Exception
      */
     public function testValidScopes(): void
     {
@@ -86,6 +88,7 @@ class FilterScopesTest extends TestCase
 
     /**
      * Test implicit scope matching on IdP hostname
+     * @throws \Exception
      */
     public function testImplicitScopes(): void
     {
@@ -116,6 +119,7 @@ class FilterScopesTest extends TestCase
 
     /**
      * Test invalid scopes.
+     * @throws \Exception
      */
     public function testInvalidScopes(): void
     {
@@ -163,6 +167,7 @@ class FilterScopesTest extends TestCase
 
     /**
      * Test that implicit matching is not done when explicit scopes present
+     * @throws \Exception
      */
     public function testNoImplicitMatchingWhenExplicitScopes(): void
     {
@@ -191,6 +196,7 @@ class FilterScopesTest extends TestCase
 
     /**
      * Test that the scope is considered to be the part after the first @ sign
+     * @throws \Exception
      */
     public function testAttributeValueMultipleAt(): void
     {

--- a/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
+++ b/tests/modules/saml/src/Auth/Process/NameIDAttributeTest.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Test\Module\saml\Auth\Process;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Error;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Module\saml\Auth\Process\NameIDAttribute;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\XML\saml\NameID;
@@ -25,6 +26,7 @@ class NameIDAttributeTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws Exception
      */
     private function processFilter(array $config, array $request): array
     {
@@ -36,6 +38,7 @@ class NameIDAttributeTest extends TestCase
 
     /**
      * Test minimal configuration.
+     * @throws Exception
      */
     public function testMinimalConfig(): void
     {
@@ -67,6 +70,7 @@ class NameIDAttributeTest extends TestCase
 
     /**
      * Test custom attribute name.
+     * @throws Exception
      */
     public function testCustomAttributeName(): void
     {
@@ -99,6 +103,7 @@ class NameIDAttributeTest extends TestCase
 
     /**
      * Test custom format.
+     * @throws Exception
      */
     public function testFormat(): void
     {
@@ -157,6 +162,7 @@ class NameIDAttributeTest extends TestCase
 
     /**
      * Test invalid request silently continues, leaving the state untouched
+     * @throws Exception
      */
     public function testInvalidRequestLeavesStateUntouched(): void
     {
@@ -181,6 +187,7 @@ class NameIDAttributeTest extends TestCase
 
     /**
      * Test custom attribute name with format.
+     * @throws Exception
      */
     public function testCustomAttributeNameAndFormat(): void
     {
@@ -213,6 +220,7 @@ class NameIDAttributeTest extends TestCase
 
     /**
      * Test overriding NameID Format/NameQualifier/SPNameQualifier with defaults.
+     * @throws Exception
      */
     public function testOverrideNameID(): void
     {

--- a/tests/modules/saml/src/Auth/Process/PairwiseIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/PairwiseIDTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\Exception\ProtocolViolationException;
-use SimpleSAML\{Configuration, Logger, Utils};
+use SimpleSAML\{Configuration, Error\CriticalConfigurationError, Logger, Utils};
 use SimpleSAML\Module\saml\Auth\Process\PairwiseID;
 
 /**
@@ -59,6 +59,7 @@ class PairwiseIDTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws CriticalConfigurationError
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -72,6 +73,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test the most basic functionality
+     * @throws CriticalConfigurationError
      */
     public function testBasic(): void
     {
@@ -96,6 +98,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test the most basic functionality, but with a scoped scope-attribute
+     * @throws CriticalConfigurationError
      */
     public function testBasicScopedScope(): void
     {
@@ -120,6 +123,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test the most basic functionality on proxied request
+     * @throws CriticalConfigurationError
      */
     public function testBasicProxiedRequest(): void
     {
@@ -144,6 +148,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test the proxied request with multiple hops
+     * @throws CriticalConfigurationError
      */
     public function testProxiedRequestMultipleHops(): void
     {
@@ -168,6 +173,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test that illegal characters in scope throws an exception.
+     * @throws CriticalConfigurationError
      */
     public function testScopeIllegalCharacterThrowsException(): void
     {
@@ -184,6 +190,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test that generated ID's for the same user, but different SP's are NOT equal
+     * @throws CriticalConfigurationError
      */
     public function testUniqueIdentifierPerSPSameUser(): void
     {
@@ -214,6 +221,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test that generated ID's for different users, but the same SP's are NOT equal
+     * @throws CriticalConfigurationError
      */
     public function testUniqueIdentifierPerUserSameSP(): void
     {
@@ -244,6 +252,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test that generated ID's for the same user and same SP, but with a different salt are NOT equal
+     * @throws CriticalConfigurationError
      */
     public function testUniqueIdentifierDifferentSalts(): void
     {
@@ -280,6 +289,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test that generated ID's for the same user and same SP, but with a different scope are NOT equal
+     * @throws CriticalConfigurationError
      */
     public function testUniqueIdentifierDifferentScopes(): void
     {
@@ -319,6 +329,7 @@ class PairwiseIDTest extends TestCase
 
     /**
      * Test that weak identifiers log a warning
+     * @throws CriticalConfigurationError
      */
     public function testWeakIdentifierLogsWarning(): void
     {

--- a/tests/modules/saml/src/Auth/Process/SubjectIDTest.php
+++ b/tests/modules/saml/src/Auth/Process/SubjectIDTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test\Module\saml\Auth\Process;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use SimpleSAML\{Configuration, Logger, Utils};
+use SimpleSAML\{Configuration, Error\CriticalConfigurationError, Logger, Utils};
 use SimpleSAML\Module\saml\Auth\Process\SubjectID;
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\Exception\ProtocolViolationException;
@@ -59,6 +59,7 @@ class SubjectIDTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return array  The state array after processing.
+     * @throws CriticalConfigurationError
      */
     private static function processFilter(array $config, array $request): array
     {
@@ -73,6 +74,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test the most basic functionality
+     * @throws CriticalConfigurationError
      */
     public function testBasic(): void
     {
@@ -93,6 +95,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test the most basic functionality with hash
+     * @throws CriticalConfigurationError
      */
     public function testBasicWithHash(): void
     {
@@ -116,6 +119,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test the most basic functionality, but with a scoped scope-attribute
+     * @throws CriticalConfigurationError
      */
     public function testScopedScope(): void
     {
@@ -136,6 +140,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test that illegal characters in userID throws an exception.
+     * @throws CriticalConfigurationError
      */
     public function testUserIDIllegalCharacterThrowsException(): void
     {
@@ -151,6 +156,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test that illegal characters in scope throws an exception.
+     * @throws CriticalConfigurationError
      */
     public function testScopeIllegalCharacterThrowsException(): void
     {
@@ -166,6 +172,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test that generated ID's for different users, but the same SP's are NOT equal
+     * @throws CriticalConfigurationError
      */
     public function testUniqueIdentifierPerUserSameSP(): void
     {
@@ -195,6 +202,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test that generated ID's for the same user and same SP, but with a different scope are NOT equal
+     * @throws CriticalConfigurationError
      */
     public function testUniqueIdentifierDifferentScopes(): void
     {
@@ -233,6 +241,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test that weak identifiers log a warning
+     * @throws CriticalConfigurationError
      */
     public function testWeakIdentifierLogsWarning(): void
     {
@@ -249,6 +258,7 @@ class SubjectIDTest extends TestCase
 
     /**
      * Test that weak identifiers log a warning: not an actual domain name
+     * @throws CriticalConfigurationError
      */
     public function testScopeNotADomainLogsWarning(): void
     {

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use SAML2\{AuthnRequest, LogoutRequest};
 use SimpleSAML\Assert\AssertionFailedException;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\CriticalConfigurationError;
 use SimpleSAML\Error\Exception;
 use SimpleSAML\Module\saml\Auth\Source\SP;
 use SimpleSAML\SAML2\Constants as C;
@@ -121,6 +122,8 @@ class SPTest extends ClearStateTestCase
      * 2 of https://simplesamlphp.org/docs/development/saml:sp
      *
      * @return \SimpleSAML\SAML2\AuthnRequest The AuthnRequest generated.
+     * @throws \ReflectionException
+     * @throws \Exception
      */
     private function createAuthnRequest(array $state = []): AuthnRequest
     {
@@ -148,6 +151,9 @@ class SPTest extends ClearStateTestCase
      * 2 of https://simplesamlphp.org/docs/development/saml:sp
      *
      * @return \SimpleSAML\SAML2\LogoutRequest The LogoutRequest generated.
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     private function createLogoutRequest(array $state = []): LogoutRequest
     {
@@ -170,6 +176,7 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test generating an AuthnRequest
+     * @throws \ReflectionException
      */
     public function testAuthnRequest(): void
     {
@@ -195,6 +202,7 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test setting a Subject
+     * @throws \Exception
      */
     public function testNameID(): void
     {
@@ -260,6 +268,7 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test setting ForcedAuthn
+     * @throws \ReflectionException
      */
     public function testForcedAuthn(): void
     {
@@ -289,6 +298,9 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test specifying an IDPList where no metadata found for those idps is an error
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testIdpListWithNoMatchingMetadata(): void
     {
@@ -308,6 +320,9 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test specifying an IDPList where the list does not overlap with the Idp specified in SP config is an error
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testIdpListWithExplicitIdpNotMatch(): void
     {
@@ -338,6 +353,9 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test that IDPList overlaps with the IDP specified in SP config results in AuthnRequest
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testIdpListWithExplicitIdpMatch(): void
     {
@@ -383,6 +401,9 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test that IDPList with a single valid idp and no SP config idp results in AuthnRequest to that idp
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testIdpListWithSingleMatch(): void
     {
@@ -424,6 +445,9 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test that IDPList with multiple valid idp and no SP config idp results in discovery redirect
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testIdpListWithMultipleMatch(): void
     {
@@ -461,6 +485,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Basic test for the hosted metadata generation in a default config
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedBasicConfig(): void
     {
@@ -489,6 +515,7 @@ class SPTest extends ClearStateTestCase
     /**
      * Test that adding IDPList to the state (of an AuthRequest)
      * will result in that IDP being added to the scope
+     * @throws \ReflectionException
      */
     public function testSPIdpListScoping(): void
     {
@@ -505,6 +532,7 @@ class SPTest extends ClearStateTestCase
     /**
      * Test that adding IDPList to the idp metadata
      * will result in that IDP being added to the scope
+     * @throws \ReflectionException
      */
     public function testIdpMetadataScoping(): void
     {
@@ -520,6 +548,8 @@ class SPTest extends ClearStateTestCase
     /**
      * Test that adding IDPList to the config
      * will result in that IDP being added to the scope
+     * @throws \ReflectionException
+     * @throws \Exception
      */
     public function testRemoteMetadataScoping(): void
     {
@@ -548,6 +578,8 @@ class SPTest extends ClearStateTestCase
      * Test that makes sure that the order in which the IDPList config is applied
      * is correct. Ie: The state IDPList has the highest priority, then the remote metadata,
      * then the idp config array.
+     * @throws \ReflectionException
+     * @throws \Exception
      */
     #[DataProvider('getScopingOrders')]
     public function testSPIdpListScopingOrder(
@@ -625,6 +657,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Test for the hosted metadata generation with a custom entityID
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedSetEntityId(): void
     {
@@ -639,6 +673,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Contacts in SP hosted config appear in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedContacts(): void
     {
@@ -706,6 +742,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * A globally set tech contact also appears in SP hosted metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedContactsIncludesGlobalTechContact(): void
     {
@@ -751,6 +789,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * The special value na@example.org global tech contact is not included in SP metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedContactsSkipsNAGlobalTechContact(): void
     {
@@ -780,6 +820,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * Contacts in SP hosted of unknown type throws Exceptiona
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedContactsUnknownTypeThrowsException(): void
     {
@@ -808,6 +850,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP acs.Bindings option overrides default bindigs
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedAcsBindingsOption(): void
     {
@@ -837,6 +881,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP acs.Bindings option with unsupported value should be skipped
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedAcsBindingsUnknownValueIsSkipped(): void
     {
@@ -866,6 +912,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP SLO Bindings option overrides default bindigs
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedSloBindingsOption(): void
     {
@@ -887,6 +935,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP empty SLO Bindings option omits SLO in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedSloBindingsEmptyNotInMetadata(): void
     {
@@ -904,6 +954,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP SLO Bindings option with unknown value is accepted as-is
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedSloBindingsUnknownValueIsAccepted(): void
     {
@@ -929,6 +981,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP SLO Location option is used as URL for all SLO Bindings
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedSloURLIsUsedForAllSLOBindings(): void
     {
@@ -957,6 +1011,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP AssertionConsumerService option overrides default bindigs
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedAssertionConsumerServiceOption(): void
     {
@@ -1002,6 +1058,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config options WantAssertionsSigned, redirect.sign is reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedSigning(): void
     {
@@ -1052,6 +1110,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option RegistrationInfo is reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedContainsRegistrationInfo(): void
     {
@@ -1081,6 +1141,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option NameIDPolicy is reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedNameIDPolicy(): void
     {
@@ -1103,6 +1165,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option NameIDPolicy specified without Format is reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedNameIDPolicyNullFormat(): void
     {
@@ -1122,6 +1186,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option Organization* are reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedOrganizationData(): void
     {
@@ -1153,6 +1219,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option Organization* without explicit DisplayName are reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedOrganizationDataDefaultForDisplayNameIsName(): void
     {
@@ -1178,6 +1246,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option Organization* without URL is rejected with an Exception
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testMetadataHostedOrganizationURLMissingRaisesException(): void
     {
@@ -1202,6 +1272,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option for UIInfo is reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedUIInfo(): void
     {
@@ -1231,6 +1303,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option for entity attribute extensions is reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedEntityExtensions(): void
     {
@@ -1251,6 +1325,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option for Name, Description, Attributes is in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedNameDescriptionAttributes(): void
     {
@@ -1299,6 +1375,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config option for Name, Description require attributes to be specified
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedNameDescriptionAbsentWhenNoAttributes(): void
     {
@@ -1323,6 +1401,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config for attributes also requires name in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedAttributesRequiresName(): void
     {
@@ -1344,6 +1424,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config for attributes with extra options
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHostedAttributesExtraOptions(): void
     {
@@ -1373,6 +1455,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config for holder-of-key profile via ProtocolBinding is reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadataHolderOfKeyViaProtocolBindingIsInMetadata(): void
     {
@@ -1400,6 +1484,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config with certificate are reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadatCertificateIsInMetadata(): void
     {
@@ -1426,6 +1512,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * SP config with certificate in rollocer scenario are reflected in metadata
+     * @throws Exception
+     * @throws \Exception
      */
     public function testMetadatCertificateInRolloverIsInMetadata(): void
     {
@@ -1459,6 +1547,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * We only support SAML 2.0 as a protocol with this auth source
+     * @throws Exception
+     * @throws \Exception
      */
     public function testSupportedProtocolsReturnsSAML20Only(): void
     {
@@ -1475,6 +1565,8 @@ class SPTest extends ClearStateTestCase
 
     /**
      * We only support SAML 2.0 as a protocol with this auth source
+     * @throws Exception
+     * @throws \Exception
      */
     public function testSAML11BindingsDoesNotInfluenceProtocolsSupported(): void
     {
@@ -1505,9 +1597,12 @@ class SPTest extends ClearStateTestCase
         $this->assertEquals('urn:oasis:names:tc:SAML:2.0:protocol', $protocols[0]);
     }
 
-   /**
-    * Test sending a LogoutRequest
-    */
+    /**
+     * Test sending a LogoutRequest
+     * @throws \DOMException
+     * @throws Exception
+     * @throws \Throwable
+     */
     public function testLogoutRequest(): void
     {
         $nameId = new NameID('someone@example.com');

--- a/tests/modules/saml/src/Controller/DiscoTest.php
+++ b/tests/modules/saml/src/Controller/DiscoTest.php
@@ -24,6 +24,7 @@ class DiscoTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -44,6 +45,8 @@ class DiscoTest extends TestCase
      * Test that accessing the disco-endpoint leads to a RedirectResponse
      *
      * @return void
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDisco(): void
     {

--- a/tests/modules/saml/src/Controller/MetadataTest.php
+++ b/tests/modules/saml/src/Controller/MetadataTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test\Module\saml\Controller;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Error, Session, Utils};
+use SimpleSAML\{Configuration, Error, Error\Exception, Session, Utils};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\saml\Controller;
 use Symfony\Component\HttpFoundation\{Request, Response};
@@ -27,8 +27,10 @@ class MetadataTest extends TestCase
     protected Utils\Auth $authUtils;
 
     protected MetaDataStorageHandler $mdh;
+
     /**
      * Set up for each test.
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -131,6 +133,9 @@ class MetadataTest extends TestCase
     /**
      * Test that accessing the metadata-endpoint with or without authentication
      * and admin.protectmetadata set to true or false is handled properly
+     * @throws Error\Error
+     * @throws \Exception
+     * @throws \Throwable
      */
     #[DataProvider('provideMetadataAccess')]
     public function testMetadataAccess(bool $authenticated, bool $protected): void
@@ -183,6 +188,8 @@ class MetadataTest extends TestCase
 
     /**
      * Test that saml20-idp setting disabled disables access
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testDisabledSAML20IDPReturnsNoAccess(): void
     {
@@ -210,6 +217,9 @@ class MetadataTest extends TestCase
 
     /**
      * Test that requesting a non-existing entityID throws an exception
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testMetadataUnknownEntityThrowsError(): void
     {
@@ -228,6 +238,10 @@ class MetadataTest extends TestCase
 
     /**
      * Basic smoke test of generated metadata
+     * @throws Error\Error
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testMetadataYieldsContent(): void
     {
@@ -253,6 +267,10 @@ class MetadataTest extends TestCase
 
     /**
      * Test not specifying explict entityID falls back to a default
+     * @throws Error\Error
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testMetadataDefaultIdPYieldsContent(): void
     {
@@ -278,6 +296,10 @@ class MetadataTest extends TestCase
 
     /**
      * Check if caching headers are set
+     * @throws Error\Error
+     * @throws Exception
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function testMetadataCachingHeaders(): void
     {

--- a/tests/modules/saml/src/Controller/ProxyTest.php
+++ b/tests/modules/saml/src/Controller/ProxyTest.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Module\saml\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Auth, Configuration, Error};
+use SimpleSAML\{Auth, Configuration, Error, Error\BadRequest};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\saml\Controller;
 use SimpleSAML\Module\saml\Error\NoAvailableIDP;
@@ -29,6 +29,7 @@ class ProxyTest extends TestCase
 
     /**
      * Set up for each test.
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -70,6 +71,7 @@ class ProxyTest extends TestCase
 
     /**
      * Tear down after each test.
+     * @throws \Exception
      */
     protected function tearDown(): void
     {
@@ -105,6 +107,7 @@ class ProxyTest extends TestCase
      * Test that accessing the invalidSession-endpoint with StateId results in a Template
      *
      * @return void
+     * @throws BadRequest
      */
     public function testWithStateId(): void
     {
@@ -134,6 +137,7 @@ class ProxyTest extends TestCase
      * with pressing cancel results in a Response
      *
      * @return void
+     * @throws BadRequest
      */
     public function testWithStateIdCancel(): void
     {
@@ -164,6 +168,7 @@ class ProxyTest extends TestCase
      * with pressing continue results in a Response
      *
      * @return void
+     * @throws BadRequest
      */
     public function testWithStateIdContinue(): void
     {

--- a/tests/modules/saml/src/Controller/ServiceProviderTest.php
+++ b/tests/modules/saml/src/Controller/ServiceProviderTest.php
@@ -8,7 +8,7 @@ use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Auth, Configuration, Error, Session, Utils};
+use SimpleSAML\{Auth, Configuration, Error, Error\AuthSource, Error\BadRequest, Error\ConfigurationError, Error\NoState, Session, Utils};
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\saml\Auth\Source;
 use SimpleSAML\Module\saml\Controller;
@@ -51,6 +51,7 @@ class ServiceProviderTest extends TestCase
     /**
      * Set up for each test.
      * @throws Exception
+     * @throws \Throwable
      */
     protected function setUp(): void
     {
@@ -112,6 +113,7 @@ class ServiceProviderTest extends TestCase
 
     /**
      * Tear down after each test.
+     * @throws Exception
      */
     protected function tearDown(): void
     {
@@ -126,6 +128,7 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the login-endpoint with a non-SP authsource leads to an exception
      *
      * @return void
+     * @throws \Throwable
      */
     public function testLoginWrongAuthSource(): void
     {
@@ -146,6 +149,8 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the login-endpoint without ReturnTo parameter leads to an exception
      *
      * @return void
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testLoginMissingReturnTo(): void
     {
@@ -165,6 +170,8 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the login-endpoint with empty ReturnTo parameter leads to an exception
      *
      * @return void
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testLoginEmptyReturnTo(): void
     {
@@ -186,6 +193,8 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the login-endpoint with ReturnTo parameter leads to a Response
      *
      * @return void
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testLogin(): void
     {
@@ -208,6 +217,8 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the discoResponse-endpoint without AuthID leads to an exception
      *
      * @return void
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testDiscoResponseMissingAuthId(): void
     {
@@ -229,6 +240,8 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the discoResponse-endpoint with AuthID but without idpentityid results in an exception
      *
      * @return void
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testWithAuthIdWithoutEntity(): void
     {
@@ -319,6 +332,7 @@ class ServiceProviderTest extends TestCase
      * @param   bool   $expectingException
      *
      * @return void
+     * @throws Exception
      */
     #[DataProvider('loginNotAuthenticatedDataProvider')]
     public function testLoginHandleNotAuthenticated(
@@ -439,6 +453,7 @@ class ServiceProviderTest extends TestCase
      * @param   bool   $expectingException
      *
      * @return void
+     * @throws Exception
      */
     #[DataProvider('loginAuthenticatedDataProvider')]
     public function testLoginHandleAuthenticated(
@@ -522,6 +537,9 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the discoResponse-endpoint with non-SP authsource in state results in an exception
      *
      * @return void
+     * @throws BadRequest
+     * @throws NoState
+     * @throws \Throwable
      */
     public function testWithNonSPAuthSource(): void
     {
@@ -549,6 +567,8 @@ class ServiceProviderTest extends TestCase
     /**
      * Test that accessing the discoResponse-endpoint with SP authsource in state results in a Response
      * @return void
+     * @throws Exception
+     * @throws \Throwable
      */
     public function testWithSPAuthSource(): void
     {
@@ -591,6 +611,7 @@ class ServiceProviderTest extends TestCase
      * Test that accessing the wrongAuthnContextClassRef-endpoint without AuthID leads to a Template
      *
      * @return void
+     * @throws ConfigurationError
      */
     public function testWrongAuthnContextClassRef(): void
     {
@@ -789,6 +810,9 @@ XML;
     /**
      * Test that accessing the metadata-endpoint with or without authentication
      * and admin.protectmetadata set to true or false is handled properly
+     * @throws AuthSource
+     * @throws Exception
+     * @throws \Throwable
      */
     #[DataProvider('provideMetadataAccess')]
     public function testMetadataAccess(bool $authenticated, bool $protected): void
@@ -835,6 +859,9 @@ XML;
 
     /**
      * Test that requesting a non-existing authsource yields an error
+     * @throws AuthSource
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testMetadataUnknownEntityThrowsError(): void
     {
@@ -852,6 +879,9 @@ XML;
 
     /**
      * Basic smoke test of generated metadata
+     * @throws AuthSource
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testMetadataYieldsContent(): void
     {
@@ -872,6 +902,9 @@ XML;
 
     /**
      * Check if caching headers are set
+     * @throws AuthSource
+     * @throws Error\Exception
+     * @throws \Throwable
      */
     public function testMetadataCachingHeaders(): void
     {

--- a/tests/modules/saml/src/IdP/SAML2Test.php
+++ b/tests/modules/saml/src/IdP/SAML2Test.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Module\saml\IdP;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use SimpleSAML\Assert\AssertionFailedException;
-use SimpleSAML\{Configuration, IdP};
+use SimpleSAML\{Configuration, Error\BadRequest, IdP};
 use SimpleSAML\Error\Exception;
 use SimpleSAML\Metadata\{MetaDataStorageHandler, MetaDataStorageHandlerSerialize};
 use SimpleSAML\Module\saml\IdP\SAML2;
@@ -55,6 +55,7 @@ class SAML2Test extends ClearStateTestCase
 
     /**
      * Test that invoking the idp initiated endpoint with the minimum necessary parameters works.
+     * @throws BadRequest
      */
     public function testIdPInitiatedLoginMinimumParams(): void
     {
@@ -79,6 +80,7 @@ class SAML2Test extends ClearStateTestCase
 
     /**
      * Test that invoking the idp initiated endpoint with the optional parameters works.
+     * @throws BadRequest
      */
     public function testIdPInitiatedLoginOptionalParams(): void
     {
@@ -113,6 +115,7 @@ class SAML2Test extends ClearStateTestCase
 
     /**
      * Test that invoking the idp initiated endpoint using minimum shib params works
+     * @throws BadRequest
      */
     public function testIdPInitShibCompatyMinimumParams(): void
     {
@@ -139,6 +142,7 @@ class SAML2Test extends ClearStateTestCase
 
     /**
      * Test that invoking the idp initiated endpoint using minimum shib params works
+     * @throws BadRequest
      */
     public function testIdPInitShibCompatOptionalParams(): void
     {
@@ -174,6 +178,7 @@ class SAML2Test extends ClearStateTestCase
      *
      * @param array $queryParams
      * @return array The state array used for handling the authentication request.
+     * @throws BadRequest
      */
     private function idpInitiatedHelper(array $queryParams): array
     {
@@ -242,6 +247,7 @@ EOT;
      * @param array $metadata IdP metadata entry as found in saml20-idp-hosted
      * @param array $extraconfig Additional SimpleSAML global config to load
      * @return array Output of the getHostedMetadata() method
+     * @throws \Exception
      */
     private function idpMetadataHandlerHelper(array $metadata, array $extraconfig = []): array
     {
@@ -265,6 +271,7 @@ EOT;
 
     /**
      * A minimally configured hosted IdP has all default fields with expected values.
+     * @throws \Exception
      */
     public function testIdPGetHostedMetadataMinimal(): void
     {
@@ -422,6 +429,7 @@ EOT;
 
     /**
      * NameIDFormat option can be specified as string or array
+     * @throws \Exception
      */
     public function testIdPGetHostedNameIdFormat(): void
     {
@@ -467,6 +475,7 @@ EOT;
 
     /**
      * IdP config option Organization* are reflected in metadata
+     * @throws \Exception
      */
     public function testMetadataHostedOrganizationData(): void
     {
@@ -493,6 +502,7 @@ EOT;
 
     /**
      * IdP config option Organization* without explicit DisplayName are reflected in metadata
+     * @throws \Exception
      */
     public function testMetadataHostedOrganizationDataDefaultForDisplayNameIsName(): void
     {
@@ -513,6 +523,7 @@ EOT;
 
     /**
      * IdP config option Organization* without URL is rejected with an Exception
+     * @throws \Exception
      */
     public function testMetadataHostedOrganizationURLMissingRaisesException(): void
     {
@@ -532,6 +543,7 @@ EOT;
 
     /**
      * IdP config option for entity attributes is reflected in metadata
+     * @throws \Exception
      */
     public function testMetadataHostedEntityAttributes(): void
     {
@@ -560,6 +572,8 @@ EOT;
 
     /**
      * IdP config option for entity attribute extensions is reflected in metadata
+     * @throws \DOMException
+     * @throws \Exception
      */
     public function testMetadataHostedEntityExtensions(): void
     {
@@ -589,6 +603,7 @@ EOT;
 
     /**
      * IdP config option for UIInfo is reflected in metadata
+     * @throws \Exception
      */
     public function testMetadataHostedUIInfo(): void
     {
@@ -628,6 +643,7 @@ EOT;
 
     /**
      * IdP config option RegistrationInfo is reflected in metadata
+     * @throws \Exception
      */
     public function testMetadataHostedContainsRegistrationInfo(): void
     {
@@ -655,6 +671,7 @@ EOT;
 
     /**
      * IdP config options wrt signing are reflected in metadata
+     * @throws \Exception
      */
     public function testMetadataHostedSigning(): void
     {
@@ -673,6 +690,7 @@ EOT;
 
     /**
      * Contacts in IdP hosted config appear in metadata
+     * @throws \Exception
      */
     public function testMetadataHostedContacts(): void
     {
@@ -734,6 +752,7 @@ EOT;
 
     /**
      * A globally set tech contact also appears in IdP hosted metadata
+     * @throws \Exception
      */
     public function testMetadataHostedContactsIncludesGlobalTechContact(): void
     {
@@ -773,6 +792,7 @@ EOT;
 
     /**
      * The special value na@example.org global tech contact is not included in IdP metadata
+     * @throws \Exception
      */
     public function testMetadataHostedContactsSkipsNAGlobalTechContact(): void
     {
@@ -798,6 +818,7 @@ EOT;
 
     /**
      * Contacts in IdP hosted of unknown type throws Exceptiona
+     * @throws \Exception
      */
     public function testMetadataHostedContactsUnknownTypeThrowsException(): void
     {

--- a/tests/modules/saml/src/IdP/SQLNameIDTest.php
+++ b/tests/modules/saml/src/IdP/SQLNameIDTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test\Module\saml\IdP;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use SimpleSAML\{Configuration, Error, Store};
+use SimpleSAML\{Configuration, Error, Error\CriticalConfigurationError, Store};
 use SimpleSAML\Module\saml\IdP\SQLNameID;
 use SimpleSAML\Store\StoreFactory;
 
@@ -21,6 +21,7 @@ class SQLNameIDTest extends TestCase
 {
     /**
      * @param array $config
+     * @throws CriticalConfigurationError
      */
     private function addGetDelete(array $config = []): void
     {
@@ -33,6 +34,8 @@ class SQLNameIDTest extends TestCase
 
     /**
      * Test Store.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testSQLStore(): void
     {
@@ -53,6 +56,8 @@ class SQLNameIDTest extends TestCase
 
     /**
      * Test incompatible Store.
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testIncompatibleStore(): void
     {
@@ -76,6 +81,7 @@ class SQLNameIDTest extends TestCase
 
     /**
      * Test Database.
+     * @throws CriticalConfigurationError
      */
     public function testDatabase(): void
     {
@@ -100,6 +106,7 @@ class SQLNameIDTest extends TestCase
     /**
      * @param \SimpleSAML\Configuration|\SimpleSAML\Store\StoreInterface $service
      * @param class-string $className
+     * @throws \ReflectionException
      */
     protected function clearInstance($service, string $className): void
     {

--- a/tests/src/SimpleSAML/Auth/ProcessingChainTest.php
+++ b/tests/src/SimpleSAML/Auth/ProcessingChainTest.php
@@ -7,6 +7,7 @@ namespace Test\SimpleSAML\Auth;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Auth\ProcessingChain;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Module\core\Auth\Process\AttributeAdd;
 use SimpleSAML\Module\core\Auth\Process\AttributeLimit;
 use SimpleSAML\Module\core\Auth\Process\AttributeMap;
@@ -21,6 +22,10 @@ class ProcessingChainTest extends TestCase
     }
 
 
+    /**
+     * @throws Exception
+     * @throws \Exception
+     */
     public function testInsertAuthProcs(): void
     {
         $config = [];
@@ -44,6 +49,10 @@ class ProcessingChainTest extends TestCase
         $this->assertInstanceOf(AttributeLimit::class, $filterInChain[2]);
     }
 
+    /**
+     * @throws Exception
+     * @throws \Exception
+     */
     public function testInsertAuthFromConfigs(): void
     {
         $config = [];

--- a/tests/src/SimpleSAML/Auth/ProcessingFilterTest.php
+++ b/tests/src/SimpleSAML/Auth/ProcessingFilterTest.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Test\Auth\ProcessingFilter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Auth\ProcessingFilter as AuthProcFilter;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Module\core\Auth\Process\AttributeAlter;
 
 /**
@@ -21,6 +22,7 @@ class ProcessingFilterTest extends TestCase
      * @param array $config  The filter configuration.
      * @param array $request  The request state.
      * @return \SimpleSAML\Auth\ProcessingFilter
+     * @throws Exception
      */
     private static function processFilter(array $config, array $request): AuthProcFilter
     {
@@ -30,6 +32,7 @@ class ProcessingFilterTest extends TestCase
 
     /**
      * Test that a filter without precondition will run.
+     * @throws Exception
      */
     public function testWithoutPrecondition(): void
     {
@@ -52,6 +55,7 @@ class ProcessingFilterTest extends TestCase
 
     /**
      * Test that a filter with a precondition evaluating to true will run.
+     * @throws Exception
      */
     public function testWithPreconditionTrue(): void
     {
@@ -75,6 +79,7 @@ class ProcessingFilterTest extends TestCase
 
     /**
      * Test that a filter with a precondition evaluating to false will not run.
+     * @throws Exception
      */
     public function testWithPreconditionFalse(): void
     {

--- a/tests/src/SimpleSAML/Auth/SimpleTest.php
+++ b/tests/src/SimpleSAML/Auth/SimpleTest.php
@@ -16,6 +16,7 @@ use SimpleSAML\TestUtils\ClearStateTestCase;
 class SimpleTest extends ClearStateTestCase
 {
     /**
+     * @throws \ReflectionException
      */
     public function testGetProcessedURL(): void
     {

--- a/tests/src/SimpleSAML/Auth/SourceTest.php
+++ b/tests/src/SimpleSAML/Auth/SourceTest.php
@@ -17,6 +17,7 @@ use SimpleSAML\Test\Utils\{TestAuthSource, TestAuthSourceFactory};
 class SourceTest extends ClearStateTestCase
 {
     /**
+     * @throws \ReflectionException
      */
     public function testParseAuthSource(): void
     {

--- a/tests/src/SimpleSAML/Auth/StateTest.php
+++ b/tests/src/SimpleSAML/Auth/StateTest.php
@@ -89,6 +89,9 @@ class StateTest extends TestCase
     }
 
 
+    /**
+     * @throws Exception
+     */
     public function testValidateStateIdSimple(): void
     {
         Auth\State::validateStateId('_aaabb');
@@ -98,6 +101,9 @@ class StateTest extends TestCase
     }
 
 
+    /**
+     * @throws Exception
+     */
     public function testValidateStateIdWithReturnURL(): void
     {
         Auth\State::validateStateId('_aaabb:https://loeki.tv/wp-login.php?example=testsomething&urn=urn:example:org');

--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SimpleSAML\Assert\AssertionFailedException;
-use SimpleSAML\{Configuration, Error};
+use SimpleSAML\{Configuration, Error, Error\CriticalConfigurationError};
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\TestUtils\ClearStateTestCase;
 
@@ -19,6 +19,7 @@ class ConfigurationTest extends ClearStateTestCase
 {
     /**
      * Test \SimpleSAML\Configuration::getVersion()
+     * @throws Exception
      */
     public function testGetVersion(): void
     {
@@ -29,6 +30,7 @@ class ConfigurationTest extends ClearStateTestCase
 
     /**
      * Test that the default instance fails to load even if we previously loaded another instance.
+     * @throws Exception
      */
     public function testLoadDefaultInstance(): void
     {
@@ -44,6 +46,7 @@ class ConfigurationTest extends ClearStateTestCase
     /**
      * Test that after a \SimpleSAML\Error\CriticalConfigurationError exception, a basic, self-survival configuration
      * is loaded.
+     * @throws Exception
      */
     public function testCriticalConfigurationError(): void
     {
@@ -142,6 +145,7 @@ class ConfigurationTest extends ClearStateTestCase
 
     /**
      * Test \SimpleSAML\Configuration::getBasePath()
+     * @throws CriticalConfigurationError
      */
     public function testGetBasePath(): void
     {
@@ -200,6 +204,7 @@ class ConfigurationTest extends ClearStateTestCase
 
     /**
      * Test \SimpleSAML\Configuration::resolvePath()
+     * @throws Exception
      */
     public function testResolvePath(): void
     {
@@ -221,6 +226,7 @@ class ConfigurationTest extends ClearStateTestCase
 
     /**
      * Test \SimpleSAML\Configuration::getPathValue()
+     * @throws Exception
      */
     public function testGetPathValue(): void
     {
@@ -713,6 +719,7 @@ class ConfigurationTest extends ClearStateTestCase
      * Test \SimpleSAML\Configuration::getDefaultEndpoint().
      *
      * Iterate over all different valid definitions of endpoints and check if the expected output is produced.
+     * @throws Exception
      */
     public function testGetDefaultEndpoint(): void
     {
@@ -901,6 +908,7 @@ class ConfigurationTest extends ClearStateTestCase
 
     /**
      * Test \SimpleSAML\Configuration::getEndpoints().
+     * @throws Exception
      */
     public function testGetEndpoints(): void
     {
@@ -1075,6 +1083,7 @@ class ConfigurationTest extends ClearStateTestCase
 
     /**
      * Test \SimpleSAML\Configuration::getConfig() preloaded nonexistent file
+     * @throws Exception
      */
     public function testGetConfigNonexistentFilePreload(): void
     {
@@ -1139,6 +1148,7 @@ class ConfigurationTest extends ClearStateTestCase
      * Test that Configuration objects can be initialized from an array.
      *
      * ATTENTION: this test must be kept the last.
+     * @throws Exception
      */
     public function testLoadInstanceFromArray(): void
     {

--- a/tests/src/SimpleSAML/DatabaseTest.php
+++ b/tests/src/SimpleSAML/DatabaseTest.php
@@ -46,6 +46,7 @@ class DatabaseTest extends TestCase
      *
      * @param string $getMethod The method to get.
      * @return mixed The method itself.
+     * @throws \ReflectionException
      */
     protected static function getMethod($getMethod)
     {
@@ -57,6 +58,7 @@ class DatabaseTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function setUp(): void
     {
@@ -98,6 +100,8 @@ class DatabaseTest extends TestCase
 
 
     /**
+     * @throws \ReflectionException
+     * @throws Exception
      */
     public function testInstances(): void
     {
@@ -161,6 +165,8 @@ class DatabaseTest extends TestCase
 
 
     /**
+     * @throws \ReflectionException
+     * @throws Exception
      */
     public function testSecondaries(): void
     {
@@ -231,6 +237,7 @@ class DatabaseTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testQuerying(): void
     {
@@ -280,6 +287,7 @@ class DatabaseTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function tearDown(): void
     {

--- a/tests/src/SimpleSAML/Error/ErrorTest.php
+++ b/tests/src/SimpleSAML/Error/ErrorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\Test\Error;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Error\Error;
@@ -22,6 +23,9 @@ class ErrorTest extends TestCase
     private MockObject|Throwable|null $causeMock;
     private MockObject|ErrorCodes|null $errorCodesMock;
 
+    /**
+     * @throws Exception
+     */
     protected function setUp(): void
     {
         $this->errorCodes = new ErrorCodes();

--- a/tests/src/SimpleSAML/Locale/LanguageTest.php
+++ b/tests/src/SimpleSAML/Locale/LanguageTest.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Test\Locale;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\CannotSetCookie;
 use SimpleSAML\Locale\Language;
 
 /**
@@ -16,6 +17,7 @@ class LanguageTest extends TestCase
 {
     /**
      * Test SimpleSAML\Locale\Language::getDefaultLanguage().
+     * @throws CannotSetCookie
      */
     public function testGetDefaultLanguage(): void
     {
@@ -36,6 +38,7 @@ class LanguageTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Language::getLanguageCookie().
+     * @throws \Exception
      */
     public function testGetLanguageCookie(): void
     {
@@ -60,6 +63,8 @@ class LanguageTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Language::getLanguageList().
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function testGetLanguageListNoConfig(): void
     {
@@ -73,6 +78,8 @@ class LanguageTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Language::getLanguageList().
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function testGetLanguageListCorrectConfig(): void
     {
@@ -91,6 +98,8 @@ class LanguageTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Language::getLanguageList().
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function testGetLanguageListIncorrectConfig(): void
     {
@@ -106,6 +115,7 @@ class LanguageTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Language::getLanguageParameterName().
+     * @throws CannotSetCookie
      */
     public function testGetLanguageParameterName(): void
     {
@@ -125,6 +135,8 @@ class LanguageTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Language::isLanguageRTL().
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     public function testIsLanguageRTL(): void
     {
@@ -155,6 +167,7 @@ class LanguageTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Language::setLanguage().
+     * @throws \Exception
      */
     public function testSetLanguage(): void
     {
@@ -174,6 +187,10 @@ class LanguageTest extends TestCase
         $this->assertEquals('en', $l->getLanguage());
     }
 
+    /**
+     * @throws CannotSetCookie
+     * @throws \Exception
+     */
     public function testGetPreferredLanguages(): void
     {
         // test defaults

--- a/tests/src/SimpleSAML/Locale/LocalizationTest.php
+++ b/tests/src/SimpleSAML/Locale/LocalizationTest.php
@@ -25,6 +25,7 @@ class LocalizationTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Localization().
+     * @throws \Exception
      */
     public function testLocalization(): void
     {
@@ -36,6 +37,7 @@ class LocalizationTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Localization::addDomain().
+     * @throws \Exception
      */
     public function testAddDomain(): void
     {
@@ -51,6 +53,7 @@ class LocalizationTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Localization::addModuleDomains().
+     * @throws \Exception
      */
     public function testAddModuleDomain(): void
     {
@@ -68,6 +71,7 @@ class LocalizationTest extends TestCase
 
     /**
      * Test SimpleSAML\Locale\Localization::addModuleDomains() with a theme.
+     * @throws \Exception
      */
     public function testAddModuleDomainWithTheme(): void
     {

--- a/tests/src/SimpleSAML/Locale/TranslateTest.php
+++ b/tests/src/SimpleSAML/Locale/TranslateTest.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Test\Locale;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\CannotSetCookie;
 use SimpleSAML\Locale\Translate;
 
 /**
@@ -16,6 +17,7 @@ class TranslateTest extends TestCase
 {
     /**
      * Test SimpleSAML\Locale\Translate::noop().
+     * @throws CannotSetCookie
      */
     public function testNoop(): void
     {

--- a/tests/src/SimpleSAML/LoggerTest.php
+++ b/tests/src/SimpleSAML/LoggerTest.php
@@ -50,6 +50,7 @@ class LoggerTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testCreateLoggingHandlerHonorsCustomHandler(): void
     {
@@ -64,6 +65,7 @@ class LoggerTest extends TestCase
 
 
     /**
+     * @throws Exception
      */
     public function testCaptureLog(): void
     {

--- a/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
+++ b/tests/src/SimpleSAML/Metadata/MetaDataStorageHandlerTest.php
@@ -14,6 +14,9 @@ use SimpleSAML\TestUtils\ClearStateTestCase;
 
 class MetaDataStorageHandlerTest extends ClearStateTestCase
 {
+    /**
+     * @throws Exception
+     */
     protected function getHandler(?array $c = null): MetaDataStorageHandler
     {
         $c ??= [
@@ -41,8 +44,10 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
             'empty list' => [[]],
         ];
     }
+
     /**
      * Test that loading specific entities work, and that metadata source precedence is followed
+     * @throws Exception
      */
     #[DataProvider('entityIDsList')]
     public function testLoadEntities(array $entityIDs): void
@@ -71,6 +76,7 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
 
     /**
      * Test that retrieving a full metadataSet from a source works and precedence works
+     * @throws Exception
      */
     public function testLoadMetadataSet(): void
     {
@@ -95,6 +101,7 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
 
     /**
      * Query from a metadata set for which we have no entities should be empty
+     * @throws Exception
      */
     public function testLoadMetadataSetEmpty(): void
     {
@@ -104,6 +111,7 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
 
     /**
      * Test the current metadata entity selection
+     * @throws MetadataNotFound
      */
     public function testGetMetadataCurrent(): void
     {
@@ -114,6 +122,7 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
 
     /**
      * Test the helper that returns the metadata as a Configuration object
+     * @throws MetadataNotFound
      */
     public function testGetMetadataConfig(): void
     {
@@ -148,6 +157,7 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
 
     /**
      * Test the current metadata entity selection, empty set
+     * @throws MetadataNotFound
      */
     public function testGetMetadataCurrentEmptySet(): void
     {
@@ -166,8 +176,9 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
         $this->getHandler()->getMetaData('doesnotexist', 'saml20-sp-remote');
     }
 
-    /*
+    /**
      * Test using the entityID from metadata-templates/saml20-idp-hosted.php
+     * @throws MetadataNotFound
      */
     public function testSampleEntityIdException(): void
     {
@@ -201,6 +212,9 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
         $this->assertCount(2, $idps);
     }
 
+    /**
+     * @throws MetadataNotFound
+     */
     public function testCanGetDefaultHostedIdpInCaseOfMultipleHostedIdps(): void
     {
         $config = [
@@ -215,6 +229,10 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
         $this->assertSame('urn:x-simplesamlphp:example-idp-1', $defaultIdp['entityid']);
     }
 
+    /**
+     * @throws MetadataNotFound
+     * @throws Exception
+     */
     public function testCanGetParticularIdpInCaseOfMultipleHostedIdps(): void
     {
         $config = [
@@ -229,6 +247,9 @@ class MetaDataStorageHandlerTest extends ClearStateTestCase
         $this->assertSame('urn:x-simplesamlphp:example-idp-2', $particularIdp['entityid']);
     }
 
+    /**
+     * @throws Exception
+     */
     public function testCanOverrideHostedIdpOptionsInCaseOfMultipleHostedIdps(): void
     {
         $config = [

--- a/tests/src/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
+++ b/tests/src/SimpleSAML/Metadata/MetaDataStorageSourceTest.php
@@ -37,6 +37,7 @@ class MetaDataStorageSourceTest extends TestCase
 
     /**
      * Test \SimpleSAML\Metadata\MetaDataStorageSourceTest::getConfig XML static XML source
+     * @throws Exception
      */
     public function testStaticXMLSource(): void
     {
@@ -60,6 +61,7 @@ class MetaDataStorageSourceTest extends TestCase
 
     /**
      * Test loading multiple entities
+     * @throws Exception
      */
     public function testLoadEntitiesStaticXMLSource(): void
     {

--- a/tests/src/SimpleSAML/Metadata/SAMLBuilderTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLBuilderTest.php
@@ -7,6 +7,8 @@ namespace SimpleSAML\Test\Metadata;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\CriticalConfigurationError;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Metadata\SAMLBuilder;
 use SimpleSAML\Module\saml\Auth\Source\SP;
 use SimpleSAML\XML\{Chunk, DOMDocumentFactory};
@@ -37,6 +39,7 @@ class SAMLBuilderTest extends TestCase
 
     /**
      * Test the requested attributes are valued correctly.
+     * @throws \Exception
      */
     public function testAttributes(): void
     {
@@ -117,6 +120,7 @@ class SAMLBuilderTest extends TestCase
 
     /**
      * Test the working of the isDefault config option
+     * @throws \Exception
      */
     public function testAttributeConsumingServiceDefault(): void
     {
@@ -172,6 +176,7 @@ class SAMLBuilderTest extends TestCase
 
     /**
      * Test the index option is used correctly.
+     * @throws \Exception
      */
     public function testAttributeConsumingServiceIndex(): void
     {
@@ -216,6 +221,7 @@ class SAMLBuilderTest extends TestCase
 
     /**
      * Test the required protocolSupportEnumeration in AttributeAuthorityDescriptor
+     * @throws \Exception
      */
     public function testProtocolSupportEnumeration(): void
     {
@@ -265,6 +271,8 @@ class SAMLBuilderTest extends TestCase
 
     /**
      * Test custom metadata extension (saml:Extensions).
+     * @throws \DOMException
+     * @throws \Exception
      */
     public function testCustomMetadataExtension(): void
     {
@@ -305,6 +313,7 @@ class SAMLBuilderTest extends TestCase
 
     /**
      * Test adding contacts to metadata
+     * @throws \Exception
      */
     public function testContacts(): void
     {
@@ -399,6 +408,11 @@ class SAMLBuilderTest extends TestCase
 
     /*
      * Test certificate data.
+     */
+    /**
+     * @throws CriticalConfigurationError
+     * @throws Exception
+     * @throws \Exception
      */
     public function testCertificateData(): void
     {

--- a/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
@@ -19,6 +19,7 @@ class SAMLParserTest extends SigningTestCase
 {
     /**
      * Test that DiscoveryResponse is parsed
+     * @throws \Exception
      */
     public function testDiscoveryResponse(): void
     {
@@ -54,6 +55,7 @@ XML,
 
     /**
      * Test Registration Info is parsed
+     * @throws \Exception
      */
     public function testRegistrationInfo(): void
     {
@@ -86,6 +88,7 @@ XML,
     /**
      * Test RegistrationInfo is inherited correctly from parent EntitiesDescriptor.
      * According to the spec overriding RegistrationInfo is not valid. We ignore attempts to override
+     * @throws \Exception
      */
     public function testRegistrationInfoInheritance(): void
     {
@@ -137,6 +140,7 @@ XML,
 
     /**
      * Test Registration Info is parsed
+     * @throws \Exception
      */
     public function testRegistrationPolicy(): void
     {
@@ -171,6 +175,7 @@ XML,
 
     /**
      * Test Registration Info is parsed
+     * @throws \Exception
      */
     public function testRegistrationInstant(): void
     {
@@ -203,6 +208,7 @@ XML,
 
     /**
      * Test AttributeConsumingService is parsed
+     * @throws \Exception
      */
     public function testAttributeConsumingServiceParsing(): void
     {
@@ -251,6 +257,7 @@ XML,
 
     /**
      * @return \DOMDocument
+     * @throws \Exception
      */
     public function makeTestDocument(): DOMDocument
     {
@@ -277,6 +284,7 @@ XML,
 
     /**
      * Test RoleDescriptor/Extensions is parsed
+     * @throws \Exception
      */
     public function testRoleDescriptorExtensions(): void
     {
@@ -368,6 +376,7 @@ XML,
 
     /**
      * Test entity category hidden from discovery is parsed
+     * @throws \Exception
      */
     public function testHiddenFromDiscovery(): void
     {
@@ -400,6 +409,7 @@ XML,
 
     /**
      * Test entity category hidden from discovery is not returned when not present
+     * @throws \Exception
      */
     public function testHiddenFromDiscoveryNotHidden(): void
     {
@@ -431,6 +441,7 @@ XML,
 
     /**
      * Test entity category hidden from discovery is not returned when no mace dir entity categories present
+     * @throws \Exception
      */
     public function testHiddenFromDiscoveryNotHiddenNoMaceDirEC(): void
     {

--- a/tests/src/SimpleSAML/ModuleTest.php
+++ b/tests/src/SimpleSAML/ModuleTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Module};
+use SimpleSAML\{Configuration, Error\CriticalConfigurationError, Module};
 use Symfony\Component\Filesystem\Path;
 
 use function count;
@@ -21,6 +21,7 @@ class ModuleTest extends TestCase
 {
     /**
      * Test for SimpleSAML\Module::isModuleEnabled().
+     * @throws Exception
      */
     public function testIsModuleEnabled(): void
     {
@@ -44,6 +45,7 @@ class ModuleTest extends TestCase
 
     /**
      * Test for SimpleSAML\Module::getModuleURL().
+     * @throws CriticalConfigurationError
      */
     public function testGetModuleURL(): void
     {
@@ -66,6 +68,7 @@ class ModuleTest extends TestCase
 
     /**
      * Test for SimpleSAML\Module::getModules().
+     * @throws Exception
      */
     public function testGetModules(): void
     {
@@ -98,6 +101,7 @@ class ModuleTest extends TestCase
 
     /**
      * Test for SimpleSAML\Module::resolveClass(). It covers all the valid use cases.
+     * @throws Exception
      */
     public function testResolveClass(): void
     {

--- a/tests/src/SimpleSAML/SessionHandlerPHPTest.php
+++ b/tests/src/SimpleSAML/SessionHandlerPHPTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use SimpleSAML\{Configuration, SessionHandlerPHP};
+use SimpleSAML\{Configuration, Error\CannotSetCookie, SessionHandlerPHP};
 use SimpleSAML\TestUtils\ClearStateTestCase;
 
 use function array_merge;
@@ -71,6 +71,7 @@ class SessionHandlerPHPTest extends ClearStateTestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testGetSessionHandler(): void
     {
@@ -81,6 +82,8 @@ class SessionHandlerPHPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     #[Depends('testXdebugMode')]
     #[RunInSeparateProcess]
@@ -104,6 +107,8 @@ class SessionHandlerPHPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     #[Depends('testXdebugMode')]
     #[RunInSeparateProcess]
@@ -124,6 +129,8 @@ class SessionHandlerPHPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     #[Depends('testXdebugMode')]
     #[RunInSeparateProcess]
@@ -144,6 +151,8 @@ class SessionHandlerPHPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     #[Depends('testXdebugMode')]
     #[RunInSeparateProcess]
@@ -164,6 +173,8 @@ class SessionHandlerPHPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CannotSetCookie
+     * @throws \Exception
      */
     #[Depends('testXdebugMode')]
     #[RunInSeparateProcess]
@@ -188,6 +199,7 @@ class SessionHandlerPHPTest extends ClearStateTestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testNewSessionId(): void
     {

--- a/tests/src/SimpleSAML/SessionTest.php
+++ b/tests/src/SimpleSAML/SessionTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SimpleSAML\TestUtils\ClearStateTestCase;
-use SimpleSAML\{Configuration, Session};
+use SimpleSAML\{Configuration, Error\CannotSetCookie, Session};
 
 use function time;
 
@@ -20,6 +20,8 @@ class SessionTest extends ClearStateTestCase
     protected Session $session;
 
     /**
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function setUp(): void
     {
@@ -29,6 +31,7 @@ class SessionTest extends ClearStateTestCase
     }
 
     /**
+     * @throws CannotSetCookie
      */
     public function testSetRememberMeExpireDefaults(): void
     {
@@ -42,6 +45,7 @@ class SessionTest extends ClearStateTestCase
     }
 
     /**
+     * @throws CannotSetCookie
      */
     public function testSetRememberMeExpireExplicit(): void
     {

--- a/tests/src/SimpleSAML/Store/RedisStoreTest.php
+++ b/tests/src/SimpleSAML/Store/RedisStoreTest.php
@@ -7,7 +7,7 @@ namespace SimpleSAML\Test\Store;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Predis\Client;
-use SimpleSAML\{Configuration, Store};
+use SimpleSAML\{Configuration, Error\CriticalConfigurationError, Store};
 
 use function array_key_exists;
 
@@ -33,6 +33,7 @@ class RedisStoreTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
      */
     protected function setUp(): void
     {

--- a/tests/src/SimpleSAML/Store/SQLStoreTest.php
+++ b/tests/src/SimpleSAML/Store/SQLStoreTest.php
@@ -7,6 +7,7 @@ namespace SimpleSAML\Test\Store;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\CriticalConfigurationError;
 use SimpleSAML\Store;
 
 use function str_repeat;
@@ -80,6 +81,7 @@ class SQLStoreTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
      */
     public function testGetEmptyData(): void
     {
@@ -90,6 +92,7 @@ class SQLStoreTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
      */
     public function testInsertData(): void
     {
@@ -101,6 +104,7 @@ class SQLStoreTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
      */
     public function testOverwriteData(): void
     {
@@ -113,6 +117,7 @@ class SQLStoreTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
      */
     public function testDeleteData(): void
     {
@@ -125,6 +130,7 @@ class SQLStoreTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
      */
     public function testVeryLongKey(): void
     {

--- a/tests/src/SimpleSAML/Store/StoreFactoryTest.php
+++ b/tests/src/SimpleSAML/Store/StoreFactoryTest.php
@@ -23,6 +23,8 @@ use SimpleSAML\Store\StoreFactory;
 class StoreFactoryTest extends TestCase
 {
     /**
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testDefaultStore(): void
     {
@@ -37,6 +39,8 @@ class StoreFactoryTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testPhpSessionStore(): void
     {
@@ -53,6 +57,8 @@ class StoreFactoryTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testMemcacheStore(): void
     {
@@ -70,6 +76,8 @@ class StoreFactoryTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testRedisStore(): void
     {
@@ -90,6 +98,8 @@ class StoreFactoryTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testSqlStore(): void
     {
@@ -109,6 +119,8 @@ class StoreFactoryTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     public function testPathStore(): void
     {
@@ -128,6 +140,7 @@ class StoreFactoryTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testNotFoundStoreException(): void
     {
@@ -146,6 +159,8 @@ class StoreFactoryTest extends TestCase
 
 
     /**
+     * @throws CriticalConfigurationError
+     * @throws \Exception
      */
     protected function tearDown(): void
     {
@@ -163,6 +178,7 @@ class StoreFactoryTest extends TestCase
     /**
      * @param \SimpleSAML\Configuration|\SimpleSAML\Store\StoreInterface $service
      * @param class-string $className
+     * @throws \ReflectionException
      */
     protected function clearInstance($service, string $className): void
     {

--- a/tests/src/SimpleSAML/Utils/AttributesTest.php
+++ b/tests/src/SimpleSAML/Utils/AttributesTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Error;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Utils\Attributes;
 
 /**
@@ -34,6 +35,7 @@ class AttributesTest extends TestCase
 
     /**
      * Test the getExpectedAttributeMethod() method with a non-normalized attributes array.
+     * @throws Exception
      */
     public function testGetExpectedAttributeNonNormalizedArray(): void
     {
@@ -105,6 +107,7 @@ class AttributesTest extends TestCase
 
     /**
      * Test that the getExpectedAttribute() method successfully obtains values from the attributes array.
+     * @throws Exception
      */
     public function testGetExpectedAttribute(): void
     {

--- a/tests/src/SimpleSAML/Utils/ConfigTest.php
+++ b/tests/src/SimpleSAML/Utils/ConfigTest.php
@@ -6,7 +6,7 @@ namespace SimpleSAML\Test\Utils;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Error, Utils};
+use SimpleSAML\{Error, Error\CriticalConfigurationError, Utils};
 
 use function dirname;
 use function putenv;
@@ -35,6 +35,7 @@ class ConfigTest extends TestCase
 
     /**
      * Test default config dir with not environment variable
+     * @throws CriticalConfigurationError
      */
     public function testDefaultConfigDir(): void
     {
@@ -48,6 +49,7 @@ class ConfigTest extends TestCase
 
     /**
      * Test valid dir specified by env var overrides default config dir
+     * @throws CriticalConfigurationError
      */
     public function testEnvVariableConfigDir(): void
     {
@@ -59,6 +61,7 @@ class ConfigTest extends TestCase
 
     /**
      * Test valid dir specified by env redirect var overrides default config dir
+     * @throws CriticalConfigurationError
      */
     public function testEnvRedirectVariableConfigDir(): void
     {
@@ -71,6 +74,7 @@ class ConfigTest extends TestCase
 
     /**
      * Test which directory takes precedence
+     * @throws CriticalConfigurationError
      */
     public function testEnvRedirectPriorityVariableConfigDir(): void
     {

--- a/tests/src/SimpleSAML/Utils/CryptoTest.php
+++ b/tests/src/SimpleSAML/Utils/CryptoTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use org\bovigo\vfs\{vfsStream, vfsStreamDirectory};
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Error, Utils};
+use SimpleSAML\{Configuration, Error, Error\Exception, Utils};
 
 use function file_put_contents;
 use function substr;
@@ -151,6 +151,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPrivateKeyNotRequiredMetadataMissing(): void
     {
@@ -175,6 +176,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPrivateKeyBasic(): void
     {
@@ -193,6 +195,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPrivateKeyPassword(): void
     {
@@ -218,6 +221,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPrivateKeyPrefix(): void
     {
@@ -256,6 +260,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPublicKeyNotRequiredMetadataMissing(): void
     {
@@ -269,6 +274,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPublicKeyNotX509Certificate(): void
     {
@@ -292,6 +298,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPublicKeyNotSigning(): void
     {
@@ -315,6 +322,7 @@ PHP;
 
 
     /**
+     * @throws Exception
      */
     public function testLoadPublicKeyBasic(): void
     {

--- a/tests/src/SimpleSAML/Utils/EMailTest.php
+++ b/tests/src/SimpleSAML/Utils/EMailTest.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\ConfigurationError;
 use SimpleSAML\TestUtils\ClearStateTestCase;
 use SimpleSAML\Utils\EMail;
 
@@ -66,6 +67,7 @@ class EMailTest extends ClearStateTestCase
      * Test that the data given is visible in the resulting mail
      *
      * @param string $template
+     * @throws ConfigurationError
      */
     #[DataProvider('mailTemplates')]
     public function testMailContents($template): void
@@ -99,6 +101,7 @@ class EMailTest extends ClearStateTestCase
 
 
     /**
+     * @throws Exception
      */
     public function testInvalidTransportConfiguration(): void
     {
@@ -136,6 +139,7 @@ class EMailTest extends ClearStateTestCase
     /**
      * Test setting configuration.
      *
+     * @throws Exception
      */
     public function testGetDefaultMailAddress(): void
     {

--- a/tests/src/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/src/SimpleSAML/Utils/HTTPTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use SimpleSAML\{Configuration, Error, Utils};
+use SimpleSAML\{Configuration, Error, Error\CannotSetCookie, Error\CriticalConfigurationError, Error\Exception, Utils};
 use SimpleSAML\TestUtils\ClearStateTestCase;
 
 use function parse_url;
@@ -127,6 +127,7 @@ class HTTPTest extends ClearStateTestCase
 
     /**
      * Test SimpleSAML\Utils\HTTP::getSelfHost() with and without custom port.
+     * @throws CriticalConfigurationError
      */
     public function testGetSelfHost(): void
     {
@@ -147,6 +148,7 @@ class HTTPTest extends ClearStateTestCase
 
     /**
      * Test SimpleSAML\Utils\HTTP::getSelfHostWithPort(), with and without custom port.
+     * @throws CriticalConfigurationError
      */
     public function testGetSelfHostWithPort(): void
     {
@@ -176,6 +178,7 @@ class HTTPTest extends ClearStateTestCase
 
     /**
      * Test SimpleSAML\Utils\HTTP::getSelfURL().
+     * @throws CriticalConfigurationError
      */
     public function testGetSelfURLMethods(): void
     {
@@ -315,6 +318,7 @@ class HTTPTest extends ClearStateTestCase
 
     /**
      * Test SimpleSAML\Utils\HTTP::checkURLAllowed(), without regex.
+     * @throws Exception
      */
     public function testCheckURLAllowedWithoutRegex(): void
     {
@@ -348,6 +352,7 @@ class HTTPTest extends ClearStateTestCase
 
     /**
      * Test SimpleSAML\Utils\HTTP::checkURLAllowed(), with regex.
+     * @throws Exception
      */
     public function testCheckURLAllowedWithRegex(): void
     {
@@ -463,6 +468,8 @@ class HTTPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CannotSetCookie
+     * @throws CriticalConfigurationError
      */
     #[Depends('testXdebugMode')]
     #[RunInSeparateProcess]
@@ -524,6 +531,7 @@ class HTTPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CriticalConfigurationError
      */
     public function testSetCookieInsecure(): void
     {
@@ -545,6 +553,8 @@ class HTTPTest extends ClearStateTestCase
 
 
     /**
+     * @throws CannotSetCookie
+     * @throws CriticalConfigurationError
      */
     #[Depends('testXdebugMode')]
     #[RunInSeparateProcess]

--- a/tests/src/SimpleSAML/Utils/SystemTest.php
+++ b/tests/src/SimpleSAML/Utils/SystemTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Test\Utils;
 
+use Random\RandomException;
 use org\bovigo\vfs\{vfsStream, vfsStreamDirectory};
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use SimpleSAML\{Configuration, Error, Utils};
+use SimpleSAML\{Configuration, Error, Error\Exception, Utils};
 
 use function chmod;
 use function file_get_contents;
@@ -60,6 +61,7 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testResolvePathRemoveTrailingSlashes(): void
     {
@@ -74,6 +76,7 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testResolvePathPreferAbsolutePathToBase(): void
     {
@@ -88,6 +91,7 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testResolvePathCurDirPath(): void
     {
@@ -102,6 +106,7 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testResolvePathParentPath(): void
     {
@@ -116,6 +121,7 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testResolvePathAllowsStreamWrappers(): void
     {
@@ -130,6 +136,7 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws \Exception
      */
     public function testResolvePathAllowsAwsS3StreamWrappers(): void
     {
@@ -144,6 +151,9 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \ReflectionException
+     * @throws RandomException
      */
     public function testWriteFileBasic(): void
     {
@@ -161,6 +171,9 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \ReflectionException
+     * @throws RandomException
      */
     public function testWriteFileContents(): void
     {
@@ -182,6 +195,9 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \ReflectionException
+     * @throws RandomException
      */
     public function testWriteFileMode(): void
     {
@@ -203,6 +219,8 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testGetTempDirBasic(): void
     {
@@ -220,6 +238,8 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testGetTempDirNonExistent(): void
     {
@@ -237,6 +257,7 @@ class SystemTest extends TestCase
 
 
     /**
+     * @throws \ReflectionException
      */
     public function testGetTempDirBadPermissions(): void
     {
@@ -269,6 +290,7 @@ class SystemTest extends TestCase
     /**
      * @param \SimpleSAML\Configuration $service
      * @param class-string $className
+     * @throws \ReflectionException
      */
     protected function clearInstance(Configuration $service, string $className): void
     {

--- a/tests/src/SimpleSAML/Utils/TimeTest.php
+++ b/tests/src/SimpleSAML/Utils/TimeTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SimpleSAML\Assert\AssertionFailedException;
-use SimpleSAML\{Configuration, Error, Utils};
+use SimpleSAML\{Configuration, Error, Error\Exception, Utils};
 
 use function date_default_timezone_get;
 use function gmmktime;
@@ -39,6 +39,8 @@ class TimeTest extends TestCase
 
     /**
      * Test the SimpleSAML\Utils\Time::initTimezone() method.
+     * @throws Exception
+     * @throws \Exception
      */
     public function testInitTimezone(): void
     {

--- a/tests/src/SimpleSAML/Utils/XMLTest.php
+++ b/tests/src/SimpleSAML/Utils/XMLTest.php
@@ -11,7 +11,7 @@ use DOMText;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\{Configuration, Error, Utils};
+use SimpleSAML\{Configuration, Error, Error\Exception, Utils};
 use SimpleSAML\XML\DOMDocumentFactory;
 
 /**
@@ -23,6 +23,7 @@ class XMLTest extends TestCase
     private const FRAMEWORK = 'vendor/simplesamlphp/saml2/tests/resources/xml';
 
     /**
+     * @throws DOMException
      */
     public function testIsDomNodeOfTypeBasic(): void
     {
@@ -39,6 +40,7 @@ class XMLTest extends TestCase
 
 
     /**
+     * @throws DOMException
      */
     public function testIsDomNodeOfTypeMissingNamespace(): void
     {
@@ -54,6 +56,7 @@ class XMLTest extends TestCase
 
 
     /**
+     * @throws DOMException
      */
     public function testIsDomNodeOfTypeEmpty(): void
     {
@@ -70,6 +73,7 @@ class XMLTest extends TestCase
 
 
     /**
+     * @throws DOMException
      */
     public function testIsDomNodeOfTypeShortcut(): void
     {
@@ -87,6 +91,7 @@ class XMLTest extends TestCase
 
 
     /**
+     * @throws DOMException
      */
     public function testIsDomNodeOfTypeIncorrectName(): void
     {
@@ -104,6 +109,7 @@ class XMLTest extends TestCase
 
 
     /**
+     * @throws DOMException
      */
     public function testIsDomNodeOfTypeIncorrectNamespace(): void
     {
@@ -223,6 +229,7 @@ HEREDOC;
 
 
     /**
+     * @throws DOMException
      */
     public function testFormatXmlStringBasic(): void
     {
@@ -255,6 +262,7 @@ NOWDOC;
 
 
     /**
+     * @throws \Exception
      */
     public function testIsValidMalformedXml(): void
     {
@@ -271,6 +279,7 @@ NOWDOC;
 
 
     /**
+     * @throws \Exception
      */
     public function testIsValidMetadata(): void
     {
@@ -286,6 +295,7 @@ NOWDOC;
     }
 
     /**
+     * @throws Exception
      */
     public function testCheckSAMLMessageInvalidType(): void
     {

--- a/tests/src/SimpleSAML/XHTML/TemplateTest.php
+++ b/tests/src/SimpleSAML/XHTML/TemplateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\ConfigurationError;
+use SimpleSAML\Error\CriticalConfigurationError;
 use SimpleSAML\XHTML\Template;
 
 /**
@@ -17,6 +19,10 @@ class TemplateTest extends TestCase
 {
     private const TEMPLATE = 'sandbox.twig';
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     public function testSetup(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -24,6 +30,10 @@ class TemplateTest extends TestCase
         $this->assertEquals(self::TEMPLATE, $t->getTemplateName());
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     public function testNormalizeName(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -31,6 +41,10 @@ class TemplateTest extends TestCase
         $this->assertEquals(self::TEMPLATE, $t->getTemplateName());
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     public function testTemplateModuleNamespace(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -46,6 +60,10 @@ class TemplateTest extends TestCase
         ];
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     #[DataProvider('debugModeProvider')]
     public function testTemplateDebugMode(bool $debugMode): void
     {
@@ -61,6 +79,11 @@ class TemplateTest extends TestCase
         }
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     */
     public function testGetEntityDisplayNameBasic(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -79,6 +102,11 @@ class TemplateTest extends TestCase
         $this->assertEquals('Something', $name);
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     */
     public function testGetEntityDisplayNamePriorities(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -112,6 +140,11 @@ class TemplateTest extends TestCase
         $this->assertEquals('UIname NL', $name);
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     * @throws \Exception
+     */
     public function testGetEntityPropertyTranslation(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');

--- a/tests/src/SimpleSAML/XHTML/TemplateTranslationTest.php
+++ b/tests/src/SimpleSAML/XHTML/TemplateTranslationTest.php
@@ -7,12 +7,14 @@ namespace SimpleSAML\Test\XHTML;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Error\ConfigurationError;
+use SimpleSAML\Error\CriticalConfigurationError;
 use SimpleSAML\Locale\{Translate, TwigTranslator};
 use SimpleSAML\Module;
 use SimpleSAML\XHTML\Template;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Finder\{Finder, SplFileInfo};
-use Twig\{Environment, TwigFilter, TwigFunction};
+use Twig\{Environment, Error\LoaderError, Error\RuntimeError, Error\SyntaxError, TwigFilter, TwigFunction};
 use Twig\Extra\Intl\IntlExtension;
 use Twig\Loader\FilesystemLoader;
 
@@ -21,6 +23,10 @@ use Twig\Loader\FilesystemLoader;
 #[CoversClass(Template::class)]
 class TemplateTranslationTest extends TestCase
 {
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     public function testCoreCardinalityErrorTemplate(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -41,6 +47,10 @@ class TemplateTranslationTest extends TestCase
         $this->assertStringContainsString('got 1 values, want 2', $html);
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     public function testCoreLoginUserPassTemplate(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -64,6 +74,10 @@ class TemplateTranslationTest extends TestCase
         $this->assertStringContainsString('value="h.c oersted"', $html);
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     public function testCoreLogoutIframeTemplate(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -99,6 +113,10 @@ class TemplateTranslationTest extends TestCase
         $this->assertStringContainsString('ze missing service', $html);
     }
 
+    /**
+     * @throws ConfigurationError
+     * @throws CriticalConfigurationError
+     */
     public function testAuthStatusTemplate(): void
     {
         $c = Configuration::loadFromArray([], '', 'simplesaml');
@@ -122,6 +140,11 @@ class TemplateTranslationTest extends TestCase
         );
     }
 
+    /**
+     * @throws SyntaxError
+     * @throws RuntimeError
+     * @throws LoaderError
+     */
     public function testValidateTwigFiles(): void
     {
         $root = dirname(__DIR__, 4);

--- a/tests/src/SimpleSAML/XML/ParserTest.php
+++ b/tests/src/SimpleSAML/XML/ParserTest.php
@@ -40,6 +40,7 @@ XML;
 
 
     /**
+     * @throws Exception
      */
     public function testGetValue(): void
     {
@@ -52,6 +53,7 @@ XML;
 
 
     /**
+     * @throws Exception
      */
     public function testGetEmptyValue(): void
     {
@@ -73,6 +75,7 @@ XML;
 
 
     /**
+     * @throws Exception
      */
     public function testGetDefaultValue(): void
     {
@@ -85,6 +88,7 @@ XML;
 
 
     /**
+     * @throws Exception
      */
     public function testGetValueAlternatives(): void
     {
@@ -104,6 +108,7 @@ XML;
 
 
     /**
+     * @throws Exception
      */
     public function testGetEmptyValueAlternatives(): void
     {

--- a/tests/src/SimpleSAML/XML/SignerTest.php
+++ b/tests/src/SimpleSAML/XML/SignerTest.php
@@ -65,6 +65,7 @@ NOWDOC;
 
 
     /**
+     * @throws Exception
      */
     public function testSignerBasic(): void
     {
@@ -75,6 +76,7 @@ NOWDOC;
 
 
     /**
+     * @throws Exception
      */
     public function testSignBasic(): void
     {
@@ -114,6 +116,7 @@ NOWDOC;
 
 
     /**
+     * @throws Exception
      */
     public function testSignWithCertificate(): void
     {
@@ -140,6 +143,7 @@ NOWDOC;
 
 
     /**
+     * @throws Exception
      */
     public function testSignWithMultiCertificate(): void
     {
@@ -171,6 +175,7 @@ NOWDOC;
 
 
     /**
+     * @throws Exception
      */
     public function testSignMissingPrivateKey(): void
     {
@@ -193,6 +198,7 @@ NOWDOC;
      * @param \SimpleSAML\Configuration $service
      * @param class-string $className
      * @param mixed $value
+     * @throws \ReflectionException
      */
     protected function clearInstance(Configuration $service, string $className, mixed $value = null): void
     {

--- a/tests/src/SimpleSAML/XML/ValidatorTest.php
+++ b/tests/src/SimpleSAML/XML/ValidatorTest.php
@@ -28,6 +28,7 @@ class ValidatorTest extends SigningTestCase
 
 
     /**
+     * @throws Exception
      */
     public function testGetX509Certificate(): void
     {
@@ -55,6 +56,7 @@ class ValidatorTest extends SigningTestCase
 
 
     /**
+     * @throws Exception
      */
     public function testIsNodeValidatedSuccess(): void
     {
@@ -82,6 +84,7 @@ class ValidatorTest extends SigningTestCase
 
 
     /**
+     * @throws Exception
      */
     public function testIsNodeValidatedFailure(): void
     {


### PR DESCRIPTION
Used PhpStorm and Psalm to thread the thrown exceptions throughout the code. The addition of extra `@throws` should be pretty minimal.

Added checkForThrowsDocblock and checkForThrowsInGlobalScope to psalm.xml

Psalm will now emit:

* **MissingThrowsDocblock**, for exceptions that can be added as `@throws`
* **UncaughtThrowInGlobalScope**, for exceptions that happen at the non-class level. Meaning you can probably get to see the uncaught results of them as an end-user. These probably need some try-catch handling right there or somewhere deeper in the call chain.