### PR TITLE
Consider it an error if session.check_function can not be called

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -20,6 +20,7 @@ Released TBD
 * Allow "Secure" cookie attribute via HTTP on localhost (#2483)
 * Fix override over errorURL
 * Introduced a new assets.salt to allow cache busting without leaking version information (#2490)
+* If session.check_function is set and can not be called a log message will be generated (#2498)
 
 ## Version 2.4.2
 

--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -20,7 +20,7 @@ Released TBD
 * Allow "Secure" cookie attribute via HTTP on localhost (#2483)
 * Fix override over errorURL
 * Introduced a new assets.salt to allow cache busting without leaking version information (#2490)
-* If session.check_function is set and can not be called a log message will be generated (#2498)
+* If session.check_function is set and can not be called an error is raised (#2498)
 
 ## Version 2.4.2
 

--- a/src/SimpleSAML/Session.php
+++ b/src/SimpleSAML/Session.php
@@ -182,6 +182,9 @@ class Session implements Utils\ClearableState
             $checkFunction = self::$config->getOptionalValue('session.check_function', null);
             if (is_callable($checkFunction)) {
                 call_user_func($checkFunction, $this, true);
+            } else {
+                Logger::error('Configuration error: session.check_function'
+                            . ' is defined but is not callable by SimpleSAMLphp.');
             }
         }
     }
@@ -376,6 +379,9 @@ class Session implements Utils\ClearableState
                     Logger::warning('Session did not pass check function.');
                     return null;
                 }
+            } else {
+                Logger::error('Configuration error: session.check_function'
+                            . ' is defined but is not callable by SimpleSAMLphp');
             }
         }
 

--- a/src/SimpleSAML/Session.php
+++ b/src/SimpleSAML/Session.php
@@ -180,11 +180,10 @@ class Session implements Utils\ClearableState
 
             // initialize data for session check function if defined
             $checkFunction = self::$config->getOptionalValue('session.check_function', null);
-            if (is_callable($checkFunction)) {
+            if($checkFunction) {
+                Assert::isCallable($checkFunction,
+                                   'Configuration error: session.check_function is not callable');
                 call_user_func($checkFunction, $this, true);
-            } else {
-                Logger::error('Configuration error: session.check_function'
-                            . ' is defined but is not callable by SimpleSAMLphp.');
             }
         }
     }
@@ -373,15 +372,14 @@ class Session implements Utils\ClearableState
 
             // run session check function if defined
             $checkFunction = $globalConfig->getOptionalValue('session.check_function', null);
-            if (is_callable($checkFunction)) {
+            if($checkFunction) {
+                Assert::isCallable($checkFunction,
+                                   'Configuration error: session.check_function is not callable');
                 $check = call_user_func($checkFunction, $session);
                 if ($check !== true) {
                     Logger::warning('Session did not pass check function.');
                     return null;
                 }
-            } else {
-                Logger::error('Configuration error: session.check_function'
-                            . ' is defined but is not callable by SimpleSAMLphp');
             }
         }
 

--- a/src/SimpleSAML/Session.php
+++ b/src/SimpleSAML/Session.php
@@ -180,9 +180,11 @@ class Session implements Utils\ClearableState
 
             // initialize data for session check function if defined
             $checkFunction = self::$config->getOptionalValue('session.check_function', null);
-            if($checkFunction) {
-                Assert::isCallable($checkFunction,
-                                   'Configuration error: session.check_function is not callable');
+            if ($checkFunction) {
+                Assert::isCallable(
+                    $checkFunction,
+                    'Configuration error: session.check_function is not callable',
+                );
                 call_user_func($checkFunction, $this, true);
             }
         }
@@ -372,9 +374,11 @@ class Session implements Utils\ClearableState
 
             // run session check function if defined
             $checkFunction = $globalConfig->getOptionalValue('session.check_function', null);
-            if($checkFunction) {
-                Assert::isCallable($checkFunction,
-                                   'Configuration error: session.check_function is not callable');
+            if ($checkFunction) {
+                Assert::isCallable(
+                    $checkFunction,
+                    'Configuration error: session.check_function is not callable',
+                );
                 $check = call_user_func($checkFunction, $session);
                 if ($check !== true) {
                     Logger::warning('Session did not pass check function.');


### PR DESCRIPTION
If the user configuration includes a definition of the check_function we should not silently ignore it if we can not call it. Consider for example if the admin is using that to reject or drop a session for a group of nefarious users. They would rather know that the function is not callable than assume everything is ok. This could happen after initial testing for example if the function is in a module that was not enabled during an upgrade etc.

My main doubt here is that it could cause error messages to appear during a 2.4 series update. But then it will only happen if there is an existing error in config.php. 
