### PR TITLE
Add ProfileAuth authsource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,4 @@ typings/
 
 # dotenv environment variables file
 .env
+cache

--- a/modules/core/src/Auth/UserPassBase.php
+++ b/modules/core/src/Auth/UserPassBase.php
@@ -250,7 +250,7 @@ abstract class UserPassBase extends Auth\Source
         $httpUtils->redirectTrustedURL($url, $params);
 
         // The previous function never returns, so this code is never executed.
-        assert::true(false);
+        Assert::true(false);
     }
 
 

--- a/modules/exampleauth/public/assets/css/default.css
+++ b/modules/exampleauth/public/assets/css/default.css
@@ -1,0 +1,23 @@
+h2 {
+    margin-bottom: 0;
+}
+
+h2:hover {
+    margin-bottom: 0;
+}
+
+a {
+    text-decoration: unset;
+}
+
+a:hover {
+    color: unset;
+}
+
+table.profile {
+    font-size: smaller;
+}
+
+.profile td.key {
+    padding-right: 10px;
+}

--- a/modules/exampleauth/routing/routes/routes.yml
+++ b/modules/exampleauth/routing/routes/routes.yml
@@ -20,3 +20,10 @@ exampleauth-resume:
     _controller: 'SimpleSAML\Module\exampleauth\Controller\ExampleAuth::resume'
   }
   methods: [GET]
+
+profileauth-login:
+  path: /profileauth
+  defaults: {
+    _controller: 'SimpleSAML\Module\exampleauth\Controller\ProfileAuth::login'
+  }
+  methods: [GET, POST]

--- a/modules/exampleauth/src/Auth/Source/UserClick.php
+++ b/modules/exampleauth/src/Auth/Source/UserClick.php
@@ -147,8 +147,7 @@ class UserClick extends Auth\Source
      *
      * Note that both the username and the password are UTF-8 encoded.
      *
-     * @param int $id  The username the user wrote.
-     * @param string $password  The password the user wrote.
+     * @param int $id  The userprofile the user clicked on.
      * @return array  Associative array with the users attributes.
      */
     protected function login(int $id): array

