### PR TITLE
Expose available languages publicly

### DIFF
--- a/src/SimpleSAML/Locale/Language.php
+++ b/src/SimpleSAML/Locale/Language.php
@@ -144,16 +144,20 @@ class Language
      * Constructor
      *
      * @param \SimpleSAML\Configuration $configuration Configuration object
+     * @param bool $handleLanguageRequestParameter Whether to handle the language request parameter, if present
+     * (switch the current language and possibly set the language cookie). Can be disabled by consumers which
+     * only need to query the instance, like the available languages, without triggering side effects.
      */
     public function __construct(
         private Configuration $configuration,
+        bool $handleLanguageRequestParameter = true,
     ) {
         $this->availableLanguages = $this->getInstalledLanguages();
         $this->defaultLanguage = $configuration->getOptionalString('language.default', self::FALLBACKLANGUAGE);
         $this->languageParameterName = $configuration->getOptionalString('language.parameter.name', 'language');
         $this->customFunction = $configuration->getOptionalArray('language.get_language_function', null);
         $this->rtlLanguages = $configuration->getOptionalArray('language.rtl', []);
-        if (isset($_GET[$this->languageParameterName])) {
+        if ($handleLanguageRequestParameter && isset($_GET[$this->languageParameterName])) {
             $this->setLanguage(
                 $_GET[$this->languageParameterName],
                 $configuration->getOptionalBoolean('language.parameter.setcookie', true),
@@ -205,6 +209,19 @@ class Language
         }
 
         return $availableLanguages;
+    }
+
+
+    /**
+     * Return the languages that are both configured to be available (the `language.available` configuration
+     * option) and known to the translation system, i.e. the set of languages actually usable for the user
+     * interface.
+     *
+     * @return string[] The available languages.
+     */
+    public function getAvailableLanguages(): array
+    {
+        return $this->availableLanguages;
     }
 
 

--- a/tests/src/SimpleSAML/Locale/LanguageTest.php
+++ b/tests/src/SimpleSAML/Locale/LanguageTest.php
@@ -175,6 +175,56 @@ class LanguageTest extends TestCase
     }
 
 
+    /**
+     * Test SimpleSAML\Locale\Language::getAvailableLanguages().
+     */
+    public function testGetAvailableLanguages(): void
+    {
+        // test default
+        $c = Configuration::loadFromArray([], '', 'simplesaml');
+        $l = new Language($c);
+        $this->assertEquals(['en'], $l->getAvailableLanguages());
+
+        // test configured languages
+        $c = Configuration::loadFromArray([
+            'language.available' => ['en', 'nn', 'es'],
+        ], '', 'simplesaml');
+        $l = new Language($c);
+        $this->assertEquals(['en', 'nn', 'es'], $l->getAvailableLanguages());
+
+        // test that configured languages unknown to the translation system are excluded
+        $c = Configuration::loadFromArray([
+            'language.available' => ['en', 'foo'],
+        ], '', 'simplesaml');
+        $l = new Language($c);
+        $this->assertEquals(['en'], $l->getAvailableLanguages());
+    }
+
+
+    /**
+     * Test disabling the handling of the language request parameter (Language constructor).
+     */
+    public function testLanguageRequestParameterHandlingCanBeDisabled(): void
+    {
+        unset($_COOKIE['language']);
+        $c = Configuration::loadFromArray([
+            'language.available' => ['en', 'nn', 'es'],
+            'language.parameter.setcookie' => false,
+        ], '', 'simplesaml');
+        $_GET['language'] = 'es';
+
+        // by default, the language request parameter is handled
+        $l = new Language($c);
+        $this->assertEquals('es', $l->getLanguage());
+
+        // handling of the language request parameter can be disabled
+        $l = new Language($c, handleLanguageRequestParameter: false);
+        $this->assertEquals('en', $l->getLanguage());
+
+        unset($_GET['language']);
+    }
+
+
     public function testGetPreferredLanguages(): void
     {
         // test defaults


### PR DESCRIPTION
I'm implementing support for `ui_locales` paremeter for `oidc` module https://github.com/simplesamlphp/simplesamlphp-module-oidc/pull/350

I need to know langauages supported by SSP, and my initial thought was to rely on `language.available` confg option, but now I see there is additional handling in SSP method `\SimpleSAML\Locale\Language::getInstalledLanguages` which is used to populate `availableLanguages` property. So I propose to make a public getter for that property so this can be fetched by other consumers...

Also, in the constructor there is a step which checks for language request parameter in $_GET and, if set, uses it to set the language. I would propose a switch which can be used to turn this off, so when I call it from `oidc` I don't have this side effect. 

This all should be fully backward compatible.

I see there is a public method `\SimpleSAML\Locale\Language::getLanguageList`, but I would rather propose also adding getter for `availableLanguages`, if you don't mind. 