### PR TITLE
Feature: support for session.datastore.limit configuration setting

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -607,6 +607,15 @@ $config = [
     'session.datastore.timeout' => (4 * 60 * 60), // 4 hours
 
     /*
+     * The datastore within a session can contain an arbitrary number of login and logout requests, as well as
+     * error reports.  Historically, this is unlimited, which can result in very large sessions if a user agent makes
+     * repeated and frequent requests.
+     * Setting a limit here ensures older objects are discarded as new ones are added. A value of 25 is recommended as
+     * this should not cause any real inconvenience, but limits the maximum size of a session.
+     */
+    'session.datastore.limit' => 0, // no limit
+
+    /*
      * Sets the duration, in seconds, auth state should be stored.
      */
     'session.state.timeout' => (60 * 60), // 1 hour

--- a/src/SimpleSAML/Session.php
+++ b/src/SimpleSAML/Session.php
@@ -929,9 +929,30 @@ class Session implements Utils\ClearableState
 
         $this->dataStore[$type][$id] = $dataInfo;
 
+        $this->maintainDataStoreLimit($type);
+
         $this->markDirty();
     }
 
+    /**
+     * This ensures that the number of elements in a data store does not exceed configured limits
+     * and trims it until the limit is not exceeded, removing elements from the start of the array
+     */
+    private function maintainDataStoreLimit(string $type): void
+    {
+        $limit = self::$config->getOptionalInteger('session.datastore.limit', 0);
+        if ($limit <= 0) {
+            return;
+        }
+        if (!array_key_exists($type, $this->dataStore)) {
+           return;
+        }
+        $count = count($this->dataStore[$type]);
+        while ($count > $limit) {
+            array_shift($this->dataStore[$type]);
+            $count--;
+        }
+    }
 
     /**
      * This function removes expired data from the data store.

--- a/tests/src/SimpleSAML/SessionTest.php
+++ b/tests/src/SimpleSAML/SessionTest.php
@@ -134,4 +134,30 @@ class SessionTest extends ClearStateTestCase
             $this->assertNull($fetchedData);
         }
     }
+
+    public function testDataStoreLimit()
+    {
+        $session = Session::getSessionFromRequest();
+
+        //for this test, we set a datastore limit
+        $config = Configuration::loadFromArray(['session.datastore.limit' => 3], '[ARRAY]', 'simplesaml');
+        $session->setConfiguration($config);
+
+        //set 3 values for a data type testType
+        $session->setData('testType', 'testKey1', 'data1');
+        $session->setData('testType', 'testKey2', 'data2');
+        $session->setData('testType', 'testKey3', 'data3');
+
+        //we still expect the first value to be present...
+        $this->assertEquals('data1', $this->session->getData('testType', 'testKey1'));
+
+        //but if we add one more, it should get removed
+        $session->setData('testType', 'testKey4', 'data4');
+        $this->assertNull($this->session->getData('testType', 'testKey1'));
+
+        //verify the other expected values remain
+        $this->assertEquals('data2', $this->session->getData('testType', 'testKey2'));
+        $this->assertEquals('data3', $this->session->getData('testType', 'testKey3'));
+        $this->assertEquals('data4', $this->session->getData('testType', 'testKey4'));
+    }
 }


### PR DESCRIPTION
Implementation of https://github.com/simplesamlphp/simplesamlphp/issues/2665

Provides a new configuration setting `session.datastore.limit` which is assumed be zero by default for backwards compatibility. If set to a non zero positive integer, will ensure that no subkey of the session dataStore can contain more than that number of elements. A new elements are added, the earliest ones are removed.

This ensures that a session can not grow to become a denial of service by becoming too large. A level of 25 is suggested as a future default value.