--- a/modules/exampleauth/src/Auth/Source/UserClick.php
+++ b/modules/exampleauth/src/Auth/Source/UserClick.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\exampleauth\Auth\Source;
+
+use Exception;
+use SAML2\Constants;
+use SimpleSAML\Auth;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Error;
+use SimpleSAML\Logger;
+use SimpleSAML\Module;
+use SimpleSAML\Utils;
+use Symfony\Component\HttpFoundation\{Request, Response};
+
+/**
+ * Profileauth authentication source.
+ *
+ * This class is an authentication source which stores all users in an array,
+ * and authenticates users by clicking on their name.
+ *
+ * @package SimpleSAMLphp
+ */
+
+class UserClick extends Auth\Source
+{
+    /**
+     * The string used to identify our states.
+     */
+    public const STAGEID = '\SimpleSAML\Module\exampleauth\Auth\UserClick.state';
+
+    /**
+     * The key of the AuthId field in the state.
+     */
+    public const AUTHID = '\SimpleSAML\Module\exampleauth\Auth\UserClick.AuthId';
+
+    /**
+     * Our users, stored in an associative array. The key of the array is "<id>",
+     * while the value of each element is a new array with the attributes for each user.
+     *
+     * @var array
+     */
+    public array $users = [];
+
+    protected function getUsers($config) {
+        $users = [];
+
+        // Validate and parse our configuration
+        foreach ($config as $id => $attributes) {
+            $attrUtils = new Utils\Attributes();
+
+            try {
+                $attributes = $attrUtils->normalizeAttributesArray($attributes);
+            } catch (Exception $e) {
+                throw new Exception('Invalid attributes for user ' . $id .
+                    ' in authentication source ' . $this->authId . ': ' . $e->getMessage());
+            }
+            $users[$id] = $attributes;
+        }
+        return $users;
+    }
+
+    /**
+     * Constructor for this authentication source.
+     *
+     * @param array $info  Information about this authentication source.
+     * @param array $config  Configuration.
+     */
+    public function __construct(array $info, array $config)
+    {
+        // Call the parent constructor first, as required by the interface
+        parent::__construct($info, $config);
+
+        if (array_key_exists('users', $config)) {
+            $users = $config['users'];
+        } else {
+            Logger::warning("Module exampleauth:UserClick misconfigured." .
+                "Put users in 'users' key in your authsource.");
+            throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
+        }
+
+        $this->users = $this->getUsers($users);
+
+    }
+
+    /**
+     * Initialize login.
+     *
+     * This function saves the information about the login, and redirects to a
+     * login page.
+     *
+     * @param array &$state  Information about the current authentication.
+     */
+    public function authenticate(array &$state): void
+    {
+        /*
+         * Save the identifier of this authentication source, so that we can
+         * retrieve it later. This allows us to call the login()-function on
+         * the current object.
+         */
+        $state[self::AUTHID] = $this->authId;
+
+        // Save the $state-array, so that we can restore it after a redirect
+        $id = Auth\State::saveState($state, self::STAGEID);
+
+        /*
+         * If there is only one user configured, skip the persona chooser
+         */
+        if (count($this->users) == 1) {
+            $this->handleLogin($id, 0);
+        }
+
+        /*
+         * Redirect to the login form. We include the identifier of the saved
+         * state array as a parameter to the login form.
+         */
+        $url = Module::getModuleURL('exampleauth/profileauth');
+        $params = ['AuthState' => $id];
+        $httpUtils = new Utils\HTTP();
+        $httpUtils->redirectTrustedURL($url, $params);
+
+        // The previous function never returns, so this code is never executed.
+        assert::true(false);
+    }
+
+
+    /**
+     * Attempt to log in using the given user id.
+     *
+     * On a successful login, this function should return the users attributes. On failure,
+     * it should throw an exception. If the error was caused by the user entering the wrong
+     * username or password, a \SimpleSAML\Error\Error(\SimpleSAML\Error\ErrorCodes::WRONGUSERPASS) should be thrown.
+     *
+     * Note that both the username and the password are UTF-8 encoded.
+     *
+     * @param int $id  The username the user wrote.
+     * @param string $password  The password the user wrote.
+     * @return array  Associative array with the users attributes.
+     */
+    protected function login(int $id): array
+    {
+        if (!array_key_exists($id, $this->users)) {
+            throw new Error\Error(Error\ErrorCodes::WRONGUSERPASS);
+        }
+
+        return $this->users[$id];
+    }
+
+    /**
+     * Handle login request.
+     *
+     * This function is used by the login form (exampleauth/login) when the user
+     * enters a username and password. On success, it will not return. On wrong
+     * username/password failure, and other errors, it will throw an exception.
+     *
+     * @param string $authStateId  The identifier of the authentication state.
+     * @param string $id  The username the user wrote.
+     */
+    public static function handleLogin(string $authStateId, int $id): void
+    {
+        // Here we retrieve the state array we saved in the authenticate-function.
+        $state = Auth\State::loadState($authStateId, self::STAGEID);
+
+        // Retrieve the authentication source we are executing.
+        Assert::keyExists($state, self::AUTHID);
+
+        /** @var \SimpleSAML\Module\exampleauth\Auth\Source\UserClick|null $source */
+        $source = Auth\Source::getById($state[self::AUTHID]);
+        if ($source === null) {
+            throw new \Exception('Could not find authentication source with id ' . $state[self::AUTHID]);
+        }
+
+        /*
+         * $source now contains the authentication source on which authenticate()
+         * was called. We should call login() on the same authentication source.
+         */
+
+        // Attempt to log in
+        try {
+            $attributes = $source->login($id);
+        } catch (\Exception $e) {
+            Logger::stats('Unsuccessful login attempt from ' . $_SERVER['REMOTE_ADDR'] . '.');
+            throw $e;
+        }
+
+        Logger::stats('User \'' . $id . '\' successfully authenticated from ' . $_SERVER['REMOTE_ADDR']);
+
+        // Save the attributes we received from the login-function in the $state-array
+        $state['Attributes'] = $attributes;
+
+        // Return control to SimpleSAMLphp after successful authentication.
+        Auth\Source::completeAuth($state);
+    }
+
+
+}

