### PR TITLE
Update doc-block to match redirect behavior

### DIFF
--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -248,10 +248,7 @@ class HTTP
 
 
     /**
-     * This function redirects the user to the specified address.
-     *
-     * This function will use the "HTTP 303 See Other" redirection if the current request used the POST method and the
-     * HTTP version is 1.1. Otherwise, a "HTTP 302 Found" redirection will be used.
+     * This function redirects the user to the specified address using the "HTTP 303 See Other" redirection.
      *
      * The function will also generate a simple web page with a clickable link to the target page.
      *


### PR DESCRIPTION
From https://github.com/simplesamlphp/simplesamlphp/commit/edb7699d1f321bc01e49567318d5db08b831ea54 method `\SimpleSAML\Utils\HTTP::redirect` only uses 303 redirection, so update method doc-block to reflect that.