### PR TITLE
Draft: Another way to return a 405 if calling SSO with HEAD req.

### DIFF
--- a/modules/saml/routing/routes/routes.yml
+++ b/modules/saml/routing/routes/routes.yml
@@ -64,6 +64,13 @@ saml-legacy-sp-metadata:
   }
   methods: [GET]
 
+websso-single-sign-on-head:
+  path: /idp/singleSignOnService
+  defaults: {
+    _controller: 'SimpleSAML\Module\saml\Controller\WebBrowserSingleSignOn::headRequestNotAllowed'
+  }
+  methods: [HEAD]
+  
 websso-single-sign-on:
   path: /idp/singleSignOnService
   defaults: {

--- a/modules/saml/src/Controller/WebBrowserSingleSignOn.php
+++ b/modules/saml/src/Controller/WebBrowserSingleSignOn.php
@@ -20,6 +20,9 @@ use SimpleSAML\Logger;
 use SimpleSAML\Metadata;
 use SimpleSAML\Module;
 use SimpleSAML\Store\StoreFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
 
 /**
  * Controller class for the Web Browser Single Sign On profile.
@@ -107,6 +110,23 @@ class WebBrowserSingleSignOn
         return new RunnableResponse([$binding, 'send'], [$artifactResponse]);
     }
 
+    public function headRequestNotAllowed(): RunnableResponse
+    {
+        Logger::info('Handling a HEAD request by returning method not allowed...');
+        
+        $request = Request::createFromGlobals();
+
+        // These are the allowed methods from routes.yml
+        $allowedMethods = ['GET', 'POST'];
+        $message = sprintf(
+            'No route found for "%s %s": Method Not Allowed (Allow: %s)',
+            $request->getMethod(),
+            $request->getUriForPath($request->getPathInfo()),
+            implode(', ', $allowedMethods)
+        );
+
+        throw new MethodNotAllowedHttpException($allowedMethods, $message);
+    }
 
     /**
      * The SSOService is part of the SAML 2.0 IdP code, and it receives incoming Authentication Requests


### PR DESCRIPTION
This relates to https://github.com/simplesamlphp/simplesamlphp/pull/2475

To play with this, goto admin/test and login with an authentication source. Harvest the SignOnService full link from the web console.

Test on the console with the following...
```
$  curl --insecure -I -X HEAD  'https://fqdn/sspdev/module.php/saml/idp/singleSignOnService?SAMLRequest=...'
HTTP/1.1 405 Method Not Allowed

$  curl --insecure -I -X GET   'https://fqdn/sspdev/module.php/saml/idp/singleSignOnService?SAMLRequest=...'
HTTP/1.1 303 See Other
```

I was also experimenting with rejecting HEAD requests for all single idp lookups with the following. This seems to work but you also loose the ability to get a 404 for links which will never actually work. eg `singleSignOnServiceFOO?SAMLRequest=` will just give a 405 if you wildcard with the below.

```
websso-idp-head:
  path: /idp/{methodname}
  controller: 'SimpleSAML\Module\saml\Controller\WebBrowserSingleSignOn::headRequestNotAllowed'
  defaults:
    methodname: 1  
  methods: [HEAD]
```