--- a/modules/exampleauth/src/Controller/ProfileAuth.php
+++ b/modules/exampleauth/src/Controller/ProfileAuth.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\exampleauth\Controller;
+
+use Exception as BuiltinException;
+use SimpleSAML\{Auth, Configuration, Error, Module, Utils};
+use SimpleSAML\Module\exampleauth\Auth\Source\UserClick;
+use SimpleSAML\XHTML\Template;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use SimpleSAML\Logger;
+
+use function array_key_exists;
+use function substr;
+use function time;
+use function trim;
+
+/**
+ * Controller class for the login module.
+ *
+ * This class serves the different views available in the module.
+ *
+ * @package SimpleSAML\Module\login
+ */
+class ProfileAuth
+{
+    /**
+     * @var \SimpleSAML\Auth\Source|string
+     * @psalm-var \SimpleSAML\Auth\Source|class-string
+     */
+    protected $authSource = Auth\Source::class;
+
+    /**
+     * @var \SimpleSAML\Auth\State|string
+     * @psalm-var \SimpleSAML\Auth\State|class-string
+     */
+    protected $authState = Auth\State::class;
+
+    /**
+     * Controller constructor.
+     *
+     * It initializes the global configuration for the controllers implemented here.
+     *
+     * @param \SimpleSAML\Configuration              $config The configuration to use by the controllers.
+     *
+     * @throws \Exception
+     */
+    public function __construct(
+        protected Configuration $config
+    ) {
+    }
+
+    /**
+     * This page shows a list of users, and passes information from it
+     * to the \SimpleSAML\Module\exampleauth\Auth\UserClick class, which is a class for
+     * user authentication.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     */
+    public function login(Request $request): Response
+    {
+        // Retrieve the authentication state
+        if (!$request->query->has('AuthState')) {
+            throw new Error\BadRequest('Missing AuthState parameter.');
+        }
+        $authStateId = $request->query->get('AuthState');
+        $this->authState::validateStateId($authStateId);
+
+        $state = $this->authState::loadState($authStateId, UserClick::STAGEID);
+
+        /** @var \SimpleSAML\Module\exampleauth\Auth\UserClick|null $source */
+        $source = $this->authSource::getById($state[UserClick::AUTHID]);
+        if ($source === null) {
+            throw new BuiltinException(
+                'Could not find authentication source with id ' . $state[UserClick::AUTHID]
+            );
+        }
+
+        return $this->handleLogin($request, $source, $state);
+    }
+
+
+    /**
+     * This method handles the generic part for both login and loginuserpassorg
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \SimpleSAML\Module\exampleauth\Auth\UserClick $source
+     * @param array $state
+     */
+    private function handleLogin(Request $request, UserClick $source, array $state): Response
+    {
+        $authStateId = $request->query->get('AuthState');
+        $this->authState::validateStateId($authStateId);
+
+        $organizations = $organization = null;
+
+        $id = $this->getIDFromRequest($request, $source, $state);
+
+        $errorCode = null;
+        $errorParams = null;
+
+        if (isset($state['error'])) {
+            $errorCode = $state['error']['code'];
+            $errorParams = $state['error']['params'];
+        }
+
+        $cookies = [];
+        if ($id !== '') {
+            $httpUtils = new Utils\HTTP();
+            $sameSiteNone = $httpUtils->canSetSamesiteNone() ? Cookie::SAMESITE_NONE : null;
+
+            try {
+                UserClick::handleLogin($authStateId, (int)$id);
+            } catch (Error\Error $e) {
+                // Login failed. Extract error code and parameters, to display the error
+                $errorCode = $e->getErrorCode();
+                $errorParams = $e->getParameters();
+                $state['error'] = [
+                    'code' => $errorCode,
+                    'params' => $errorParams
+                ];
+                $authStateId = Auth\State::saveState($state, $source::STAGEID);
+            }
+
+            if (isset($state['error'])) {
+                unset($state['error']);
+            }
+        }
+
+        $t = new Template($this->config, 'exampleauth:userclick.twig');
+
+        $t->data['users'] = $source->users;
+        $t->data['formURL'] = Module::getModuleURL('exampleauth/profileauth', ['AuthState' => $authStateId]);
+
+        $t->data['errorcode'] = $errorCode;
+        $t->data['errorcodes'] = Error\ErrorCodes::getAllErrorCodeMessages();
+        $t->data['errorparams'] = $errorParams;
+
+        if (isset($state['SPMetadata'])) {
+            $t->data['SPMetadata'] = $state['SPMetadata'];
+        } else {
+            $t->data['SPMetadata'] = null;
+        }
+
+        foreach ($cookies as $cookie) {
+            $t->headers->setCookie($cookie);
+        }
+
+        return $t;
+    }
+
+    /**
+     * Retrieve the username from the request, a cookie or the state
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \SimpleSAML\Auth\Source $source
+     * @param array $state
+     * @return string
+     */
+    private function getIDFromRequest(Request $request, Auth\Source $source, array $state): string
+    {
+        $id = '';
+
+        if ($request->query->has('id')) {
+            $id = trim($request->query->get('id'));
+        } elseif (isset($state['exampleauth:id'])) {
+            $id = strval($state['exampleauth:id']);
+        }
+
+        return $id;
+    }
+
+}

