### PR TITLE
fix: header.twig: fix typo in LI HTML tag

### DIFF
--- a/templates/_header.twig
+++ b/templates/_header.twig
@@ -25,7 +25,7 @@
           <ul class="pure-menu-list">
           {% for key, lang in languageBar %}
             {% if key == currentLanguage %}
-            <li><a class="pure-menu-heading" href="#">{{ lang.name }}</a><li>
+            <li><a class="pure-menu-heading" href="#">{{ lang.name }}</a></li>
             {% else %}
             {% if lang.url %}
             <li class="pure-menu-item"><a href="{{ lang.url }}


### PR DESCRIPTION
Use a *closing* `</li>` tag.

Avoid rendering an extra empty item on the list (really visible only when stylesheets are not loaded)