### PR TITLE
Update UNC path handling

### DIFF
--- a/src/SimpleSAML/Utils/System.php
+++ b/src/SimpleSAML/Utils/System.php
@@ -145,7 +145,12 @@ class System
         // check for absolute path
         if (substr($path, 0, 1) === '/') {
             // absolute path. */
-            $ret = '/';
+            if (substr($path, 0, 2) === '//') {
+                // UNC absolute path
+                $ret = '//';
+            } else {
+                $ret = '/';
+            }
         } elseif ($this->pathContainsDriveLetter($path)) {
             $ret = '';
         } else {

--- a/tests/src/SimpleSAML/Utils/SystemTest.php
+++ b/tests/src/SimpleSAML/Utils/SystemTest.php
@@ -279,4 +279,21 @@ class SystemTest extends TestCase
         $reflectedInstance->setValue($service, []);
         $reflectedInstance->setAccessible(false);
     }
+
+
+    /**
+     */
+    public function testUNCpaths(): void
+    {
+        if (DIRECTORY_SEPARATOR == '\\') {
+
+            $base = null;
+            $path = "\\some-pc\some-share\some.key";
+
+            $res = $this->sysUtils->resolvePath($path, $base);
+            $expected = "//some-pc/some-share/some.key";
+
+            $this->assertEquals($expected, $res);
+        }
+    }
 }

--- a/tests/src/SimpleSAML/Utils/SystemTest.php
+++ b/tests/src/SimpleSAML/Utils/SystemTest.php
@@ -285,7 +285,7 @@ class SystemTest extends TestCase
      */
     public function testUNCpaths(): void
     {
-        if (DIRECTORY_SEPARATOR == '\\') {
+        if (DIRECTORY_SEPARATOR === '\\') {
 
             $base = null;
             $path = "\\some-pc\some-share\some.key";


### PR DESCRIPTION
This

```
\\some-pc\some-share\some.key
```

Should result in

```
var_dump($ret);
string(29) "//some-pc/some-share/some.key"
```

Which according to
https://github.com/simplesamlphp/simplesamlphp/issues/2586 should be able to be loaded.

I only have a partial php win env so it needs verification against a real SSP install.