### PR TITLE
Fix various errors and warnings detected in VS Code

### DIFF
--- a/bin/memcacheSync.php
+++ b/bin/memcacheSync.php
@@ -26,7 +26,8 @@ $baseDir = dirname(__FILE__, 2);
 require_once($baseDir . '/src/_autoload.php');
 
 // Initialize the configuration
-$configdir = SimpleSAML\Utils\Config::getConfigDir();
+$configUtils = new SimpleSAML\Utils\Config();
+$configdir = $configUtils->getConfigDir();
 \SimpleSAML\Configuration::setConfigDir($configdir);
 
 // Things we should warn the user about

--- a/modules/core/src/Controller/ErrorReport.php
+++ b/modules/core/src/Controller/ErrorReport.php
@@ -30,7 +30,7 @@ class ErrorReport
      * It initializes the global configuration for the controllers implemented here.
      *
      * @param \SimpleSAML\Configuration $config The configuration to use by the controllers.
-     * @param \SimpleSAML\Session $config The session to use by the controllers.
+     * @param \SimpleSAML\Session $session The session to use by the controllers.
      */
     public function __construct(
         protected Configuration $config,

--- a/modules/saml/src/Controller/ServiceProvider.php
+++ b/modules/saml/src/Controller/ServiceProvider.php
@@ -132,7 +132,7 @@ class ServiceProvider
      * @param   Utils\HTTP    $httpUtils
      *
      * @return string
-     * @throws BadRequest
+     * @throws \SimpleSAML\Error\BadRequest
      * @throws Error\Exception
      */
     protected function loginHandler(

--- a/modules/saml/src/IdP/SAML2.php
+++ b/modules/saml/src/IdP/SAML2.php
@@ -702,7 +702,7 @@ class SAML2
      *
      * @param \SimpleSAML\IdP $idp The IdP we are sending a logout request from.
      * @param array           $association The association that should be terminated.
-     * @param string|NULL $relayState An id that should be carried across the logout.
+     * @param string|null $relayState An id that should be carried across the logout.
      *
      * @return string The logout URL.
      */

--- a/src/SimpleSAML/Command/SspCacheClearCommand.php
+++ b/src/SimpleSAML/Command/SspCacheClearCommand.php
@@ -59,7 +59,7 @@ EOF,);
     }
 
     /**
-     * @throws ExceptionInterface
+     * @throws \Symfony\Component\Console\Exception\ExceptionInterface
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
+++ b/src/SimpleSAML/Command/UpdateTranslatableStringsCommand.php
@@ -83,7 +83,7 @@ class UpdateTranslatableStringsCommand extends Command
      * It is expected that $iterator was made by getIterator() on Translations.
      * This can be useful as the entries are cloned in the iterator order.
      *
-     * @param Gettext\Translations $ret
+     * @param \Gettext\Translations $ret
      * @param iterable $iterator
      * @return $ret
      */

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerDirectory.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerDirectory.php
@@ -131,12 +131,10 @@ class MetaDataStorageHandlerDirectory extends MetaDataStorageSource
             }
         }
 
-
-
-
         if (!is_array($metadata)) {
-            throw new Exception('Could not load metadata set [' . $set . '] from file: ' . $metadatasetfile);
+            throw new Exception('Could not load metadata set [' . $set . '] from file: ' . $metadatasetdir);
         }
