### PR TITLE
Require xml-common:^1.24.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "simplesamlphp/saml2": "^5.0.0",
         "simplesamlphp/saml2-legacy": "^4.18.1",
         "simplesamlphp/simplesamlphp-assets-base": "~2.3.0",
+        "simplesamlphp/xml-common": "^1.24.2",
         "simplesamlphp/xml-security": "^1.7",
         "symfony/cache": "^6.4",
         "symfony/config": "^6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b0c0ad16505f7f68450544c69b2e8c8",
+    "content-hash": "3b3959487c032fcc02f83769ff84cb67",
     "packages": [
         {
             "name": "gettext/gettext",


### PR DESCRIPTION
In `SimpleSAML\Utils\Time::parseDuration()` we call `SimpleSAML\XML\Assert::validDuration()`.\
This is only available since `simplesamlphp/xml-common:1.24.2`.

Currently there is no explicit requirement for `simplesamlphp/xml-common`, it is only pulled in as an indirect dependency.\
There could be other version constraints in a project that cause `simplesamlphp/xml-common` to be downgraded to something less than 1.24.2.

It is generally best practice to explicitly require things we use directly.

(I open this PR for 2.4.x, but maybe you want it somewhere else and then backport, up to you)