### PR TITLE
Fix typo in MetadataTest docblock

### DIFF
--- a/tests/modules/saml/src/Controller/MetadataTest.php
+++ b/tests/modules/saml/src/Controller/MetadataTest.php
@@ -269,7 +269,7 @@ class MetadataTest extends TestCase
 
 
     /**
-     * Test not specifying explict entityID falls back to a default
+     * Test not specifying explicit entityID falls back to a default
      */
     public function testMetadataDefaultIdPYieldsContent(): void
     {


### PR DESCRIPTION
Typo in a test docblock: `explict` -> `explicit`.

`tests/modules/saml/src/Controller/MetadataTest.php:272`. Comment only, no functional change.
