### PR TITLE
Update FontAwesome icon names

### DIFF
--- a/modules/admin/templates/federation.twig
+++ b/modules/admin/templates/federation.twig
@@ -55,7 +55,7 @@
                 <a class="pure-button copy hljs" data-clipboard-target="#url-{{ key }}"
                    title="{% trans %}Copy to clipboard{% endtrans %}"><span class="fa fa-copy"></span></a>
                 <a class="pure-button hljs" href="{{ set.url }}">
-                  <span class="fa fa-external-link-square-alt"></span>
+                  <span class="fa fa-square-arrow-up-right"></span>
                 </a>
               </div>
               <code id="url-{{ key }}" class="code-box-content">{{ set.url }}</code>

--- a/modules/core/templates/logout-iframe.twig
+++ b/modules/core/templates/logout-iframe.twig
@@ -37,11 +37,11 @@
     {%- for key, sp in remaining_services %}
       {%- set timeout = 5 %}
       {%- set name = sp['metadata']|entityDisplayName %}
-      {%- set icon = 'circle-o-notch'  %}
+      {%- set icon = 'circle-notch'  %}
       {%- if sp['status'] == 'completed' %}
-        {%- set icon = 'check-circle' %}
+        {%- set icon = 'circle-check' %}
       {%- elseif sp['status'] == 'failed' %}
-        {%- set icon = 'exclamation-circle' %}
+        {%- set icon = 'circle-exclamation' %}
         {%- set failed = true %}
       {%- elseif (sp['status'] == 'onhold' or sp['status'] == 'inprogress') %}
         {%- set remaining = remaining + 1 %}


### PR DESCRIPTION
A few of the Twig templates still have old FontAwesome 4 icon names. While these are mostly backwards compatible still, at least one used in the logout-iframe.twig has gone completely (circle-o-notch) resulting in a broken display.

This updates the names to the version 6+ naming per https://docs.fontawesome.com/v6/web/setup/upgrade/whats-changed#icons-renamed-in-version-6