### PR TITLE
Utils\Http php 8.5 deprecation fix

### DIFF
--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -537,7 +537,7 @@ class HTTP
             if (PHP_VERSION_ID > 80500) {
                 $http_response_headers = http_get_last_response_headers();
             } else {
-                $http_response_headers = $http_response_header;
+                $http_response_headers = $http_response_header ?? [];
             }
             if (!empty($http_response_headers)) {
                 $headers = [];


### PR DESCRIPTION
Fixes `Deprecated: The predefined locally scoped $http_response_header variable is deprecated, call http_get_last_response_headers() instead`