### PR TITLE
Fix multiauth not delegating when number of sources is 1 as intended

### DIFF
--- a/modules/multiauth/src/Auth/Source/MultiAuth.php
+++ b/modules/multiauth/src/Auth/Source/MultiAuth.php
@@ -125,7 +125,8 @@ class MultiAuth extends Auth\Source
                     'No authentication sources exist for the requested AuthnContextClassRefs: ' . implode(', ', $refs),
                 );
             } elseif ($number_of_sources === 1) {
-                MultiAuth::delegateAuthentication(array_key_first($new_sources), $state);
+                MultiAuth::delegateAuthentication(array_key_first($new_sources), $state)->sendContent();
+                assert(false);
             }
         }
 


### PR DESCRIPTION
In MultiAuth::authenticate, when there's a RequestedAuthnContext, resulting in only a single source being in the new_sources list, the intended behaviour is to authenticate with that source immediately.
But the following statement does nothing:
https://github.com/simplesamlphp/simplesamlphp/blob/095dce87a7373b4d0700bcd91531116d135b7566/modules/multiauth/src/Auth/Source/MultiAuth.php#L127-L129
That's because MultiAuth::delegateAuthentication used to authenticate but now just returns a RunnableResponse instead.

Since this function is not supposed to return, I called sendContent() on the RunnableResponse, I'm not sure this is the desired approach since sendContent() is not called anywhere else in this repository, but usually a RunnableResponse is returned which cannot be done here.