### PR TITLE
Normalize default modules between master and v25

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -556,18 +556,18 @@ $config = [
      ***********/
 
     /*
-     * Configuration for enabling/disabling modules. By default the 'core', 'admin' and 'saml' modules are enabled.
+     * Configuration for enabling/disabling modules. By default, the 'core', 'admin' and 'saml' modules are enabled.
      *
      * Example:
      *
      * 'module.enable' => [
      *     'exampleauth' => true, // Setting to TRUE enables.
      *     'consent' => false, // Setting to FALSE disables.
-     *     'core' => null, // Unset or NULL uses default.
+     *     'core' => null, // Unset or NULL uses default from \SimpleSAML\Module::$core_modules.
      * ],
      */
-
     'module.enable' => [
+        'core' => true,
         'admin' => true,
         'saml' => true,
     ],

--- a/src/SimpleSAML/Module.php
+++ b/src/SimpleSAML/Module.php
@@ -100,6 +100,7 @@ class Module
      */
     public static array $core_modules = [
         'core' => true,
+        'admin' => true,
         'saml' => true,
     ];
 


### PR DESCRIPTION
This adds `'admin'` to `\SimpleSAML\Module::$core_modules`, as per comment in `config/config.php.dist`: "By default, the 'core', 'admin' and 'saml' modules are enabled.".

Since the option is NOT commented-out in `config/config.php.dist`, I feel like it is better to have the default modules listed as the value of the option. 

Example usages:

* src/SimpleSAML/Module.php:147 (uses it as optional config with default value from `\SimpleSAML\Module::$core_modules`
```
return self::isModuleEnabledWithConf($module, $config->getOptionalArray('module.enable', self::$core_modules));
```
* src/SimpleSAML/Module.php:588 (uses it as optional config with default value being empty array, which feels wrong - I might create sepparate PR for this)
```
$config = Configuration::getOptionalConfig()->getOptionalArray('module.enable', []);
```
* src/SimpleSAML/Command/SspCacheClearCommand.php:85 (uses it as mandatory config)
```
$this->enabledModules = Configuration::getInstance()->getArray('module.enable');
```
