### PR TITLE
HTTP: have getServerHTTPS() honor https baseurlpath when $_SERVER['HTTPS'] is absent

### DIFF
--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -209,13 +209,7 @@ class HTTP
         // virtual host the library knows about is configured for HTTPS.
         //
         // No client-controlled header is read at any point.
-        try {
-            $cfg = Configuration::getInstance();
-        } catch (\Exception $e) {
-            // Configuration not yet loaded — nothing more to check.
-            return false;
-        }
-
+        $cfg = Configuration::getInstance();
         $baseURL = $cfg->getOptionalString('baseurlpath', null);
         if (
             $baseURL !== null

--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -178,18 +178,57 @@ class HTTP
      */
     public function getServerHTTPS(): bool
     {
-        if (!array_key_exists('HTTPS', $_SERVER)) {
-            // not an https-request
+        // When $_SERVER['HTTPS'] is set — by a web server that terminates
+        // TLS itself — it is the authoritative signal. Preserve the
+        // existing three-case interpretation exactly, so an admin's
+        // explicit 'off' (IIS convention) still wins.
+        if (array_key_exists('HTTPS', $_SERVER)) {
+            if ($_SERVER['HTTPS'] === 'off') {
+                return false;
+            }
+            return !empty($_SERVER['HTTPS']);
+        }
+
+        // $_SERVER['HTTPS'] is COMPLETELY ABSENT. This is the typical
+        // php-fpm case behind a TLS-terminating reverse proxy: nginx's
+        // stock fastcgi_params line `fastcgi_param HTTPS $https
+        // if_not_empty;` only sends the param when $https itself is
+        // non-empty, which only happens when nginx terminates TLS.
+        //
+        // Fall back to the admin-set baseurlpath. We trust it only when:
+        //   (a) it is a full URL starting with https://, AND
+        //   (b) its host exactly matches the current request's host.
+        //
+        // (a) restricts to deployments where the admin has explicitly
+        // declared an HTTPS deployment scheme (the maintainer-prescribed
+        // form for reverse-proxy setups, e.g. as in
+        // github.com/simplesamlphp/simplesamlphp/pull/795).
+        //
+        // (b) prevents a multi-host SimpleSAMLphp installation from
+        // over-promoting unrelated requests to HTTPS just because some
+        // virtual host the library knows about is configured for HTTPS.
+        //
+        // No client-controlled header is read at any point.
+        try {
+            $cfg = Configuration::getInstance();
+        } catch (\Exception $e) {
+            // Configuration not yet loaded — nothing more to check.
             return false;
         }
 
-        if ($_SERVER['HTTPS'] === 'off') {
-            // IIS with HTTPS off
-            return false;
+        $baseURL = $cfg->getOptionalString('baseurlpath', null);
+        if (
+            $baseURL !== null
+            && preg_match('#^https://([^/:]+)(?::([0-9]+))?#', $baseURL, $matches)
+        ) {
+            $configuredHost = strtolower($matches[1]);
+            $currentHost = strtolower($this->getServerHost());
+            if ($configuredHost === $currentHost) {
+                return true;
+            }
         }
 
-        // otherwise, HTTPS will be non-empty
-        return !empty($_SERVER['HTTPS']);
+        return false;
     }
 
 

--- a/src/SimpleSAML/Utils/HTTP.php
+++ b/src/SimpleSAML/Utils/HTTP.php
@@ -218,9 +218,29 @@ class HTTP
             $configuredHost = strtolower($matches[1]);
             $currentHost = strtolower($this->getServerHost());
             if ($configuredHost === $currentHost) {
+                Logger::debug(
+                    "getServerHTTPS(): no \$_SERVER['HTTPS']; treating the request as HTTPS "
+                    . "because the 'baseurlpath' host '" . $configuredHost
+                    . "' matches the current host.",
+                );
+
                 return true;
             }
+
+            Logger::debug(
+                "getServerHTTPS(): no \$_SERVER['HTTPS']; not treating the request as HTTPS "
+                . "because the 'baseurlpath' host '" . $configuredHost
+                . "' does not match the current host '" . $currentHost . "'.",
+            );
+
+            return false;
         }
+
+        Logger::debug(
+            "getServerHTTPS(): no \$_SERVER['HTTPS'] and 'baseurlpath' is not a full https:// "
+            . "URL, so the request is not treated as HTTPS. If TLS is terminated at an upstream "
+            . "proxy, set 'baseurlpath' (or 'application.baseURL') to your full https:// URL.",
+        );
 
         return false;
     }

--- a/tests/src/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/src/SimpleSAML/Utils/HTTPTest.php
@@ -808,4 +808,267 @@ class HTTPTest extends ClearStateTestCase
 
         $_SERVER = $originalServer;
     }
