### PR TITLE
store.redis.tls should apply to sentinels

### DIFF
--- a/src/SimpleSAML/Store/RedisStore.php
+++ b/src/SimpleSAML/Store/RedisStore.php
@@ -102,6 +102,7 @@ class RedisStore implements StoreInterface
                         'service' => $mastergroup,
                         'prefix' => $prefix,
                         'parameters' => [
+                            'scheme' => $scheme,
                             'database' => $database,
                         ]
                         + (!empty($ssl) ? ['ssl' => $ssl] : [])


### PR DESCRIPTION
The documentation in config.php.dist says

> Communicate with Redis over a secure connection instead of plain TCP.
> 
> This setting affects both single host connections as
> well as Sentinel mode.

However, that's not what actually happens. We can connect to TLS-enabled sentinels using tls://, but
if they return a TLS-enabled master, then we still try tcp:// rather than tls:// when connecting. That causes an exception to be thrown:

```
Caused by: Predis\Connection\ConnectionException: Error while reading line from the server. [tcp://172.16.2.104:6379]
```

This completes the configuration started in #1828 by making it possible to use a wholly TLS-enabled Redis setup with sentinels.