### PR TITLE
Record values from RequestedAttributes

### DIFF
--- a/src/SimpleSAML/Metadata/SAMLParser.php
+++ b/src/SimpleSAML/Metadata/SAMLParser.php
@@ -1028,22 +1028,30 @@ class SAMLParser
 
         $format = null;
         foreach ($element->getRequestedAttribute() as $child) {
-            $attrname = $child->getName();
-            $sp['attributes'][] = $attrname;
-
-            if ($child->getIsRequired() === true) {
-                $sp['attributes.required'][] = $attrname;
+            $attrName = $child->getName();
+            $attrNameFormat = $child->getNameFormat();
+            $attrValue = $child->getAttributeValues();
+            if (empty($attrValue)) {
+                $sp['attributes'][] = $attrName;
+            } else {
+                $values = [];
+                foreach ($attrValue as $attrval) {
+                    $values[] = $attrval->getValue();
+                }
+                $sp['attributes'][$attrName] = $values;
             }
 
-            if ($child->getNameFormat() !== null) {
-                $attrformat = $child->getNameFormat();
-            } else {
-                $attrformat = C::NAMEFORMAT_UNSPECIFIED;
+            if ($child->getIsRequired() === true) {
+                $sp['attributes.required'][] = $attrName;
+            }
+
+            if ($attrNameFormat === null) {
+                $attrNameFormat = C::NAMEFORMAT_UNSPECIFIED;
             }
 
             if ($format === null) {
-                $format = $attrformat;
-            } elseif ($format !== $attrformat) {
+                $format = $attrNameFormat;
+            } elseif ($format !== $attrNameFormat) {
                 $format = C::NAMEFORMAT_UNSPECIFIED;
             }
         }

--- a/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
@@ -228,6 +228,9 @@ XML,
         <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:mace:dir:attribute-def:eduPersonPrincipalName" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri" isRequired="true"/>
         <RequestedAttribute FriendlyName="mail" Name="urn:mace:dir:attribute-def:mail" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri"/>
         <RequestedAttribute FriendlyName="displayName" Name="urn:mace:dir:attribute-def:displayName" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri"/>
+        <RequestedAttribute FriendlyName="eduPersonEntitlement" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.7" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:mace:dir:entitlement:common-lib-terms</saml:AttributeValue>
+        </RequestedAttribute>
       </AttributeConsumingService>
     </SPSSODescriptor>
 
@@ -248,6 +251,9 @@ XML,
             "urn:mace:dir:attribute-def:eduPersonPrincipalName",
             "urn:mace:dir:attribute-def:mail",
             "urn:mace:dir:attribute-def:displayName",
+            "urn:oid:1.3.6.1.4.1.5923.1.1.1.7" => [
+                "urn:mace:dir:entitlement:common-lib-terms",
+            ],
         ];
         $expected_r = ["urn:mace:dir:attribute-def:eduPersonPrincipalName"];
 


### PR DESCRIPTION
The SAML XML parser ignores any `<saml:AttributeValue>` statements within a `<md:RequestedAttribute>` element. However, the SAML metadata spec clearly allows these (cf 2.4.4.2) and SimpleSAMLphp's own core:AttributeLimit filter can use them to limit attribute values.

This change adds support for parsing the child AttributeValue elements, and renders them as an associative array as documented by core:AttributeLimit. It also interoperates with SANLBuilder to re-render the XML version of the metadata correctly with any AttributeValues intact.

The lack of support for AttributeValue in the SAMLParser class is the root cause of simplesamlphp/simplesamlphp-module-metarefresh#51. Thus, fixing this also resolves that issue.

There are also some minor cosmetic changes to variable names to make their use in parseAttributeConsumerService() consistent with the handling of EntityAttributes in processExtensions().