### PR TITLE
syntax fix for Accept header

### DIFF
--- a/src/SimpleSAML/Metadata/Sources/MDQ.php
+++ b/src/SimpleSAML/Metadata/Sources/MDQ.php
@@ -300,7 +300,7 @@ class MDQ extends MetaDataStorageSource
 
         $httpUtils = new Utils\HTTP();
         $client = $httpUtils->createHttpClient([
-            'headers' => ['Accept', 'application/samlmetadata+xml'],
+            'headers' => ['Accept' => 'application/samlmetadata+xml'],
         ]);
 
         Logger::debug(sprintf('%s: downloading metadata for "%s" from [%s]', __CLASS__, $entityId, $mdq_url));


### PR DESCRIPTION
An invalid option syntax create two empty headers:
Accept:\r\n
application/samlmetadata+xml:\r\n

Instead of the expected:
Accept: application/samlmetadata+xml:\r\n

This makes strict MDQ servers reject the request.

