### PR TITLE
Add regular expression support to AttributeValueMap authproc filter

### DIFF
--- a/modules/core/docs/authproc_attributevaluemap.md
+++ b/modules/core/docs/authproc_attributevaluemap.md
@@ -5,7 +5,8 @@ Filter that creates a target attribute based on one or more value(s) in source a
 Besides the mapping of source values to target values, the filter has the following options:
 
 * `%replace` can be used to replace all existing values in target with new ones (any existing values will be lost)
-* `%keep` can be used to keep the source attribute, otherwise it will be removed.
+* `%keep` can be used to keep the source attribute, otherwise it will be removed (regardless of whether there is a match or not).
+* `%regex` can be used to evaluate the values as regular expressions instead of plain strings.
 
 **Examples**:
 
@@ -80,6 +81,28 @@ Replace any existing `affiliation` attribute values and keep the `groups` attrib
                     'cn=employees,o=some,o=organization,dc=org',
                     'cn=employee,o=other,o=organization,dc=org',
                     'cn=workers,o=any,o=organization,dc=org',
+                ],
+            ],
+        ],
+    ],
+
+## Regular expressions
+
+Will add eduPersonAffiliation containing value `student` if the `memberOf` attribute contains
+some value matching `/^cn=student,o=[a-z]+,o=organization,dc=org`
+(eg. `cn=student,o=some,o=organization,dc=org`).
+The `memberOf` attribute will be removed (use `%keep`, to keep it) and existing values in
+`eduPersonAffiliation` will be merged (use `%replace` to replace them).
+
+    'authproc' => [
+        50 => [
+            'class' => 'core:AttributeValueMap',
+            'sourceattribute' => 'memberOf',
+            'targetattribute' => 'eduPersonAffiliation',
+            '%regex',
+            'values' => [
+                'student' => [
+                    '/^cn=student,o=[a-z]+,o=organization,dc=org$/',
                 ],
             ],
         ],

--- a/tests/modules/core/src/Auth/Process/AttributeValueMapTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeValueMapTest.php
@@ -60,6 +60,34 @@ class AttributeValueMapTest extends TestCase
 
 
     /**
+     * The most basic test of no match.
+     *
+     * @throws \SimpleSAML\Error\Exception
+     */
+    public function testBasicNoMatch(): void
+    {
+        $config = [
+            'sourceattribute' => 'memberOf',
+            'targetattribute' => 'eduPersonAffiliation',
+            'values' => [
+                'member' => [
+                    'nomatch',
+                ],
+            ],
+        ];
+        $request = [
+            'Attributes' => [
+                'memberOf' => ['theGroup'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayNotHasKey('memberOf', $attributes);
+        $this->assertArrayNotHasKey('eduPersonAffiliation', $attributes);
+    }
+
+
+    /**
      * Test basic functionality, remove duplicates
      *
      */
@@ -224,5 +252,64 @@ class AttributeValueMapTest extends TestCase
             ],
         ];
         self::processFilter($config, $request);
+    }
+
+
+    /**
+     * Basic regular expression functionality test.
+     *
+     * @throws \SimpleSAML\Error\Exception
+     */
+    public function testBasicRegex(): void
+    {
+        $config = [
+            'sourceattribute' => 'memberOf',
+            'targetattribute' => 'eduPersonAffiliation',
+            '%regex',
+            'values' => [
+                'member' => [
+                    '/^the/',
+                ],
+            ],
+        ];
+        $request = [
+            'Attributes' => [
+                'memberOf' => ['theGroup'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayNotHasKey('memberOf', $attributes);
+        $this->assertArrayHasKey('eduPersonAffiliation', $attributes);
+        $this->assertEquals($attributes['eduPersonAffiliation'], ['member']);
+    }
+
+
+    /**
+     * Basic regular expression functionality test of a "no match".
+     *
+     * @throws \SimpleSAML\Error\Exception
+     */
+    public function testBasicRegexNoMatch(): void
+    {
+        $config = [
+            'sourceattribute' => 'memberOf',
+            'targetattribute' => 'eduPersonAffiliation',
+            '%regex',
+            'values' => [
+                'member' => [
+                    '/^nomatch$/',
+                ],
+            ],
+        ];
+        $request = [
+            'Attributes' => [
+                'memberOf' => ['theGroup'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayNotHasKey('memberOf', $attributes);
+        $this->assertArrayNotHasKey('eduPersonAffiliation', $attributes);
     }
 }


### PR DESCRIPTION
The latest in what feels like a series of "that should be a regular expression" pull requests. In this case, it makes sense that the values in the AttributeValueMap authproc filter should optionally support being a regular expression rather than just a plain string.

Implemented such that if the `%regex` option is specified, then all values are evaluated as regular expressions rather than as plain strings. The default is for it to be evaluated as a plain string (ie. existing functionality).

PHPUnit tests updated to include `%regex` tests. There was also a missing "doesn't match" test to the existing basic use cases.

Documentation updated to include the new option as well.