### PR TITLE
fix for attributes.po translations.

### DIFF
--- a/src/SimpleSAML/Locale/Localization.php
+++ b/src/SimpleSAML/Locale/Localization.php
@@ -84,6 +84,7 @@ class Localization
         $this->language = new Language($configuration);
         $this->langcode = $this->language->getPosixLanguage($this->language->getLanguage());
         $this->setupL10N();
+        $this->addAttributeDomains();
     }
 
 

--- a/src/SimpleSAML/Locale/Translate.php
+++ b/src/SimpleSAML/Locale/Translate.php
@@ -111,7 +111,7 @@ class Translate
                     // try attributes.po
                     if ($text === $original) {
                         // @TODO: Fix this to be compatible with PHP 8.4 - domain cannot be an empty string
-                        $text = TranslatorFunctions::getTranslator()->dgettext("", $original);
+                        $text = TranslatorFunctions::getTranslator()->dgettext("attributes", $original);
                     }
                 }
             }


### PR DESCRIPTION
Translations from attributes.po are implicitly put into the attributes domain. The code looking for them was looking in the empty domain still. Also addAttributeDomains is included now to explicitly make sure they are loaded.

This was raised in
https://github.com/simplesamlphp/simplesamlphp/issues/2572