### PR TITLE
Hide the debug information in the error page by default

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -341,13 +341,13 @@ $config = [
     ],
 
     /*
-     * When 'showerrors' is enabled, all error messages and stack traces will be output
-     * to the browser.
-     *
-     * When 'errorreporting' is enabled, a form will be presented for the user to report
-     * the error to 'technicalcontact_email'.
+     * Error display behaviour:
+     * - Enable 'showerrors' to allow detailed messages in the browser; leave it disabled for production.
+     * - Add at least one entry to the 'debug' option to surface those messages. Without any debug flags, no extra details appear.
+     * - Include 'backtraces' in the debug array when you also want stack traces rendered.
+     * - Set 'errorreporting' to true to show a reporting form that emails the configured technical contact.
      */
-    'showerrors' => true,
+    'showerrors' => false,
     'errorreporting' => true,
 
     /*

--- a/templates/error.twig
+++ b/templates/error.twig
@@ -26,11 +26,13 @@
     </div>
 
     {# print out exception only if the exception is available #}
-    {% if showerrors -%}
+    {% if showDebugInformation -%}
         <h2>{{'Debug information' | trans}}</h2>
         <p>{{'The debug information below may be of interest to the administrator / help desk:' | trans}}</p>
         <p class="message-box error"><tt>{{ error.exceptionMsg }}</tt></p>
-        <div class="code-box code-box-content"><pre>{{ error.exceptionTrace }}</pre></div>
+        {% if showBacktrace -%}
+            <div class="code-box code-box-content"><pre>{{ error.exceptionTrace }}</pre></div>
+        {%- endif %}
     {%- endif %}
 
     {# Add error report submit section if we have a valid technical contact. 'errorreportaddress' will only be set if


### PR DESCRIPTION
The proposed changes are:
- 	The 'showerrors' is disabled by default. 
- 	If no debug flags are configured, no additional information will appear on the error page. Currently, stack traces are always displayed whenever showerrors is enabled, regardless of the debug settings.
- 	If 'backtraces' is enabled in the debug option, the stack traces information will display along with the error messages.

In a user case where the user does want to have the stack trace details in the logs, but does not want those information expose to the client side (a browser). The configuration should be set as:
```
'debug' => [
        'backtraces' => true,
    ],
'showerrors' => false,
```

which aligns with the current behaviour.