### PR TITLE
Equalize default value for 'headers.security' between master and v2.5

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -278,7 +278,7 @@ $config = [
      * Whenever you change any of these headers, make sure to validate your config by running your
      * hostname through a security-test like https://en.internet.nl
     'headers.security' => [
-          'Content-Security-Policy' =>
+        'Content-Security-Policy' =>
             "default-src 'none'; " .
             "frame-ancestors 'self'; " .
             "object-src 'none'; " .
@@ -286,10 +286,12 @@ $config = [
             "style-src 'self'; " .
             "font-src 'self'; " .
             "connect-src 'self'; " .
+            "media-src data:; " .
             "img-src 'self' data:; " .
             "base-uri 'none'",
-        'Referrer-Policy' => 'origin-when-cross-origin',
+        'X-Frame-Options' => 'SAMEORIGIN',
         'X-Content-Type-Options' => 'nosniff',
+        'Referrer-Policy' => 'origin-when-cross-origin',
     ],
      */
 

--- a/src/SimpleSAML/Configuration.php
+++ b/src/SimpleSAML/Configuration.php
@@ -63,8 +63,9 @@ class Configuration implements Utils\ClearableState
             "media-src data:; " .
             "img-src 'self' data:; " .
             "base-uri 'none'",
-        'Referrer-Policy' => 'origin-when-cross-origin',
+        'X-Frame-Options' => 'SAMEORIGIN',
         'X-Content-Type-Options' => 'nosniff',
+        'Referrer-Policy' => 'origin-when-cross-origin',
     ];
 
 


### PR DESCRIPTION
Note that in this case, `'X-Frame-Options' => 'SAMEORIGIN',` header is added. I'm not sure why it was left out in master (in v2.5 it is used).