### PR TITLE
Update base.twig

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="{{ asset("css/stylesheet.css") }}">
     <link rel="icon" href="{{ asset("icons/favicon.ico") }}">
     <meta name="robots" content="noindex, nofollow">
-    {{ include('_head.twig', ignore_missing = true) }}
     {% block preload %}{% endblock %}
   </head>
   <body id="{{ templateId }}">


### PR DESCRIPTION
_head.twig does not exist. The header is included in line 17.

Also, this line somehow causes a segmentation fault with PHP 8.2 and PHP 8.4. We are investigating this issue.