### PR TITLE
Remove stray spacing in twig

### DIFF
--- a/templates/_table.twig
+++ b/templates/_table.twig
@@ -3,21 +3,20 @@
 
 {% for name, values in items %}
     <tr class="{{ cycle(['odd', 'even'], loop.index0) }}">
-        {% block namecol -%}
+        {%~ block namecol -%}
             <td class="attrname">{{ name }}</td>
         {%- endblock %}
+    <td class="attrvalue">
+        {%- for value in values -%}
+            {% if loop.length>1 and loop.first %}<ul>{% endif -%}
+            {%- if loop.length>1 %}<li>{% endif -%}
 
-        <td class="attrvalue">
-            {% for value in values %}
-                {% if loop.length>1 and loop.first %}<ul>{% endif -%}
-                {%- if loop.length>1 %}<li>{% endif -%}
+            {%- block value %}{% endblock -%}
 
-                {%- block value %}{% endblock -%}
-
-                {%- if loop.length>1 %}</li>{% endif -%}
-                {%- if loop.length>1 and loop.last %}</ul>{% endif %}
-            {% endfor %}
-        </td>
+            {%- if loop.length>1 %}</li>{% endif -%}
+            {%- if loop.length>1 and loop.last %}</ul>{% endif %}
+        {%- endfor -%}
+    </td>
     </tr>
 {% endfor %}
 </table><br>

--- a/templates/auth_status.twig
+++ b/templates/auth_status.twig
@@ -18,9 +18,9 @@
 
 {% embed '_table.twig' -%}
 
-    {% block namecol -%}
+    {% block namecol %}
     {% set translated = name|trans %}
-    <td class="attrname">{% if translated != name %} {{ translated }} <br>{% endif %} <samp>{{ name }}</samp></td>
+    <td class="attrname">{% if translated != name %} {{ translated }} <br>{% endif %}<samp>{{ name }}</samp></td>
     {% endblock %}
 
 
@@ -28,7 +28,7 @@
     {% if name =='jpegPhoto'-%}
         <img src="data:image/jpeg;base64,{{ value }}" />
     {% else %}{{ value }}{% endif -%}
-    {% endblock %}
+    {% endblock -%}
 
 {%- endembed %}
 


### PR DESCRIPTION
the HTML table that is displayed after successfully authenticating has a lot of stray whitespacing in the `attrvalue` of elements:

```html
<tr class="even">
        <td class="attrname"> <samp>urn:oid:2.5.4.42</samp></td>

    <td class="attrvalue">
                        Dick Visser                    </td>
</tr>
<tr class="odd">
        <td class="attrname"> <samp>urn:oid:0.9.2342.19200300.100.1.3</samp></td>

    <td class="attrvalue">
                        dick.visser@geant.org                    </td>
</tr>
 ```

If the DOM is parsed by functional tests, then those fail. This patches cleans it up a bit:

 ```html
 <tr class="even">
     <td class="attrname"><samp>urn:oid:2.5.4.42</samp></td>
     <td class="attrvalue">Dick Visser</td>
 </tr>
 <tr class="odd">
     <td class="attrname"><samp>urn:oid:0.9.2342.19200300.100.1.3</samp></td>
     <td class="attrvalue">dick.visser@geant.org</td>
 </tr>
 ```