### PR TITLE
Allow "Secure" cookie attribute via HTTP on localhost

### DIFF
--- a/src/SimpleSAML/SessionHandler.php
+++ b/src/SimpleSAML/SessionHandler.php
@@ -164,7 +164,7 @@ abstract class SessionHandler
             'lifetime' => $config->getOptionalInteger('session.cookie.lifetime', 0),
             'path'     => $config->getOptionalString('session.cookie.path', '/'),
             'domain'   => $config->getOptionalString('session.cookie.domain', null),
-            'secure'   => $config->getOptionalBoolean('session.cookie.secure', $httpUtils->isHTTPS()),
+            'secure'   => $config->getOptionalBoolean('session.cookie.secure', $httpUtils->isSecureCookieAllowed()),
             'samesite' => $config->getOptionalString('session.cookie.samesite', null),
             'httponly' => true,
         ];

--- a/src/SimpleSAML/SessionHandlerPHP.php
+++ b/src/SimpleSAML/SessionHandlerPHP.php
@@ -206,8 +206,8 @@ class SessionHandlerPHP extends SessionHandler
         $session_cookie_params = session_get_cookie_params();
 
         $httpUtils = new Utils\HTTP();
-        if ($session_cookie_params['secure'] && !$httpUtils->isHTTPS()) {
-            throw new Error\Exception('Session start with secure cookie not allowed on http.');
+        if ($session_cookie_params['secure'] && !$httpUtils->isSecureCookieAllowed()) {
+            throw new Error\Exception('Session start with secure cookie not allowed on http (except on localhost).');
         }
 
         @session_start();
@@ -338,9 +338,9 @@ class SessionHandlerPHP extends SessionHandler
         }
 
         $httpUtils = new Utils\HTTP();
-        if ($cookieParams['secure'] && !$httpUtils->isHTTPS()) {
+        if ($cookieParams['secure'] && !$httpUtils->isSecureCookieAllowed()) {
             throw new Error\CannotSetCookie(
-                'Setting secure cookie on plain HTTP is not allowed.',
+                'Setting secure cookie on plain HTTP (except on localhost) is not allowed.',
                 Error\CannotSetCookie::SECURE_COOKIE,
             );
         }

--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -1188,7 +1188,7 @@ class HTTP
      */
     public function isSecureCookieAllowed(): bool
     {
-        return $this->isHTTPS() || in_array($this->getSelfHost(), ['localhost', '127.0.0.1', '::1'], true));
+        return $this->isHTTPS() || in_array($this->getSelfHost(), ['localhost', '127.0.0.1', '::1'], true);
     }
 
 

--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -1116,15 +1116,15 @@ class HTTP
             $params = $default_params;
         }
 
-        // Do not set secure cookie if not on HTTPS
-        if ($params['secure'] && !$this->isHTTPS()) {
+        // Do not set secure cookie if not on HTTPS or localhost
+        if ($params['secure'] && !$this->isSecureCookieAllowed()) {
             if ($throw) {
                 throw new Error\CannotSetCookie(
-                    'Setting secure cookie on plain HTTP is not allowed.',
+                    'Setting secure cookie on plain HTTP (except on localhost) is not allowed.',
                     Error\CannotSetCookie::SECURE_COOKIE,
                 );
             }
-            Logger::warning('Error setting cookie: setting secure cookie on plain HTTP is not allowed.');
+            Logger::warning('Error setting cookie: setting secure cookie on plain HTTP (except on localhost) is not allowed.');
             return;
         }
 
@@ -1178,6 +1178,17 @@ class HTTP
             }
             Logger::warning('Error setting cookie: headers already sent.');
         }
+    }
+
+
+    /**
+     * Check if "Secure" attribute on cookies is supported
+     *
+     * @return boolean True "Secure" attribute can be set, false otherwise.
+     */
+    public function isSecureCookieAllowed(): bool
+    {
+        return $this->isHTTPS() || $this->getSelfHost() === 'localhost';
     }
 
 

--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -1188,7 +1188,7 @@ class HTTP
      */
     public function isSecureCookieAllowed(): bool
     {
-        return $this->isHTTPS() || $this->getSelfHost() === 'localhost';
+        return $this->isHTTPS() || in_array($this->getSelfHost(), ['localhost', '127.0.0.1', '::1'], true));
     }
 
 


### PR DESCRIPTION
According to [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#secure), `Secure` attribute should be allowed on localhost even if HTTP is used.

It makes testing a little easier.

My only doubt is about "localhost" vs "127.0.0.1" should both be allowed or only the former?