### PR TITLE
In ConfigurationTest.php update Constants:: to C::, as in the use

### DIFF
--- a/tests/src/SimpleSAML/ConfigurationTest.php
+++ b/tests/src/SimpleSAML/ConfigurationTest.php
@@ -865,7 +865,7 @@ class ConfigurationTest extends ClearStateTestCase
         $this->assertEquals(
             [
                 'Location' => 'https://example.com/slo',
-                'Binding' => Constants::BINDING_HTTP_REDIRECT,
+                'Binding' => C::BINDING_HTTP_REDIRECT,
             ],
             $c->getDefaultEndpoint('SingleLogoutService'),
         );


### PR DESCRIPTION
In ConfigurationTest.php update Constants:: to C::, as in the `use … as ...;` statement.

Apparently PHP particularly doesn't care, or this test was never executed (maybe you need [tombstones](https://github.com/scheb/tombstone)?).