--- a/modules/exampleauth/src/Controller/ProfileAuth.php
+++ b/modules/exampleauth/src/Controller/ProfileAuth.php
@@ -8,9 +8,7 @@ use Exception as BuiltinException;
 use SimpleSAML\{Auth, Configuration, Error, Module, Utils};
 use SimpleSAML\Module\exampleauth\Auth\Source\UserClick;
 use SimpleSAML\XHTML\Template;
-use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\{Request, Response};
 
 use function trim;
 
@@ -106,11 +104,7 @@ class ProfileAuth
             $errorParams = $state['error']['params'];
         }
 
-        $cookies = [];
         if ($id !== '') {
-            $httpUtils = new Utils\HTTP();
-            $sameSiteNone = $httpUtils->canSetSamesiteNone() ? Cookie::SAMESITE_NONE : null;
-
             try {
                 UserClick::handleLogin($authStateId, (int)$id);
             } catch (Error\Error $e) {
@@ -142,10 +136,6 @@ class ProfileAuth
             $t->data['SPMetadata'] = $state['SPMetadata'];
         } else {
             $t->data['SPMetadata'] = null;
-        }
-
-        foreach ($cookies as $cookie) {
-            $t->headers->setCookie($cookie);
         }
 
         return $t;

--- a/modules/exampleauth/src/Controller/ProfileAuth.php
+++ b/modules/exampleauth/src/Controller/ProfileAuth.php
@@ -92,8 +92,6 @@ class ProfileAuth
         $authStateId = $request->query->get('AuthState');
         $this->authState::validateStateId($authStateId);
 
-        $organizations = $organization = null;
-
         $id = $this->getIDFromRequest($request, $source, $state);
 
         $errorCode = null;

--- a/modules/exampleauth/src/Controller/ProfileAuth.php
+++ b/modules/exampleauth/src/Controller/ProfileAuth.php
@@ -11,11 +11,7 @@ use SimpleSAML\XHTML\Template;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use SimpleSAML\Logger;
 
-use function array_key_exists;
-use function substr;
-use function time;
 use function trim;
 
 /**
@@ -39,19 +35,21 @@ class ProfileAuth
      */
     protected $authState = Auth\State::class;
 
+
     /**
      * Controller constructor.
      *
      * It initializes the global configuration for the controllers implemented here.
      *
-     * @param \SimpleSAML\Configuration              $config The configuration to use by the controllers.
+     * @param \SimpleSAML\Configuration $config The configuration to use by the controllers.
      *
      * @throws \Exception
      */
     public function __construct(
-        protected Configuration $config
+        protected Configuration $config,
     ) {
     }
+
 
     /**
      * This page shows a list of users, and passes information from it
@@ -66,6 +64,7 @@ class ProfileAuth
         if (!$request->query->has('AuthState')) {
             throw new Error\BadRequest('Missing AuthState parameter.');
         }
+
         $authStateId = $request->query->get('AuthState');
         $this->authState::validateStateId($authStateId);
 
@@ -75,7 +74,7 @@ class ProfileAuth
         $source = $this->authSource::getById($state[UserClick::AUTHID]);
         if ($source === null) {
             throw new BuiltinException(
-                'Could not find authentication source with id ' . $state[UserClick::AUTHID]
+                'Could not find authentication source with id ' . $state[UserClick::AUTHID],
             );
         }
 
@@ -120,7 +119,7 @@ class ProfileAuth
                 $errorParams = $e->getParameters();
                 $state['error'] = [
                     'code' => $errorCode,
-                    'params' => $errorParams
+                    'params' => $errorParams,
                 ];
                 $authStateId = Auth\State::saveState($state, $source::STAGEID);
             }
@@ -152,6 +151,7 @@ class ProfileAuth
         return $t;
     }
 
+
     /**
      * Retrieve the username from the request, a cookie or the state
      *
@@ -172,5 +172,4 @@ class ProfileAuth
 
         return $id;
     }
-
 }

--- a/modules/exampleauth/src/Controller/ProfileAuth.php
+++ b/modules/exampleauth/src/Controller/ProfileAuth.php
@@ -126,7 +126,12 @@ class ProfileAuth
         $t = new Template($this->config, 'exampleauth:userclick.twig');
 
         $t->data['users'] = $source->users;
-        $t->data['formURL'] = Module::getModuleURL('exampleauth/profileauth', ['AuthState' => $authStateId]);
+        $userlinks = [];
+        foreach ($source->users as $id => $attr) {
+            $userlinks[$id] = Module::getModuleURL('exampleauth/profileauth', ['AuthState' => $authStateId,
+                                                                               "id" => $id ]);
+        }
+        $t->data['usersLinks'] = $userlinks;
 
         $t->data['errorcode'] = $errorCode;
         $t->data['errorcodes'] = Error\ErrorCodes::getAllErrorCodeMessages();

--- a/modules/exampleauth/templates/userclick.twig
+++ b/modules/exampleauth/templates/userclick.twig
@@ -1,0 +1,63 @@
+{% set pagetitle = 'Continue as persona' %}
+
+{% extends "@core/base.twig" %}
+
+{% block preload %}
+    <link rel="stylesheet" href="{{ asset('css/default.css', 'exampleauth') }}">
+{% endblock %}
+
+{% block content %}
+    {%- if not isProduction %}
+
+    <div class="message-box warning">
+      {% trans %}You are now accessing a pre-production system. This authentication setup is for testing and pre-production verification only. If someone sent you a link that pointed you here, and you are not <i>a tester</i> you probably got the wrong link, and should <b>not be here</b>.{% endtrans %}
+    </div>
+    {% endif -%}
+    {% if errorcode -%}
+    <div class="pure-g">
+        <div class="pure-u-1">
+            <div class="message-box error">
+
+                {% set errtitles = errorcodes['title'] %}
+                {% set errtitle = errtitles[errorcode] %}
+
+                <h3>{{ errtitle|trans(errorparams) }}</h3>
+
+                {% set errdescs = errorcodes['descr'] %}
+                {% set errdesc = errdescs[errorcode] %}
+
+                <p>{{ errdesc|trans(errorparams) }}</p>
+
+            </div>
+        </div>
+    </div>
+    {%- endif %}
+
+    <p><b>{{ 'Continue as persona' }}</b></p>
+
+    {% for id, attributes in users %}
+    <a href="{{formURL}}&id={{ id }}">
+    <div>
+    <h2>
+        {{ attributes['displayName'][0] }}
+    </h2>
+    <table class="profile">
+    <tbody>
+        {%- for key, values in attributes %}
+        <tr>
+            <td class=key>
+                <b>{{ key }}</b>
+            </td>
+            <td>
+                {%- for value in values %}
+                {{ value }}<br>
+                {%- endfor %}
+            </td>
+            {%- endfor %}
+        </tr>
+    </tbody>
+    </table>
+    </a>
+    {%- endfor %}
+
+{% endblock %}

--- a/modules/exampleauth/templates/userclick.twig
+++ b/modules/exampleauth/templates/userclick.twig
@@ -36,7 +36,7 @@
     <p><b>{{ 'Continue as persona' }}</b></p>
 
     {% for id, attributes in users %}
-    <a href="{{formURL}}&id={{ id }}">
+    <a href="{{ usersLinks[id] }}">
     <div>
     <h2>
         {{ attributes['displayName'][0] }}

--- a/modules/multiauth/src/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/src/Auth/Source/MultiAuth.php
@@ -6,7 +6,6 @@ namespace SimpleSAML\Module\multiauth\Auth\Source;
 
 use Exception;
 use SAML2\Exception\Protocol\NoAuthnContextException;
-use SimpleSAML\Assert\Assert;
 use SimpleSAML\Auth;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error;
@@ -94,7 +93,7 @@ class MultiAuth extends Auth\Source
      *
      * @param array &$state Information about the current authentication.
      */
-    public function authenticate(array &$state): void
+    public function authenticate(array &$state): never
     {
         $state[self::AUTHID] = $this->authId;
         $state[self::SOURCESID] = $this->sources;
@@ -145,9 +144,6 @@ class MultiAuth extends Auth\Source
 
         $httpUtils = new Utils\HTTP();
         $httpUtils->redirectTrustedURL($url, $params);
-
-        // The previous function never returns, so this code is never executed
-        Assert::true(false);
     }
 
 

--- a/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
+++ b/tests/modules/multiauth/src/Controller/DiscoControllerTest.php
@@ -128,7 +128,7 @@ class DiscoControllerTest extends TestCase
                 // stub
             }
 
