### PR TITLE
Fix auth state authninstant

### DIFF
--- a/src/SimpleSAML/Auth/State.php
+++ b/src/SimpleSAML/Auth/State.php
@@ -129,7 +129,7 @@ class State
             'Attributes',
             'Expire',
             'LogoutState',
-            'AuthInstant',
+            'AuthnInstant',
             'RememberMe',
             'saml:sp:NameID',
         ];

--- a/tests/src/SimpleSAML/Auth/StateTest.php
+++ b/tests/src/SimpleSAML/Auth/StateTest.php
@@ -27,7 +27,7 @@ class StateTest extends TestCase
             'Attributes' => [],
             'Expire' => 1234,
             'LogoutState' => 'logoutState',
-            'AuthInstant' => 123456,
+            'AuthnInstant' => 123456,
             'RememberMe' => true,
             'saml:sp:NameID' => 'nameID',
         ];


### PR DESCRIPTION
The time of authentication is handled in the field 'AuthnInstant' and should be persisted in the state in case it is needed.

This PR fixes a typo in a key reference for the field 'AuthnInstant'.

Since these kind of typos can happen quite unnoticed, we should consider using constants to refer to array keys.
Any thoughts about it?