### PR TITLE
Allow a whitelist of errors to be shown when showerrors is true

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -348,6 +348,66 @@ $config = [
     'errorreporting' => true,
 
     /*
+     * When showerrors is true, this is an array of which errors
+     * should still be shown to the user. By default an error will
+     * always be shown if showerrors==true and this setting is at the default value to allow all.
+     *
+     * If you list anything in this option you have to explicitly list each error
+     * you would like to be shown to the user. You can also set the value to false
+     * to hide that error. If this setting is used with anything other than the default
+     * value and an error is not listed in the list then a backtrace for that error
+     * will not be shown.
+     *
+     * These can be any of the error codes in
+     * src/SimpleSAML/Error/ErrorCodes.php
+     *
+     */
+    'showerrors.whitelist' => [ '*' => true ],
+    /*
+       some of the many possibilities for this setting
+       
+    'showerrors.whitelist' => [
+       'ACSPARAMS' => true,
+       'ADMINNOTHASHED' => true,
+       'ARSPARAMS' => true,
+       'AUTHSOURCEERROR' => true,
+       'BADREQUEST' => true,
+       'CASERROR' => true,
+       'CONFIG' => true,
+       'CREATEREQUEST' => true,
+       'DISCOPARAMS' => true,
+       'GENERATEAUTHNRESPONSE' => true,
+       'INVALIDCERT' => true,
+       'LDAPERROR' => true,
+       'LOGOUTINFOLOST' => true,
+       'LOGOUTREQUEST' => true,
+       'MEMCACHEDOWN' => true,
+       'METADATA' => true,
+       'METADATANOTFOUND' => true,
+       'METHODNOTALLOWED' => true,
+       'NOACCESS' => true,
+       'NOCERT' => true,
+       'NORELAYSTATE' => true,
+       'NOSTATE' => true,
+       'NOTFOUND' => true,
+       'NOTFOUNDREASON' => true,
+       'NOTSET' => true,
+       'NOTVALIDCERT' => true,
+       'NOTVALIDCERTSIGNATURE' => true,
+       'PROCESSASSERTION' => true,
+       'PROCESSAUTHNREQUEST' => true,
+       'RESPONSESTATUSNOSUCCESS' => true,
+       'SLOSERVICEPARAMS' => true,
+       'SSOPARAMS' => true,
+       'UNHANDLEDEXCEPTION' => true,
+       'UNKNOWNCERT' => true,
+       'USERABORTED' => true,
+       'WRONGUSERPASS' => true,
+       ],
+     */
+
+    
+    /*
      * Custom error show function called from SimpleSAML\Error\Error::show.
      * See docs/simplesamlphp-errorhandling.md for function code example.
      *


### PR DESCRIPTION
If this whitelist is not used then all errors are shown if showerrors is true. You can use this new option to explicitly allow backtraces and descriptions to be shown to the user for only select error events.

If you provide a list of errors to show then anything not on that list will not be shown to the user. The error will be logged etc as normal.

This was raised in
https://github.com/simplesamlphp/simplesamlphp/pull/2513

This is a rebase of https://github.com/simplesamlphp/simplesamlphp/pull/2521 to `master`
