### PR TITLE
Update for cookie deletion on logout.

### DIFF
--- a/docs/simplesamlphp-advancedfeatures.md
+++ b/docs/simplesamlphp-advancedfeatures.md
@@ -18,7 +18,22 @@ A bridge between two protocols is built using both an IdP and an SP, connected t
 To let a SAML 2.0 SP talk to a SAML 1.1 IdP, you build a SimpleSAMLphp bridge from a SAML 2.0 IdP and a SAML 1.1 SP.
 The SAML 2.0 SP talks to the SAML 2.0 IdP, which hands the request over to the SAML 1.1 SP, which forwards it to the SAML 1.1 IdP.
 
-If you have followed the instructions for setting up an SP, and have configured an authentication source, all you need to do is to add that authentication source to the IdP.
+If you have followed the instructions for setting up an SP, and have
+configured an authentication source, you have a configuration that is
+close to being able to be used with the IdP. Instead of directly using
+the authentication source with the IdP you might like to clone that
+configuration and use the the saml:SPBridge type. This subclass of
+saml:SP is close but does not try to delete the cookie on SP logout.
+As the IdP that is running the bridge and the SP are running on the
+same instance of SSP this would cause an issue where the same cookie
+is shared and should not be deleted by the SP prior to the IdP
+deleting it.
+
+The saml:SPBridge class will leave the cookie active and when the IdP
+that is bridging to that SP is then logged out the IdP can then
+cleanly delete the session cookie and does not get into a state where
+it is expecting a cookie to exist but it has already been deleted due
+to the bridge configuration.
 
 ### Example of bridge configuration
 
@@ -32,7 +47,7 @@ In `config/authsources.php`:
 
 ```php
 'default-sp' => [
-    'saml:SP',
+    'saml:SPBridge',
 ],
 ```
 

--- a/docs/simplesamlphp-reference-idp-hosted.md
+++ b/docs/simplesamlphp-reference-idp-hosted.md
@@ -92,6 +92,11 @@ entry matches.
     set to `__DEFAULT__`, and that IdP will be used when no other
     entries in the metadata matches.
 
+`logout_delete_session_cookie`
+:   Delete the SAMLAuthToken cookie on logout from the IdP. `true` is the defualt. You may consdier
+    setting this option to `false` if you wish to have a degenerate installation with the SP and IdP
+    on the same install instance.
+
 `logouttype`
 :   The logout handler to use. Either `iframe` or `traditional`. `traditional` is the default.
 

--- a/docs/simplesamlphp-reference-idp-hosted.md
+++ b/docs/simplesamlphp-reference-idp-hosted.md
@@ -93,7 +93,7 @@ entry matches.
     entries in the metadata matches.
 
 `logout_delete_session_cookie`
-:   Delete the SAMLAuthToken cookie on logout from the IdP. `true` is the defualt. You may consdier
+:   Delete the SAMLAuthToken cookie on logout from the IdP. `true` is the default. You may consider
     setting this option to `false` if you wish to have a degenerate installation with the SP and IdP
     on the same install instance.
 

--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -40,49 +40,49 @@ class SP extends \SimpleSAML\Auth\Source
      *
      * @var \SimpleSAML\Configuration
      */
-    private Configuration $metadata;
+    protected Configuration $metadata;
 
     /**
      * The IdP the user is allowed to log into.
      *
      * @var string|null  The IdP the user can log into, or null if the user can log into all IdPs.
      */
-    private ?string $idp;
+    protected ?string $idp;
 
     /**
      * URL to discovery service.
      *
      * @var string|null
      */
-    private ?string $discoURL;
+    protected ?string $discoURL;
 
     /**
      * Flag to indicate whether to disable sending the Scoping element.
      *
      * @var bool
      */
-    private bool $disable_scoping;
+    protected bool $disable_scoping;
 
     /**
      * If pass AuthnContextClassRef back to the IdPs in front of the SP/IdP Proxy.
      *
      * @var bool
      */
-    private bool $passAuthnContextClassRef;
+    protected bool $passAuthnContextClassRef;
 
     /**
      * A list of supported protocols.
      *
      * @var string[]
      */
-    private array $protocols = [Constants::NS_SAMLP];
+    protected array $protocols = [Constants::NS_SAMLP];
 
     /**
      * Flag to indicate whether to disable sending the Scoping element.
      *
      * @var bool
      */
