### PR TITLE
Add conditional options to AttributeAdd authproc

### DIFF
--- a/modules/core/docs/authproc_attributeadd.md
+++ b/modules/core/docs/authproc_attributeadd.md
@@ -6,6 +6,10 @@ Filter that adds attributes to the user.
 If the attribute already exists, the values added will be merged into a multi-valued attribute.
 If you instead want to replace the existing attribute, you may add the `%replace` option.
 
+If you want to only add the attribute if another attribute (or attributes) already exist, you can
+specify the optional `%if_attr_exists` (for plain strings) or `%if_attr_regex_matches`
+(for regular expressions). Both can be specified as either a single value or an array of values.
+
 Examples
 --------
 
@@ -44,5 +48,27 @@ Replace an existing attributes:
             'class' => 'core:AttributeAdd',
             '%replace',
             'uid' => ['guest'],
+        ],
+    ],
+
+Add a single-valued attribute if at least one of two existing attributes exist:
+
+    'authproc' => [
+        50 => [
+            'class' => 'core:AttributeAdd',
+            '%if_attr_exists' => ['studentId', 'staffId'],
+            'internalUser' => ['true'],
+        ],
+    ],
+
+Add a single-valued attribute if a regular expression matches an existing attribute. In this case,
+if there is an existing attribute where the attribute name starts with "graduateOf", then add a
+new "hasGraduated" attribute:
+
+    'authproc' => [
+        50 => [
+            'class' => 'core:AttributeAdd',
+            '%if_attr_regex_matches' => '/^graduateOf/',
+            'hasGraduated' => ['true'],
         ],
     ],

--- a/tests/modules/core/src/Auth/Process/AttributeAddTest.php
+++ b/tests/modules/core/src/Auth/Process/AttributeAddTest.php
@@ -187,4 +187,94 @@ class AttributeAddTest extends TestCase
         ];
         self::processFilter($config, $request);
     }
+
+
+    /**
+     * Test the most basic functionality.
+     */
+    public function testBasicAttrExists(): void
+    {
+        $config = [
+            '%if_attr_exists' => ['memberOf'],
+            'test' => ['value1', 'value2'],
+        ];
+        $request = [
+            'Attributes' => [
+                'memberOf' => ['theGroup'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey('test', $attributes);
+        $this->assertArrayHasKey('memberOf', $attributes);
+        $this->assertEquals($attributes['test'], ['value1', 'value2']);
+        $this->assertEquals($attributes['memberOf'], ['theGroup']);
+    }
+
+
+    /**
+     * Test the most basic functionality.
+     */
+    public function testBasicAttrExistsFail(): void
+    {
+        $config = [
+            '%if_attr_exists' => ['someOtherAttr'],
+            'test' => ['value1', 'value2'],
+        ];
+        $request = [
+            'Attributes' => [
+                'memberOf' => ['theGroup'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayNotHasKey('test', $attributes);
+        $this->assertArrayHasKey('memberOf', $attributes);
+        $this->assertEquals($attributes['memberOf'], ['theGroup']);
+    }
+
+
+    /**
+     * Test the most basic functionality.
+     */
+    public function testBasicRegexMatches(): void
+    {
+        $config = [
+            '%if_attr_regex_matches' => ['/^member/'],
+            'test' => ['value1', 'value2'],
+        ];
+        $request = [
+            'Attributes' => [
+                'memberOf' => ['theGroup'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey('test', $attributes);
+        $this->assertArrayHasKey('memberOf', $attributes);
+        $this->assertEquals($attributes['test'], ['value1', 'value2']);
+        $this->assertEquals($attributes['memberOf'], ['theGroup']);
+    }
+
+
+    /**
+     * Test the most basic functionality.
+     */
+    public function testBasicRegexMatchesFail(): void
+    {
+        $config = [
+            '%if_attr_regex_matches' => ['/^someOther/'],
+            'test' => ['value1', 'value2'],
+        ];
+        $request = [
+            'Attributes' => [
+                'memberOf' => ['theGroup'],
+            ],
+        ];
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayNotHasKey('test', $attributes);
+        $this->assertArrayHasKey('memberOf', $attributes);
+        $this->assertEquals($attributes['memberOf'], ['theGroup']);
+    }
 }


### PR DESCRIPTION
I have a use case where we have a number of dynamic attributes that follow a particular pattern, and if any of them exist, I need to add an attribute.

As a concrete example, if any of `customerTypeA`, `customerTypeB`, `customerTypeC`, ... exists, then set `isCustomer` = ['true'].

With this PR, this can easily be done with:

```php
    'authproc' => [
        50 => [
            'class' => 'core:AttributeAdd',
            '%if_attr_regex_matches' => '/^customerType/',
            'isCustomer' => ['true'],
        ],
    ],
```

I added both the string and regular expression options, as not every user will understand regular expressions, yet it's the only sensible way to support a dynamic list of attributes (such as my use case).

Fully backward compatible as usual. If neither options are specified then it will add the attribute, as per existing functionality. PHPUnit tests and documentation updated too.