### PR TITLE
Add Database::readPrimary() for reads that must bypass secondaries

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -9,6 +9,8 @@ See the [upgrade notes](https://simplesamlphp.org/docs/stable/simplesamlphp-upgr
 
 Released TBD
 
+* Added `SimpleSAML\Database::readPrimary()`, for reads that must not be served by a possibly lagging secondary
+
 ## Version 2.5.2
 
 Released 2026-06-01

--- a/docs/simplesamlphp-database.md
+++ b/docs/simplesamlphp-database.md
@@ -37,7 +37,7 @@ $table would be set to "sp_saml20_idp_hosted"
 
 ## Querying The Database
 
-You can query the database through two public functions read() and write() which are fairly self-explanitory when it comes to determining which one to use when querying.
+You can query the database through the public functions read(), readPrimary() and write() which are fairly self-explanitory when it comes to determining which one to use when querying.
 
 ### Writing to The Database
 
@@ -99,3 +99,28 @@ $values = [
 
 $query = $db->read("SELECT * FROM $table WHERE id = :id", $values);
 ```
+
+### Reading From The Primary
+
+Secondaries are replicas, and replication takes time. A read served by a secondary can therefore return data that is
+out of date with respect to the primary. When that is not acceptable, use readPrimary() instead of read(): it takes
+the same parameters and returns the same PDOStatement, but always queries the primary and never a secondary.
+
+```php
+$table = $db->applyPrefix("test");
+$values = [
+    'id' => [20, PDO::PARAM_INT],
+];
+
+$query = $db->readPrimary("SELECT * FROM $table WHERE id = :id", $values);
+```
+
+Reach for it when:
+
+* you read back data that was written earlier in the same request, and replication lag would make it look like the
+  write never happened;
+* the result drives a security-relevant decision, such as whether a credential or a token has been revoked. Serving
+  such a decision from a lagging secondary can keep something alive that has already been revoked on the primary.
+
+Everything else should keep using read(), so that the secondaries keep absorbing the read load they were configured
+for.

--- a/src/SimpleSAML/Database.php
+++ b/src/SimpleSAML/Database.php
@@ -292,6 +292,24 @@ class Database
 
 
     /**
+     * This executes read queries directly on the primary, bypassing any configured secondaries.
+     *
+     * Secondaries may lag behind the primary, so use this instead of this::read() whenever a stale result is not
+     * acceptable: when reading back data written earlier in the same request, or when the result drives a
+     * security-relevant decision, such as whether a credential has been revoked.
+     *
+     * @param string $stmt Prepared SQL statement
+     * @param array  $params Parameters
+     *
+     * @return \PDOStatement object
+     */
+    public function readPrimary(string $stmt, array $params = []): PDOStatement
+    {
+        return $this->query($this->dbPrimary, $stmt, $params);
+    }
+
+
+    /**
      * Return an array with information about the last operation performed in the database.
      *
      * @return array The array with error information.

--- a/tests/src/SimpleSAML/DatabaseTest.php
+++ b/tests/src/SimpleSAML/DatabaseTest.php
@@ -254,6 +254,96 @@ final class DatabaseTest extends TestCase
 
 
     /**
+     * Reads issued through readPrimary() must hit the primary, even when secondaries are configured.
+     */
+    public function testReadPrimary(): void
+    {
+        $config = [
+            'database.dsn'         => 'sqlite::memory:',
+            'database.username'    => null,
+            'database.password'    => null,
+            'database.prefix'      => 'phpunit_',
+            // Persistent connections are pooled per DSN, which would hand the primary and the secondary below
+            // the very same in-memory database and defeat the point of this test.
+            'database.persistent'  => false,
+            'database.secondaries' => [
+                [
+                    'dsn'      => 'sqlite::memory:',
+                    'username' => null,
+                    'password' => null,
+                ],
+            ],
+        ];
+
+        $sspConfiguration = new Configuration($config, "test/SimpleSAML/DatabaseTest.php");
+        $db = Database::getInstance($sspConfiguration);
+
+        $table = $db->applyPrefix("sspdbtprimary");
+        $db->write("DROP TABLE IF EXISTS $table");
+        $db->write("CREATE TABLE IF NOT EXISTS $table (ssp_key INT(16) NOT NULL, ssp_value TEXT NOT NULL)");
+
+        $ssp_key = time();
+        $ssp_value = md5(strval(rand(0, 10000)));
+        $db->write(
+            "INSERT INTO $table (ssp_key, ssp_value) VALUES (:ssp_key, :ssp_value)",
+            ['ssp_key' => [$ssp_key, PDO::PARAM_INT], 'ssp_value' => $ssp_value],
+        );
+
+        // The write went to the primary, so a primary read has to see it...
+        $query = $db->readPrimary("SELECT * FROM $table WHERE ssp_key = :ssp_key", ['ssp_key' => $ssp_key]);
+        $data = $query->fetch();
+        $this->assertEquals($ssp_value, $data['ssp_value'], "readPrimary did not query the primary database");
+        // Release the cursor, or sqlite will consider the table locked when we drop it below.
+        $query->closeCursor();
+
+        // ... while a regular read is served by the secondary, which never saw that table.
+        try {
+            $db->read("SELECT * FROM $table");
+            $this->fail("read should have been served by the secondary, which does not have table $table");
+        } catch (Exception $e) {
+            $this->assertStringContainsString('no such table', $e->getMessage());
+        }
+
+        $db->write("DROP TABLE IF EXISTS $table");
+    }
+
+
+    /**
+     * Without secondaries configured, readPrimary() behaves just like read().
+     */
+    public function testReadPrimaryWithoutSecondaries(): void
+    {
+        $table = $this->db->applyPrefix("sspdbt");
+        $this->db->write(
+            "CREATE TABLE IF NOT EXISTS $table (ssp_key INT(16) NOT NULL, ssp_value TEXT NOT NULL)",
+        );
+
+        $ssp_key = time();
+        $ssp_value = md5(strval(rand(0, 10000)));
+        $this->db->write(
+            "INSERT INTO $table (ssp_key, ssp_value) VALUES (:ssp_key, :ssp_value)",
+            ['ssp_key' => [$ssp_key, PDO::PARAM_INT], 'ssp_value' => $ssp_value],
+        );
+
+        $query = $this->db->readPrimary("SELECT * FROM $table WHERE ssp_key = :ssp_key", ['ssp_key' => $ssp_key]);
+        $data = $query->fetch();
+        $this->assertEquals($ssp_value, $data['ssp_value'], "Inserted data doesn't match what is in the database");
+    }
+
+
+    /**
+     */
+    public function testReadPrimaryFailure(): void
+    {
+        $this->expectException(Exception::class);
+        $table = $this->db->applyPrefix("sspdbt");
+        $this->assertEquals($this->config->getString('database.prefix') . "sspdbt", $table);
+
+        $this->db->readPrimary("SELECT * FROM $table");
+    }
+
+
+    /**
      */
     public function testReadFailure(): void
     {


### PR DESCRIPTION
Introduce DB method for reading from primary exclusively, for scenarios when replication lag is not acceptable. 