### PR TITLE
Update changelog with NameIDType JSON serialization

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -16,6 +16,7 @@ Released 2025-12-08
 * store.redis.tls should apply to sentinels (#2557)
 * Fix unhandled canonicalization failure (CVE-2025-66475)
 * Bump dependencies
+* NameIDType attributes are now JSON-serializable - these objects might appear in the array returned by getAuthDataArray() 
 
 ## Version 2.4.3
 


### PR DESCRIPTION
2.4.4 included a bump in the saml2-legacy dependency which changes the structure of how some attributes would be json-serialized. This MR just includes a line in the changelog to call this out explicitly, as it introduces a change of structure if using JSON to pass attributes around.