### PR TITLE
Record values from RequestedAttributes (2.5.x)

### DIFF
--- a/src/SimpleSAML/Metadata/SAMLParser.php
+++ b/src/SimpleSAML/Metadata/SAMLParser.php
@@ -1075,7 +1075,16 @@ class SAMLParser
         $sp['attributes.required'] = [];
         foreach ($element->getRequestedAttribute() as $child) {
             $attrname = $child->getName();
-            $sp['attributes'][] = $attrname;
+            $attrvalue = $child->getAttributeValue();
+            if (empty($attrvalue)) {
+                $sp['attributes'][] = $attrname;
+            } else {
+                $values = [];
+                foreach ($attrvalue as $attrval) {
+                    $values[] = $attrval->getString();
+                }
+                $sp['attributes'][$attrname] = $values;
+            }
 
             if ($child->getIsRequired() === true) {
                 $sp['attributes.required'][] = $attrname;

--- a/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
+++ b/tests/src/SimpleSAML/Metadata/SAMLParserTest.php
@@ -222,6 +222,9 @@ XML,
         <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:mace:dir:attribute-def:eduPersonPrincipalName" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri" isRequired="true"/>
         <RequestedAttribute FriendlyName="mail" Name="urn:mace:dir:attribute-def:mail" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri"/>
         <RequestedAttribute FriendlyName="displayName" Name="urn:mace:dir:attribute-def:displayName" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri"/>
+        <RequestedAttribute FriendlyName="eduPersonEntitlement" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.7" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:mace:dir:entitlement:common-lib-terms</saml:AttributeValue>
+        </RequestedAttribute>
       </AttributeConsumingService>
     </SPSSODescriptor>
 
@@ -243,6 +246,9 @@ XML,
             "urn:mace:dir:attribute-def:eduPersonPrincipalName",
             "urn:mace:dir:attribute-def:mail",
             "urn:mace:dir:attribute-def:displayName",
+            "urn:oid:1.3.6.1.4.1.5923.1.1.1.7" => [
+                "urn:mace:dir:entitlement:common-lib-terms",
+            ],
         ];
         $expected_r = ["urn:mace:dir:attribute-def:eduPersonPrincipalName"];
 


### PR DESCRIPTION
This is a backport of simplesamlphp#2581 to the simplesamlphp-2.5 branch so that it makes it into the next release.

This version tests cleanly with PHPUnit, and also in a deployed SimpleSAMLphp (2.4.4) instance.

It fixes simplesamlphp/simplesamlphp-module-metarefresh#51