### PR TITLE
Docs: remove information about fallback from md.sign.pk to pk

### DIFF
--- a/docs/simplesamlphp-advancedfeatures.md
+++ b/docs/simplesamlphp-advancedfeatures.md
@@ -81,8 +81,6 @@ wish to set the metadata.sign.privatekey and metadata.sign.certificate
 in a metadata file you need to also set metadata.sign.enable=true in
 that metadata file.
 
-There is also an additional fallback for the private key and the certificate. If `metadata.sign.privatekey` and `metadata.sign.certificate` isn't configured, SimpleSAMLphp will use the `privatekey`, `privatekey_pass` and `certificate` options in the metadata for the SP/IdP.
-
 ## Session checking function
 
 Optional session checking function, called on session init and loading, defined with 'session.check_function' in config.php.

--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -13,6 +13,9 @@ Released TBD
 * Update and improve Thai translations (#2464)
 * Update and improve Vietnamese translations (#2465)
 * Fix various errors and warnings detected in VS Code (#2468)
+* Remove information in simplesamlphp-advancedfeatures.md about
+  possible fallback from metadata.sign.privatekey to privatekey in IdP
+  and SP metadata files (#2470)
 
 ## Version 2.4.2
 


### PR DESCRIPTION
Remove information in simplesamlphp-advancedfeatures.md about possible fallback from metadata.sign.privatekey to privatekey in IdP and SP metadata files

This was raised in
https://github.com/simplesamlphp/simplesamlphp/issues/2447 as not working for IdP metadata. I have seen that is currently the case.

It should also be confirmed that the fallback is not actively working for SP metadata to make sure that this PR does not change existing functionality.

Perhaps also we should strenghten this to make sure that if metadata.sign.enable=true in the IdP/SP metadata file then we *require* you to set the metadata.sign.privatekey and metadata.sign.certificate. Though that would be a breaking change as well so should be a 2.5 type udpate.

This PR is the opposite to https://github.com/simplesamlphp/simplesamlphp/pull/2469 where we are explicitly removing the fallback.