### PR TITLE
BUGFIX: http-getselfurl-robust-path-and-query

### DIFF
--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -833,12 +833,7 @@ class HTTP
                 $port = $this->getServerPort();
             }
 
-            $suffix = $requestPath . ($requestQuery !== '' ? '?' . $requestQuery : '');
-            if ($requestFragment !== '') {
-                $suffix .= '#' . $requestFragment;
-            }
-
-            return $protocol . '://' . $hostname . $port . $suffix;
+            return $protocol . '://' . $hostname . $port . $_SERVER['REQUEST_URI'];
         }
 
         // Normal case: baseURL + script-relative path + remaining path, plus query if present


### PR DESCRIPTION
Improve HTTP::getSelfURL() path detection and URL reconstruction

`HTTP::getSelfURL()` mis-reconstructs the current URL when SimpleSAMLphp is accessed through a rewritten path such as `RewriteRule ^/cas/login(.*) /${SSP_APACHE_ALIAS}module.php/casserver/login.php$1 [PT]`. In this scenario the public URL is `/cas/login?service=...`, while Apache internally rewrites it to `/simplesaml/module.php/casserver/login.php?service=...`. The old implementation assumes that the script-relative filesystem path (for example `module.php/casserver/login.php`) appears verbatim in `$_SERVER['REQUEST_URI']`, searches for that substring in the entire `REQUEST_URI`, and rebuilds the URL by stitching together `getBaseURL()`, that matched path, and the remainder of `REQUEST_URI`. With mod_rewrite, `REQUEST_URI` contains only the external path (`/cas/login?...`), so the expected script path is not present, or may only appear by accident inside query parameters. This causes `getSelfURL()` to either fall back to an incorrect URL or to construct one that points to `module.php/...` instead of `/cas/login`, or that has a malformed path/query combination, breaking redirects and return URLs that rely on `getSelfURL()` to reflect the actual public URL.