### PR TITLE
docs: maybe suggest showerrors=false to hide backtraces?

### DIFF
--- a/docs/simplesamlphp-install.md
+++ b/docs/simplesamlphp-install.md
@@ -286,7 +286,6 @@ descriptions and backtraces from the browser.
 'showerrors' => false,
 ```
 
-
 ## Configuring PHP
 
 ### Sending e-mails from PHP


### PR DESCRIPTION
Maybe mentioning this as one of the options that an admin should consider when setting up an installation along with the others so it is not missed?