### PR TITLE
bugfix: log a warning instead on throwing an exception for invalid entityIDs

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -10,6 +10,8 @@ See the [upgrade notes](https://simplesamlphp.org/docs/stable/simplesamlphp-upgr
 Released TBD
 
 * Fixed a bug where metadata-endpoints with isDefault set would not yield the expected metadata (#2439)
+* Fixed a backwards incompatibility that would throw an exception on an invalid entityID.
+  The exception was downgraded to a warning in the log (#2448)
 
 `memcacheMonitor`
 

--- a/modules/saml/src/Auth/Source/SP.php
+++ b/modules/saml/src/Auth/Source/SP.php
@@ -10,6 +10,7 @@ use SAML2\Constants;
 use SAML2\Exception\Protocol\NoAvailableIDPException;
 use SAML2\Exception\Protocol\NoPassiveException;
 use SAML2\Exception\Protocol\NoSupportedIDPException;
+use SAML2\Exception\Protocol\ProtocolViolationException;
 use SAML2\LogoutRequest;
 use SAML2\XML\saml\NameID;
 use SimpleSAML\Assert\Assert;
@@ -105,7 +106,12 @@ class SP extends \SimpleSAML\Auth\Source
         );
 
         $entityId = $this->metadata->getString('entityID');
-        Assert::validURI($entityId);
+        try {
+            Assert::validURI($entityId);
+        } catch (ProtocolViolationException $e) {
+            Logger::warning($e->getMessage());
+        }
+
         Assert::maxLength(
             $entityId,
             Constants::SAML2INT_ENTITYID_MAX_LENGTH,


### PR DESCRIPTION
Closes #2448

While throwing an exception is the right thing to do, it may also be a little harsh.
Definitely not something we should do in a minor release.