-    private bool $requestInitiation;
+    protected bool $requestInitiation;
 
 
     /**
@@ -355,7 +355,7 @@ class SP extends \SimpleSAML\Auth\Source
      * @return array
      * @throws \Exception
      */
-    private function getACSEndpoints(): array
+    protected function getACSEndpoints(): array
     {
         // If a list of endpoints is specified in config, take that at face value
         if ($this->metadata->hasValue('AssertionConsumerService')) {
@@ -412,7 +412,7 @@ class SP extends \SimpleSAML\Auth\Source
      * @return array
      * @throws \SimpleSAML\Error\CriticalConfigurationError
      */
-    private function getSLOEndpoints(): array
+    protected function getSLOEndpoints(): array
     {
         $config = Configuration::getInstance();
         $storeType = $config->getOptionalString('store.type', 'phpsession');
@@ -445,7 +445,7 @@ class SP extends \SimpleSAML\Auth\Source
     /**
      * Get the DiscoveryResponse endpoint available for a given local SP.
      */
-    private function getDiscoveryResponseEndpoints(): array
+    protected function getDiscoveryResponseEndpoints(): array
     {
         $location = Module::getModuleURL('saml/sp/discoResponse/' . $this->getAuthId());
 
@@ -472,7 +472,7 @@ class SP extends \SimpleSAML\Auth\Source
      * @param \SimpleSAML\Configuration $idpMetadata  The metadata of the IdP.
      * @param array $state  The state array for the current authentication.
      */
-    private function startSSO2(Configuration $idpMetadata, array $state): void
+    protected function startSSO2(Configuration $idpMetadata, array $state): void
     {
         if (isset($state['saml:ProxyCount']) && $state['saml:ProxyCount'] < 0) {
             Auth\State::throwException(
@@ -740,7 +740,7 @@ class SP extends \SimpleSAML\Auth\Source
      *
      * @param array $state  The state array.
      */
-    private function startDisco(array $state): void
+    protected function startDisco(array $state): void
     {
         $id = Auth\State::saveState($state, 'saml:sp:sso');
 
@@ -1266,5 +1266,12 @@ class SP extends \SimpleSAML\Auth\Source
         }
 
         Auth\Source::completeAuth($state);
+    }
+
+    public function onLogoutCompleted(array &$state): void
+    {
+        // Delete the cookie on SP logout.
+        $session =  Session::getSessionFromRequest();
+        $session->updateSessionCookies(['expire' => true]);
     }
 }

--- a/modules/saml/src/Auth/Source/SPBridge.php
+++ b/modules/saml/src/Auth/Source/SPBridge.php
@@ -4,28 +4,6 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\saml\Auth\Source;
 
-use SAML2\AuthnRequest;
-use SAML2\Binding;
-use SAML2\Constants;
-use SAML2\Exception\Protocol\NoAvailableIDPException;
-use SAML2\Exception\Protocol\NoPassiveException;
-use SAML2\Exception\Protocol\NoSupportedIDPException;
-use SAML2\LogoutRequest;
-use SAML2\XML\saml\NameID;
-use SimpleSAML\Assert\Assert;
-use SimpleSAML\Auth;
-use SimpleSAML\Configuration;
-use SimpleSAML\Error;
-use SimpleSAML\IdP;
-use SimpleSAML\Logger;
-use SimpleSAML\Metadata\MetaDataStorageHandler;
-use SimpleSAML\Module;
-use SimpleSAML\Module\saml\Error\ProxyCountExceeded;
-use SimpleSAML\Session;
-use SimpleSAML\Store;
-use SimpleSAML\Store\StoreFactory;
-use SimpleSAML\Utils;
-
 class SPBridge extends SP
 {
     /**

--- a/modules/saml/src/Auth/Source/SPBridge.php
+++ b/modules/saml/src/Auth/Source/SPBridge.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\saml\Auth\Source;
+
+use SAML2\AuthnRequest;
+use SAML2\Binding;
+use SAML2\Constants;
+use SAML2\Exception\Protocol\NoAvailableIDPException;
+use SAML2\Exception\Protocol\NoPassiveException;
+use SAML2\Exception\Protocol\NoSupportedIDPException;
+use SAML2\LogoutRequest;
+use SAML2\XML\saml\NameID;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Auth;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error;
+use SimpleSAML\IdP;
+use SimpleSAML\Logger;
+use SimpleSAML\Metadata\MetaDataStorageHandler;
+use SimpleSAML\Module;
+use SimpleSAML\Module\saml\Error\ProxyCountExceeded;
+use SimpleSAML\Session;
+use SimpleSAML\Store;
+use SimpleSAML\Store\StoreFactory;
+use SimpleSAML\Utils;
+
+class SPBridge extends SP
+{
+    /**
+     * Constructor for SAML SP authentication source.
+     *
+     * @param array $info  Information about this authentication source.
+     * @param array $config  Configuration.
+     */
+    public function __construct(array $info, array $config)
+    {
+        // Call the parent constructor first, as required by the interface
+        parent::__construct($info, $config);
+    }
+
+    public function onLogoutCompleted(array &$state): void
+    {
+        // bridges do not delete SP cookies because we share the host with
+        // the IdP that is bridging to us
+        // That IdP will be in charge of deleting the cookies.
+    }
+}

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -586,6 +586,10 @@ class ServiceProvider
             $state = $this->authState::loadState($relayState, 'saml:slosent');
             $state['saml:sp:LogoutStatus'] = $message->getStatus();
 
+            // allow possible cookie deletion
+            // depending on if we are on a bridge.
+            $source->onLogoutCompleted($state);
+
             return new RunnableResponse([Auth\Source::class, 'completeLogout'], [&$state]);
         } elseif ($message instanceof LogoutRequest) {
             Logger::debug('module/saml2/sp/logout: Request from ' . $idpEntityId);

--- a/src/SimpleSAML/Auth/Source.php
+++ b/src/SimpleSAML/Auth/Source.php
@@ -251,6 +251,12 @@ abstract class Source
         // default logout handler which doesn't do anything
     }
 
+    public function onLogoutCompleted(array &$state): void
+    {
+        // empty.
+        // Some subclasses may want to delete some state here.
+        // This will be called from ServiceProvider
+    }
 
     /**
      * Complete logout.

--- a/src/SimpleSAML/IdP.php
+++ b/src/SimpleSAML/IdP.php
@@ -424,6 +424,12 @@ class IdP
      */
     public function getLogoutHandler(): LogoutHandlerInterface
     {
+        // Destroy session cookies.
+        if($this->getConfig()->getOptionalBoolean('logout_delete_session_cookie', true)) {
+            $session = Session::getSessionFromRequest();
+            $session->updateSessionCookies(['expire' => true]);
+        }
+
         // find the logout handler
         $logouttype = $this->getConfig()->getOptionalString('logouttype', 'traditional');
         switch ($logouttype) {

--- a/src/SimpleSAML/IdP.php
+++ b/src/SimpleSAML/IdP.php
@@ -425,7 +425,7 @@ class IdP
     public function getLogoutHandler(): LogoutHandlerInterface
     {
         // Destroy session cookies.
-        if($this->getConfig()->getOptionalBoolean('logout_delete_session_cookie', true)) {
+        if ($this->getConfig()->getOptionalBoolean('logout_delete_session_cookie', true)) {
             $session = Session::getSessionFromRequest();
             $session->updateSessionCookies(['expire' => true]);
         }


### PR DESCRIPTION
Because a bridge setup runs the IdP and SP (that you are bridging too) on the same installation instance then cookie handling is a little more complicated. The SP should not delete the cookie on logout here as it is shared with the IdP that is bridging to the SP. For that there is a new saml:SPBridge type that can be used which will be the same as the normal SP for now but does not delete the session cookie on logout. For a bridge the IdP and SP are on the same instance so the IdP can be left to delete the session cookie for that SSP install instance.

See simplesamlphp-advancedfeatures.md for information about the saml:SPBridge.

This relates to https://github.com/simplesamlphp/simplesamlphp/issues/2435

This PR also has the IdP deleting its cookie on logout. This can be turned off with the logout_delete_session_cookie (`true` by default) setting for the IdP. This setting allows degenerate installations with the IdP and SP on the same instance to continue to function. It is also a good backup mechanism allowing the new IdP cookie deletion to be turned off if it is causing issues on a bridge or other setup instance where further investigation may be needed.

Somehow there were different git hashes there and instead of merging I rolled back my 2.4 branch and moved it forward. So that should be the same as my v2 branch but with the current remote history.