+        
         return $metadata;
     }
 

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerPdo.php
@@ -92,7 +92,7 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
             while ($d = $stmt->fetch()) {
                 $data = json_decode($d['entity_data'], true);
                 if ($data === null) {
-                    throw new Error\Exception("Cannot decode metadata for entity '${d['entity_id']}'");
+                    throw new Error\Exception("Cannot decode metadata for entity '{$d['entity_id']}'");
                 }
                 if (!array_key_exists('entityid', $data)) {
                     $data['entityid'] = $d['entity_id'];
@@ -176,7 +176,7 @@ class MetaDataStorageHandlerPdo extends MetaDataStorageSource
             $data = json_decode($d['entity_data'], true);
             if (json_last_error() != JSON_ERROR_NONE) {
                 throw new \SimpleSAML\Error\Exception(
-                    "Cannot decode metadata for entity '${d['entity_id']}'",
+                    "Cannot decode metadata for entity '{$d['entity_id']}'",
                 );
             }
 

--- a/src/SimpleSAML/Metadata/SAMLParser.php
+++ b/src/SimpleSAML/Metadata/SAMLParser.php
@@ -157,7 +157,7 @@ class SAMLParser
     /**
      * This is an array of elements that may be used to validate this element.
      *
-     * @var \SimpleSAML\SAML2\SignedElementHelper[]
+     * @var \SAML2\SignedElementHelper[]
      */
     private array $validators = [];
 
@@ -353,7 +353,7 @@ class SAMLParser
      * This function parses a DOMElement which represents either an EntityDescriptor element or an
      * EntitiesDescriptor element. It will return an associative array of SAMLParser instances in both cases.
      *
-     * @param \DOMElement|NULL $element The DOMElement which contains the EntityDescriptor element or the
+     * @param \DOMElement|null $element The DOMElement which contains the EntityDescriptor element or the
      *     EntitiesDescriptor element.
      *
      * @return SAMLParser[] An associative array of SAMLParser instances. The key of the array will
@@ -380,7 +380,7 @@ class SAMLParser
     /**
      *
      * @param \SAML2\XML\md\EntityDescriptor|\SAML2\XML\md\EntitiesDescriptor $element The element we should process.
-     * @param int|NULL              $maxExpireTime The maximum expiration time of the entities.
+     * @param int|null              $maxExpireTime The maximum expiration time of the entities.
      * @param array                 $validators The parent-elements that may be signed.
      * @param array                 $parentExtensions An optional array of extensions from the parent element.
      *
@@ -761,7 +761,7 @@ class SAMLParser
      * - 'keys': Array of associative arrays with the elements from parseKeyDescriptor:
      *
      * @param \SAML2\XML\md\SSODescriptorType $element The element we should extract metadata from.
-     * @param int|NULL                       $expireTime The unix timestamp for when this element should expire, or
+     * @param int|null                       $expireTime The unix timestamp for when this element should expire, or
      *                             NULL if unknown.
      *
      * @return array An associative array with metadata we have extracted from this element.
@@ -787,7 +787,7 @@ class SAMLParser
      * This function extracts metadata from a SPSSODescriptor element.
      *
      * @param \SAML2\XML\md\SPSSODescriptor $element The element which should be parsed.
-     * @param int|NULL                     $expireTime The unix timestamp for when this element should expire, or
+     * @param int|null                     $expireTime The unix timestamp for when this element should expire, or
      *                             NULL if unknown.
      */
     private function processSPSSODescriptor(SPSSODescriptor $element, ?int $expireTime): void
@@ -821,7 +821,7 @@ class SAMLParser
      * This function extracts metadata from a IDPSSODescriptor element.
      *
      * @param \SAML2\XML\md\IDPSSODescriptor $element The element which should be parsed.
-     * @param int|NULL                      $expireTime The unix timestamp for when this element should expire, or
+     * @param int|null                      $expireTime The unix timestamp for when this element should expire, or
      *                             NULL if unknown.
      */
     private function processIDPSSODescriptor(IDPSSODescriptor $element, ?int $expireTime): void
@@ -845,7 +845,7 @@ class SAMLParser
      * This function extracts metadata from a AttributeAuthorityDescriptor element.
      *
      * @param \SAML2\XML\md\AttributeAuthorityDescriptor $element The element which should be parsed.
-     * @param int|NULL                                  $expireTime The unix timestamp for when this element should
+     * @param int|null                                  $expireTime The unix timestamp for when this element should
      *     expire, or NULL if unknown.
      */
     private function processAttributeAuthorityDescriptor(

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -483,7 +483,7 @@ class Module
      * @param string The classname.
      * @param string|null $subclass The class should be a subclass of this class. Optional.
      *
-     * @return the new object
+     * @return object The new object
      */
     public static function createObject(string $className, ?string $subclass = null): object
     {

--- a/src/SimpleSAML/Utils/Auth.php
+++ b/src/SimpleSAML/Utils/Auth.php
@@ -18,7 +18,7 @@ class Auth
     /**
      * Retrieve an admin logout URL.
      *
-     * @param string|NULL $returnTo The URL the user should arrive on after admin authentication. Defaults to null.
+     * @param string|null $returnTo The URL the user should arrive on after admin authentication. Defaults to null.
      *
      * @return string A URL which can be used for logging out.
      * @throws \InvalidArgumentException If $returnTo is neither a string nor null.

--- a/src/SimpleSAML/Utils/Config/Metadata.php
+++ b/src/SimpleSAML/Utils/Config/Metadata.php
@@ -177,7 +177,7 @@ class Metadata
      * @param array $endpoints An array with endpoints.
      * @param array|null $bindings An array with acceptable bindings. Can be null if any binding is allowed.
      *
-     * @return array|NULL The default endpoint, or null if no acceptable endpoints are used.
+     * @return array|null The default endpoint, or null if no acceptable endpoints are used.
      *
      */
     public static function getDefaultEndpoint(array $endpoints, ?array $bindings = null): ?array

--- a/src/SimpleSAML/Utils/Crypto.php
+++ b/src/SimpleSAML/Utils/Crypto.php
@@ -166,7 +166,7 @@ class Crypto
      * @param string $der Data encoded in DER format.
      * @param string $type The type of data we are encoding, as expressed by the PEM header. Defaults to "CERTIFICATE".
      * @return string The same data encoded in PEM format.
-     * @see RFC7648 for known types and PEM format specifics.
+     * @see https://www.ietf.org/rfc/rfc7648.txt for known types and PEM format specifics.
      */
     public function der2pem(string $der, string $type = 'CERTIFICATE'): string
     {
@@ -195,7 +195,7 @@ class Crypto
      * @param bool                      $full_path Whether the location found in the configuration contains the
      * full path to the private key or not (only relevant for file locations). Default to false.
      *
-     * @return array|NULL Extracted private key, or NULL if no private key is present.
+     * @return array|null Extracted private key, or NULL if no private key is present.
      * @throws \InvalidArgumentException If $required is not boolean or $prefix is not a string.
      * @throws Error\Exception If no private key is found in the metadata, or it was not possible to load
      *     it.
@@ -251,7 +251,7 @@ class Crypto
      * @param string                    $prefix The prefix which should be used when reading from the metadata array.
      *     Defaults to ''.
      *
-     * @return array|NULL Public key or certificate data, or NULL if no public key or certificate was found.
+     * @return array|null Public key or certificate data, or NULL if no public key or certificate was found.
      * @throws \InvalidArgumentException If $metadata is not an instance of \SimpleSAML\Configuration, $required is not
      *     boolean or $prefix is not a string.
      * @throws Error\Exception If no public key is found in the metadata, or it was not possible to load
@@ -297,7 +297,7 @@ class Crypto
      * @param string $pem Data encoded in PEM format.
      * @return string The same data encoded in DER format.
      * @throws \InvalidArgumentException If $pem is not encoded in PEM format.
-     * @see RFC7648 for PEM format specifics.
+     * @see https://www.ietf.org/rfc/rfc7648.txt for PEM format specifics.
      */
     public function pem2der(string $pem): string
     {

--- a/tests/modules/saml/src/Auth/Source/SPTest.php
+++ b/tests/modules/saml/src/Auth/Source/SPTest.php
@@ -258,7 +258,7 @@ class SPTest extends ClearStateTestCase
      */
     public function testForcedAuthn(): void
     {
-        /** @var bool $state['ForceAuthn'] */
+        /** @var array{ForceAuthn:bool} $state */
         $state = [
             'ForceAuthn' => true,
         ];


### PR DESCRIPTION
- Undeclared variable (incorrect name)
- Move some deprecated static functions to instances
- Namespacing on various PHPdoc tags
- Various PHPdoc tags NULL to lowercase
- Fix a PHP 8.2 deprecation re string interpolation