-            public function authenticate(array &$state): void
+            public function authenticate(array &$state): never
             {
                 // stub
             }
@@ -182,7 +182,7 @@ class DiscoControllerTest extends TestCase
                 // stub
             }
 
-            public function authenticate(array &$state): void
+            public function authenticate(array &$state): never
             {
                 // stub
             }
@@ -238,7 +238,7 @@ class DiscoControllerTest extends TestCase
                 // stub
             }
 
-            public function authenticate(array &$state): void
+            public function authenticate(array &$state): never
             {
                 // stub
             }
@@ -294,7 +294,7 @@ class DiscoControllerTest extends TestCase
                 // stub
             }
 
-            public function authenticate(array &$state): void
+            public function authenticate(array &$state): never
             {
                 // stub
             }
@@ -348,7 +348,7 @@ class DiscoControllerTest extends TestCase
                 // stub
             }
 
-            public function authenticate(array &$state): void
+            public function authenticate(array &$state): never
             {
                 // stub
             }


### PR DESCRIPTION
A new authsource that lets user choose preconfigured profiles from a list.

authsources.php:
```
    'profileauth' => [
        'exampleauth:UserClick',
        'users' => [
            [
                'uid' => ['student'],
                'displayName' => ['Student'],
                'eduPersonAffiliation' => ['student', 'member'],
            ],
            [
                'uid' => ['employee'],
                'displayName' => ['Employee'],
                'eduPersonAffiliation' => ['employee', 'member'],
            ],
        ],
    ],
```

If only one user is configured, the profile chooser will be skipped and login is automatic.