### PR TITLE
Include _head.twig from post as well as base

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{ asset("css/stylesheet.css") }}">
     <link rel="icon" href="{{ asset("icons/favicon.ico") }}">
     <meta name="robots" content="noindex, nofollow">
-    {{ include('_head.twig', ignore_missing = true) }}
+    {{ include('_head.twig', {includedFrom: 'base'}, ignore_missing = true) }}
     {% block preload %}{% endblock %}
   </head>
   <body id="{{ templateId }}">

--- a/templates/post.twig
+++ b/templates/post.twig
@@ -8,6 +8,7 @@
     <link rel="icon" href="{{ asset("icons/favicon.ico") }}">
     <title>{% trans %}Sending message{% endtrans %}</title>
     <link rel="stylesheet" href="{{ asset("css/postSubmit.css") }}">
+    {{ include('_head.twig', {includedFrom: 'post'}, ignore_missing = true) }}
     {% block preload %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
The `_head.twig` file introduced in 2.0 by commit 28cf796 provides a really convenient and straightforward way to introduce new elements into the <head> without altering the templates or overriding them in a theme.

Coupled with the proposed change to the CSS in simplesamlphp/simplesamlphp-assets-base#108, this also allows for a poor-man's theming option where colours can be overridden by simply adding some styling in `_head.twig`.

Unfortunately, while it is included by `base.twig`, it is not currently included by `post.twig`. That means it's not possible to apply this to the loader throbber introduced by 2.5 by #2516. While that might seem like a small issue, depending on the colour change, the current loader's default red can seem quite stark.

This change means `_head.twig` applies to both base HTML templates.

It introduces an additional context variable `includedFrom` so that people making changes in `_head.twig` can determine where it is being used. A grep of the source suggests I'm not changing or overloading an existing twig variable by doing this, so it's a more-or-less backwards compatible change. The only risk is that someone has an existing `_head.twig` that introduces extraneous elements into `post.twig` (but they can fix that by adding a context check against `includedFrom`).