### PR TITLE
Fix admin federation page calling a removed SAMLBuilder method for `adfs`

### DIFF
--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -7,6 +7,8 @@ See the [upgrade notes](https://simplesamlphp.org/docs/stable/simplesamlphp-upgr
 
 ## Version 2.5.4
 
+Released TBD
+
 * Fix admin federation page calling a removed SAMLBuilder method
 
 ## Version 2.5.3

--- a/docs/simplesamlphp-changelog.md
+++ b/docs/simplesamlphp-changelog.md
@@ -7,7 +7,7 @@ See the [upgrade notes](https://simplesamlphp.org/docs/stable/simplesamlphp-upgr
 
 ## Version 2.5.4
 
-Released TBD
+* Fix admin federation page calling a removed SAMLBuilder method
 
 ## Version 2.5.3
 

--- a/modules/admin/src/Controller/Federation.php
+++ b/modules/admin/src/Controller/Federation.php
@@ -18,6 +18,7 @@ use SimpleSAML\Metadata\SAMLParser;
 use SimpleSAML\Metadata\Signer;
 use SimpleSAML\Module;
 use SimpleSAML\Module\adfs\IdP\ADFS as ADFS_IdP;
+use SimpleSAML\Module\adfs\IdP\MetadataBuilder as ADFS_MetadataBuilder;
 use SimpleSAML\Module\admin\Event\FederationPageEvent;
 use SimpleSAML\Module\saml\IdP\SAML2 as SAML2_IdP;
 use SimpleSAML\Utils;
@@ -26,6 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\VarExporter\VarExporter;
+use Throwable;
 
 use function array_merge;
 use function array_pop;
@@ -294,23 +296,19 @@ class Federation
                         sprintf('The entityID cannot be longer than %d characters.', C::SAML2INT_ENTITYID_MAX_LENGTH),
                     );
 
-                    $builder = new SAMLBuilder($entity['entityid']);
-                    $builder->addSecurityTokenServiceType($entity['metadata_array']);
-                    $builder->addOrganizationInfo($entity['metadata_array']);
-                    if (isset($entity['metadata_array']['contacts'])) {
-                        foreach ($entity['metadata_array']['contacts'] as $contact) {
-                            $builder->addContact(Utils\Config\Metadata::getContact($contact));
-                        }
-                    }
+                    // The adfs module builds and signs its own WS-Federation metadata. This is the same
+                    // document that /module.php/adfs/idp/metadata serves.
+                    $idpmeta = $this->mdHandler->getMetaDataConfig($entity['metadata-index'], 'adfs-idp-hosted');
+                    $document = (new ADFS_MetadataBuilder($this->config, $idpmeta))->buildDocument()->toXML();
 
-                    $entity['metadata'] = Signer::sign(
-                        $builder->getEntityDescriptorText(),
-                        $entity['metadata_array'],
-                        'ADFS IdP',
-                    );
+                    // Serialize it exactly like the module's own endpoint does (no pretty-print)
+                    $document->ownerDocument->formatOutput = false;
+                    $document->ownerDocument->encoding = 'UTF-8';
+
+                    $entity['metadata'] = $document->ownerDocument->saveXML();
                     $entities[$index] = $entity;
                 }
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error('Federation: Error loading adfs-idp: ' . $e->getMessage());
             }
         }

--- a/tests/modules/admin/src/Controller/FederationTest.php
+++ b/tests/modules/admin/src/Controller/FederationTest.php
@@ -8,7 +8,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Auth;
 use SimpleSAML\Configuration;
+use SimpleSAML\Logger;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
+use SimpleSAML\Module;
 use SimpleSAML\Module\admin\Controller;
 use SimpleSAML\Module\saml\Auth\Source\SP;
 use SimpleSAML\Utils;
@@ -90,6 +92,20 @@ class FederationTest extends TestCase
             'authsources.php',
             'simplesaml',
         );
+    }
+
+
+    /**
+     * Clean up after each test.
+     */
+    protected function tearDown(): void
+    {
+        // Both are process-wide statics; leaving them set would leak into the other tests.
+        unset(Module::$module_info['adfs']);
+        Logger::setCaptureLog(false);
+        Logger::clearCapturedLog();
+
+        parent::tearDown();
     }
 
 
@@ -177,6 +193,83 @@ class FederationTest extends TestCase
         $response = $c->main($request);
 
         $this->assertTrue($response->isSuccessful());
+    }
+
+
+    /**
+     * A failure inside the ADFS block must degrade that one panel, not take down the whole page.
+     *
+     * The adfs module is not installed in this test-suite, so referencing one of its classes raises
+     * an \Error rather than an \Exception. That is the exact failure mode of issue #2458: an \Error
+     * escaping a `catch (Exception)` and turning a missing panel into an HTTP 500.
+     */
+    public function testMainSurvivesFailingAdfsModule(): void
+    {
+        // Report the adfs module as enabled even though it is not installed. Module::isModuleEnabled()
+        // consults this cache before it checks whether the module directory exists.
+        Module::$module_info['adfs'] = ['enabled' => true];
+
+        $request = Request::create(
+            '/federation',
+            'GET',
+        );
+
+        $mdh = new class () extends MetaDataStorageHandler {
+            public function __construct()
+            {
+            }
+
+
+            public function getList(string $set = 'saml20-idp-remote', bool $showExpired = false): array
+            {
+                if ($set === 'adfs-idp-hosted') {
+                    // More than one entry, so that the ADFS block reaches the adfs module directly.
+                    return [
+                        'urn:x-simplesamlphp:example-adfs-idp' => [
+                            'entityid' => 'urn:x-simplesamlphp:example-adfs-idp',
+                        ],
+                        'urn:x-simplesamlphp:other-adfs-idp' => [
+                            'entityid' => 'urn:x-simplesamlphp:other-adfs-idp',
+                        ],
+                    ];
+                }
+                return [];
+            }
+        };
+
+        $authSource = new class () extends Auth\Source {
+            public function __construct()
+            {
+                // stub
+            }
+
+
+            public function authenticate(array &$state): void
+            {
+                // stub
+            }
+
+
+            public static function getSourcesOfType(string $type): array
+            {
+                return [];
+            }
+        };
+
+        $c = new Controller\Federation($this->config);
+        $c->setAuthUtils($this->authUtils);
+        $c->setAuthSource($authSource);
+        $c->setMetadataStorageHandler($mdh);
+
+        Logger::setCaptureLog();
+        $response = $c->main($request);
+        Logger::setCaptureLog(false);
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNotEmpty(
+            preg_grep('/Federation: Error loading adfs-idp/', Logger::getCapturedLog()),
+            'The ADFS failure should have been logged.',
+        );
     }
 
 

--- a/tools/composer-require-checker.json
+++ b/tools/composer-require-checker.json
@@ -8,6 +8,7 @@
     "posix_getuid",
     "Predis\\Client",
     "SimpleSAML\\Module\\adfs\\IdP\\ADFS",
+    "SimpleSAML\\Module\\adfs\\IdP\\MetadataBuilder",
     "SimpleSAML\\TestUtils\\ArrayLogger"
   ]
 }


### PR DESCRIPTION
This delegates metadata generation to the adfs module, which already builds and signs this document for its own endpoint. Also, widen the catch to Throwable so an \Error can be caught too.