### PR TITLE
disable showerrors by default

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -343,7 +343,7 @@ $config = [
      * When 'errorreporting' is enabled, a form will be presented for the user to report
      * the error to 'technicalcontact_email'.
      */
-    'showerrors' => true,
+    'showerrors' => false,
     'errorreporting' => true,
 
     /*

--- a/src/SimpleSAML/Error/Error.php
+++ b/src/SimpleSAML/Error/Error.php
@@ -253,7 +253,7 @@ class Error extends Exception
         $config = Configuration::getInstance();
 
         $data = [];
-        $data['showerrors'] = $config->getOptionalBoolean('showerrors', true);
+        $data['showerrors'] = $config->getOptionalBoolean('showerrors', false);
         $data['error'] = $errorData;
         $data['errorCode'] = $this->errorCode;
         $data['parameters'] = $this->parameters;


### PR DESCRIPTION
SimpleSAMLphp has `showerrors` enabled by default.

```
     * When 'showerrors' is enabled, all error messages and stack traces will be output
     * to the browser.
```

Although this is no doubt convenient at times, it's risky from a security point of view. See, for example:

https://owasp.org/www-community/Improper_Error_Handling

> The most common problem is when detailed internal error messages such as stack traces, database dumps, and error codes are displayed to the user (hacker).

A specific example of this in SimpleSAMLphp was [CVE-2024-52596](https://github.com/advisories/GHSA-2x65-fpch-2fcm) whereby an attacker could induce a specific error condition via [XXE](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing) that causes the application to reveal potentially sensitive information within an error message.

`showerrors` should be disabled by default to avoid such problems.

Filing this as a public PR as all of the details are public already; there is no novel information about an exploitable vulnerability here.