### PR TITLE
Update changelog with NameIDType JSON serialization

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -16,7 +16,6 @@ Released 2025-12-08
 * store.redis.tls should apply to sentinels (#2557)
 * Fix unhandled canonicalization failure (CVE-2025-66475)
 * Bump dependencies
-* NameIDType attributes are now JSON-serializable - these objects might appear in the array returned by getAuthDataArray() 
 
 ## Version 2.4.3
 
@@ -37,6 +36,7 @@ Released 2025-10-05
 * Introduced a new assets.salt to allow cache busting without leaking version information (#2490)
 * If session.check_function is set and can not be called an error is raised (#2498)
 * Fix FontAwesome icon names (#2509)
+* NameIDType attributes are now JSON-serializable - these objects might appear in the array returned by getAuthDataArray() 
 
 `authorize`
 


### PR DESCRIPTION
2.4.3 included a bump in the saml2-legacy dependency which changes the structure of how some attributes would be json-serialized. This MR just includes a line in the changelog to call this out explicitly, as it introduces a change of structure if using JSON to pass attributes around.