+
+    /**
+     * Reproducer guard: when SimpleSAMLphp is invoked from an external
+     * script (script outside its own public/ directory) behind a
+     * TLS-terminating reverse proxy that does not set $_SERVER['HTTPS'],
+     * getServerHTTPS() must honor an https:// baseurlpath whose host
+     * matches the current request's host. Without this, isHTTPS()
+     * returns false and setting a secure cookie raises
+     * CriticalConfigurationError ("Setting secure cookie on plain HTTP").
+     */
+    public function testGetServerHTTPSHonorsHttpsBaseurlpathBehindProxy(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        Configuration::loadFromArray([
+            'baseurlpath' => 'https://app.example.test/simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTP_HOST'              => 'app.example.test',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'REQUEST_URI'            => '/app/sp.php?foo=bar',
+            'SCRIPT_FILENAME'        => '/var/www/app/sp.php',
+            'SERVER_PORT'            => '80',
+        ];
+
+        $this->assertTrue(
+            $httpUtils->getServerHTTPS(),
+            'getServerHTTPS() must return true when baseurlpath declares https for the current host, '
+            . 'even when $_SERVER[HTTPS] is empty (TLS-terminating-proxy topology).',
+        );
+        $this->assertTrue(
+            $httpUtils->isHTTPS(),
+            'isHTTPS() must return true in the same topology, otherwise secure-cookie setup fails.',
+        );
+        $this->assertStringStartsWith(
+            'https://',
+            $httpUtils->getSelfURL(),
+            'getSelfURL() must return an https:// URL when baseurlpath declares https for the current host.',
+        );
+
+        $_SERVER = $original;
+    }
+
+    /**
+     * Companion guard: when baseurlpath declares https for a DIFFERENT
+     * host than the current request, the host-match guard must prevent
+     * the new fallback from triggering — getServerHTTPS() must fall
+     * through to the original $_SERVER-based detection (which here
+     * yields false because $_SERVER['HTTPS'] is unset).
+     */
+    public function testGetServerHTTPSBaseurlpathHostMismatchDoesNotForceHTTPS(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        Configuration::loadFromArray([
+            'baseurlpath' => 'https://different-host.example.test/simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTP_HOST'       => 'app.example.test',
+            'REQUEST_URI'     => '/app/sp.php',
+            'SCRIPT_FILENAME' => '/var/www/app/sp.php',
+            'SERVER_PORT'     => '80',
+        ];
+
+        $this->assertFalse(
+            $httpUtils->getServerHTTPS(),
+            'getServerHTTPS() must NOT be coerced to true when baseurlpath declares https for a different host.',
+        );
+
+        $_SERVER = $original;
+    }
+
+
+    /**
+     * Branch A regression guard: when $_SERVER['HTTPS'] is set to 'on',
+     * the existing short-circuit must continue to return true regardless
+     * of any baseurlpath configuration. This guards against a future
+     * refactor that accidentally reorders the checks.
+     */
+    public function testGetServerHTTPSReturnsTrueWhenHttpsEnvIsSet(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        // No baseurlpath at all; HTTPS=on must still be honoured.
+        Configuration::loadFromArray([], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTPS'           => 'on',
+            'HTTP_HOST'       => 'app.example.test',
+            'REQUEST_URI'     => '/',
+            'SCRIPT_FILENAME' => '/var/www/app/sp.php',
+            'SERVER_PORT'     => '443',
+        ];
+        $this->assertTrue($httpUtils->getServerHTTPS());
+
+        // HTTPS=on with a totally unrelated baseurlpath also stays true.
+        Configuration::loadFromArray([
+            'baseurlpath' => 'http://different-host.example.test/simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+        $this->assertTrue(
+            $httpUtils->getServerHTTPS(),
+            'HTTPS=on env must win over a conflicting (http) baseurlpath.',
+        );
+
+        $_SERVER = $original;
+    }
+
+    /**
+     * Critical preservation guard: an admin's explicit $_SERVER['HTTPS']
+     * = 'off' (IIS convention for "no HTTPS for this request") must
+     * still return false, even when baseurlpath declares https for the
+     * matching host. The fallback only applies when HTTPS is absent
+     * from $_SERVER, not when it is explicitly off.
+     */
+    public function testGetServerHTTPSRespectsExplicitHttpsOff(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        Configuration::loadFromArray([
+            'baseurlpath' => 'https://app.example.test/simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTPS'           => 'off',
+            'HTTP_HOST'       => 'app.example.test',
+            'REQUEST_URI'     => '/',
+            'SCRIPT_FILENAME' => '/var/www/app/sp.php',
+            'SERVER_PORT'     => '80',
+        ];
+
+        $this->assertFalse(
+            $httpUtils->getServerHTTPS(),
+            'Explicit $_SERVER[HTTPS]=off must not be silently overridden by an https baseurlpath.',
+        );
+
+        $_SERVER = $original;
+    }
+
+    /**
+     * Host comparison must be case-insensitive (DNS hostnames are
+     * case-insensitive). Without this, an admin who writes baseurlpath
+     * with capital letters would see the fallback silently fail.
+     */
+    public function testGetServerHTTPSCaseInsensitiveHostMatch(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        Configuration::loadFromArray([
+            'baseurlpath' => 'https://APP.Example.Test/simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTP_HOST'       => 'app.example.test',
+            'REQUEST_URI'     => '/',
+            'SCRIPT_FILENAME' => '/var/www/app/sp.php',
+            'SERVER_PORT'     => '80',
+        ];
+
+        $this->assertTrue(
+            $httpUtils->getServerHTTPS(),
+            'Host comparison must be case-insensitive.',
+        );
+
+        $_SERVER = $original;
+    }
+
+    /**
+     * When the current request's HTTP_HOST includes a port (because
+     * the public listener uses a non-standard port and the proxy
+     * preserved the Host header), getServerHost() strips the port; the
+     * fallback host match should still succeed when baseurlpath
+     * declares the same host without a port.
+     */
+    public function testGetServerHTTPSHostWithPortInRequest(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        Configuration::loadFromArray([
+            'baseurlpath' => 'https://app.example.test/simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTP_HOST'       => 'app.example.test:8443',
+            'REQUEST_URI'     => '/',
+            'SCRIPT_FILENAME' => '/var/www/app/sp.php',
+            'SERVER_PORT'     => '8443',
+        ];
+
+        $this->assertTrue(
+            $httpUtils->getServerHTTPS(),
+            'Host with port in HTTP_HOST must still match baseurlpath without port (port stripped by getServerHost()).',
+        );
+
+        $_SERVER = $original;
+    }
+
+    /**
+     * A relative-path baseurlpath (the default `simplesaml/`, or any
+     * value not starting with https://) must NOT trigger the fallback.
+     * This guards against a future regex loosening that could
+     * false-positive on relative paths.
+     */
+    public function testGetServerHTTPSIgnoresRelativeBaseurlpath(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        Configuration::loadFromArray([
+            'baseurlpath' => 'simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTP_HOST'       => 'app.example.test',
+            'REQUEST_URI'     => '/',
+            'SCRIPT_FILENAME' => '/var/www/app/sp.php',
+            'SERVER_PORT'     => '80',
+        ];
+
+        $this->assertFalse(
+            $httpUtils->getServerHTTPS(),
+            'Relative-path baseurlpath must not trigger the HTTPS fallback.',
+        );
+
+        $_SERVER = $original;
+    }
+
+    /**
+     * An http:// (not https://) baseurlpath must NOT trigger the
+     * fallback. The fallback only honours an explicit https
+     * declaration, never an http one.
+     */
+    public function testGetServerHTTPSIgnoresHttpBaseurlpath(): void
+    {
+        $original = $_SERVER;
+        $httpUtils = new Utils\HTTP();
+
+        Configuration::loadFromArray([
+            'baseurlpath' => 'http://app.example.test/simplesaml/',
+        ], '[ARRAY]', 'simplesaml');
+
+        $_SERVER = [
+            'HTTP_HOST'       => 'app.example.test',
+            'REQUEST_URI'     => '/',
+            'SCRIPT_FILENAME' => '/var/www/app/sp.php',
+            'SERVER_PORT'     => '80',
+        ];
+
+        $this->assertFalse(
+            $httpUtils->getServerHTTPS(),
+            'An http:// baseurlpath must not be coerced into HTTPS by the fallback.',
+        );
+
+        $_SERVER = $original;
+    }
+
 }

--- a/tests/src/SimpleSAML/Utils/HTTPTest.php
+++ b/tests/src/SimpleSAML/Utils/HTTPTest.php
@@ -809,6 +809,7 @@ class HTTPTest extends ClearStateTestCase
         $_SERVER = $originalServer;
     }
 
+
     /**
      * Reproducer guard: when SimpleSAMLphp is invoked from an external
      * script (script outside its own public/ directory) behind a
@@ -852,6 +853,7 @@ class HTTPTest extends ClearStateTestCase
 
         $_SERVER = $original;
     }
+
 
     /**
      * Companion guard: when baseurlpath declares https for a DIFFERENT
@@ -920,6 +922,7 @@ class HTTPTest extends ClearStateTestCase
         $_SERVER = $original;
     }
 
+
     /**
      * Critical preservation guard: an admin's explicit $_SERVER['HTTPS']
      * = 'off' (IIS convention for "no HTTPS for this request") must
@@ -952,6 +955,7 @@ class HTTPTest extends ClearStateTestCase
         $_SERVER = $original;
     }
 
+
     /**
      * Host comparison must be case-insensitive (DNS hostnames are
      * case-insensitive). Without this, an admin who writes baseurlpath
@@ -980,6 +984,7 @@ class HTTPTest extends ClearStateTestCase
 
         $_SERVER = $original;
     }
+
 
     /**
      * When the current request's HTTP_HOST includes a port (because
@@ -1012,6 +1017,7 @@ class HTTPTest extends ClearStateTestCase
         $_SERVER = $original;
     }
 
+
     /**
      * A relative-path baseurlpath (the default `simplesaml/`, or any
      * value not starting with https://) must NOT trigger the fallback.
@@ -1042,6 +1048,7 @@ class HTTPTest extends ClearStateTestCase
         $_SERVER = $original;
     }
 
+
     /**
      * An http:// (not https://) baseurlpath must NOT trigger the
      * fallback. The fallback only honours an explicit https
@@ -1070,5 +1077,4 @@ class HTTPTest extends ClearStateTestCase
 
         $_SERVER = $original;
     }
-
 }


### PR DESCRIPTION
# Make `baseurlpath`'s HTTPS declaration apply consistently in `getServerHTTPS()`

Fixes #2637.

## Problem

`Utils\HTTP::getServerHTTPS()` consults only `$_SERVER['HTTPS']`. In nginx → php-fpm deployments behind a TLS-terminating reverse proxy, `$_SERVER['HTTPS']` is absent — nginx's stock `fastcgi_params` ships `fastcgi_param HTTPS $https if_not_empty;`, and `$https` is empty when nginx itself receives plain HTTP from the upstream proxy. So `getServerHTTPS()` returns `false` for what is actually an HTTPS request, breaking five downstream call sites:

| Caller | Symptom of the bug |
|---|---|
| `Utils\HTTP::getSelfURL()` external-script branch | `$as = new \SimpleSAML\Auth\Simple(…)` from a host application's own controller throws `CriticalConfigurationError: Setting secure cookie on plain HTTP` (the most visible failure mode) |
| `Auth\Simple::getProcessedURL()` | Returns `http://...` return-to URLs even when the original request was HTTPS |
| `Utils\HTTP::getServerPort()` | Defaults to port 80 instead of 443 when `SERVER_PORT` is missing |
| `Utils\HTTP::getBaseURL()` relative-path branch | Builds the auto-detected base URL with `http://` instead of `https://` when baseurlpath is a relative path |

The maintainer-prescribed workaround for reverse-proxy deployments — set `baseurlpath` to a full `https://` URL, restated multiple times in [#795](https://github.com/simplesamlphp/simplesamlphp/pull/795), [#376](https://github.com/simplesamlphp/simplesamlphp/pull/376), [#324](https://github.com/simplesamlphp/simplesamlphp/pull/324), [#491](https://github.com/simplesamlphp/simplesamlphp/pull/491) — works for `Utils\HTTP::getBaseURL()`'s full-URL branch (used by the "normal" branch of `getSelfURL()` for SimpleSAMLphp's own `/saml/*` URLs) but is silently ignored by `getServerHTTPS()` and therefore by the four other callers above.

For SPs that use the canonical `Auth\Simple` pattern from a host application's own controller, the maintainer's verbal guidance in [#2484](https://github.com/simplesamlphp/simplesamlphp/issues/2484#issuecomment) is "also set `application.baseURL`." That works, but it's not documented in the config template, the SP documentation, or the error message — users repeatedly burn hours discovering it (a decade of duplicate reports: [#77](https://github.com/simplesamlphp/simplesamlphp/issues/77), [#343](https://github.com/simplesamlphp/simplesamlphp/issues/343), [#654](https://github.com/simplesamlphp/simplesamlphp/issues/654), [#808](https://github.com/simplesamlphp/simplesamlphp/issues/808), [#879](https://github.com/simplesamlphp/simplesamlphp/issues/879), [#2484](https://github.com/simplesamlphp/simplesamlphp/issues/2484)).

## Approach

Threads the maintainer-stated philosophy explicitly:

1. **Do not trust client-supplied `X-Forwarded-*` headers.** Consistent with the position taken in [#795](https://github.com/simplesamlphp/simplesamlphp/pull/795), [#376](https://github.com/simplesamlphp/simplesamlphp/pull/376), [#324](https://github.com/simplesamlphp/simplesamlphp/pull/324), and [#491](https://github.com/simplesamlphp/simplesamlphp/pull/491).
2. **Trust admin-set configuration.** `baseurlpath` is set in `config.php` by the deployment administrator — this is the same source of truth the maintainers have repeatedly endorsed.
3. **Preserve every existing semantic.** When `$_SERVER['HTTPS']` is present (set or `'off'`), behavior is byte-for-byte unchanged. The new fallback only activates when the key is **absent**.
4. **Conservative host match.** Only trust `baseurlpath`'s declared scheme when its host exactly matches the current request's host (case-insensitive). Prevents a multi-host installation from over-promoting unrelated requests to HTTPS just because one configured vhost happens to declare HTTPS.

## Changes

### `src/SimpleSAML/Utils/HTTP.php` — `getServerHTTPS()`

Refactored so the original three-case `$_SERVER['HTTPS']` interpretation runs only when `array_key_exists('HTTPS', $_SERVER)`. When the key is absent, falls through to a new admin-config-based check:

```php
public function getServerHTTPS(): bool
{
    if (array_key_exists('HTTPS', $_SERVER)) {
        if ($_SERVER['HTTPS'] === 'off') {
            return false;
        }
        return !empty($_SERVER['HTTPS']);
    }

    try {
        $cfg = Configuration::getInstance();
    } catch (\Exception $e) {
        return false;
    }

    $baseURL = $cfg->getOptionalString('baseurlpath', null);
    if (
        $baseURL !== null
        && preg_match('#^https://([^/:]+)(?::([0-9]+))?#', $baseURL, $matches)
    ) {
        $configuredHost = strtolower($matches[1]);
        $currentHost = strtolower($this->getServerHost());
        if ($configuredHost === $currentHost) {
            return true;
        }
    }

    return false;
}
```

### `tests/src/SimpleSAML/Utils/HTTPTest.php` — 8 new test methods

| Test | Asserts |
|---|---|
| `testGetServerHTTPSHonorsHttpsBaseurlpathBehindProxy` | The bug — fails on master without the fix, passes with it |
| `testGetServerHTTPSBaseurlpathHostMismatchDoesNotForceHTTPS` | Host-match guard rejects cross-host baseurlpath |
| `testGetServerHTTPSReturnsTrueWhenHttpsEnvIsSet` | Branch A short-circuit preserved (HTTPS=on with conflicting baseurlpath still returns true) |
| `testGetServerHTTPSRespectsExplicitHttpsOff` | IIS-style explicit `HTTPS=off` is not overridden by fallback |
| `testGetServerHTTPSCaseInsensitiveHostMatch` | Host comparison is case-insensitive (DNS rule) |
| `testGetServerHTTPSHostWithPortInRequest` | `HTTP_HOST` with port matches baseurlpath without port (port stripped by `getServerHost()`) |
| `testGetServerHTTPSIgnoresRelativeBaseurlpath` | Default relative-path baseurlpath doesn't trigger the fallback |
| `testGetServerHTTPSIgnoresHttpBaseurlpath` | `http://` baseurlpath is not coerced into HTTPS |

## Verification

```
vendor/bin/phpunit --no-coverage
...
Tests: 888, Assertions: 2633, Warnings: 1, PHPUnit Notices: 24, Skipped: 11.
```

- 880 → **888 tests, all pass** (8 added, 0 regressions).
- The new bug-demonstration test fails on unmodified master:
  > `Failed asserting that false is true.` at `testGetServerHTTPSHonorsHttpsBaseurlpathBehindProxy`
- The same test passes after the patch is applied.
- All 4 other `getServerHTTPS()` callers in the library benefit: `getServerPort()`, `getBaseURL()`'s relative-path branch, `getSelfURL()`'s external-script branch (the bug site), and `Auth\Simple::getProcessedURL()`.

## Backward compatibility

| Pre-existing scenario | Behavior on master | Behavior with this PR |
|---|---|---|
| `$_SERVER['HTTPS']='on'` | true | **true** (unchanged) |
| `$_SERVER['HTTPS']='off'` | false | **false** (unchanged — explicit off still wins) |
| `$_SERVER['HTTPS']=''` | false (empty string check) | **false** (unchanged) |
| `$_SERVER['HTTPS']` missing, no baseurlpath / relative baseurlpath | false | **false** (unchanged) |
| `$_SERVER['HTTPS']` missing, http:// baseurlpath | false | **false** (unchanged — http baseurlpath rejected) |
| `$_SERVER['HTTPS']` missing, https:// baseurlpath, different host | false | **false** (unchanged — host-match guard rejects) |
| `$_SERVER['HTTPS']` missing, https:// baseurlpath, **same host** | false (THE BUG) | **true** (FIXED) |

Production deployments that already set `application.baseURL` as a workaround are unaffected — `getSelfURL()`'s external branch checks that first.

## Security considerations

The new fallback never reads any client-controlled header. The two inputs are:
- `baseurlpath` from `Configuration` (admin-set in `config.php`).
- `$_SERVER['HTTP_HOST']` via `getServerHost()` (already used by the library; `getServerHost()` strips any port and falls back to `SERVER_NAME` / `'localhost'`).

There is no widening of the trust surface; the change is strictly within the library's existing trust model.

## Reproducer

A self-contained Docker Compose reproducer is attached to the linked issue. Tear-down command included.
