### PR TITLE
Fix file config for `MetaDataStorageHandlerXML`

### DIFF
--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
@@ -44,6 +44,7 @@ class MetaDataStorageHandlerXML extends MetaDataStorageSource
             // get the configuration
             $globalConfig = Configuration::getInstance();
             $src = $globalConfig->resolvePath($config['file']);
+            $srcXml = file_get_contents($src);
         } elseif (array_key_exists('url', $config)) {
             $src = $config['url'];
             if (array_key_exists('context', $config)) {
@@ -72,7 +73,7 @@ class MetaDataStorageHandlerXML extends MetaDataStorageSource
 
         // To prevent "type errors", check if we have a string to pass to SAMLParser at all.
         if (!is_string($srcXml)) {
-            throw new Exception('Could not extract XML from metadata source.');
+            throw new \Exception('Could not extract XML from metadata source.');
         }
 
         $entities = SAMLParser::parseDescriptorsString($srcXml);

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
@@ -74,7 +74,7 @@ class MetaDataStorageHandlerXML extends MetaDataStorageSource
 
         // To prevent "type errors", check if we have a string to pass to SAMLParser at all.
         if (!is_string($srcXml)) {
-            throw new \Exception('Could not extract XML from metadata source.');
+            throw new Exception('Could not extract XML from metadata source.');
         }
 
         $entities = SAMLParser::parseDescriptorsString($srcXml);

--- a/src/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
+++ b/src/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Metadata;
 
+use Exception;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Configuration;
 use SimpleSAML\Utils;
@@ -63,7 +64,7 @@ class MetaDataStorageHandlerXML extends MetaDataStorageSource
         } elseif (array_key_exists('xml', $config)) {
             $srcXml = $config['xml'];
         } else {
-            throw new \Exception("Missing one of 'file', 'url' and 'xml' in XML metadata source configuration.");
+            throw new Exception("Missing one of 'file', 'url' and 'xml' in XML metadata source configuration.");
         }
 
 


### PR DESCRIPTION
With commit https://github.com/simplesamlphp/simplesamlphp/commit/ec3fb13a63c9518930a53c3548a3a86d1b091723 `metadata.sources` crashes with `[['type' => 'xml', 'file' => '/foo/bar.xml']]` (the code previously checked for `$srcXml` _and_ `$src`).

In >= `v2.5` it works correctly. I'm guessing this is due to some refactoring + cherry-picking issues.

I added the same line as it is implemented in `master`: https://github.com/simplesamlphp/simplesamlphp/blob/master/src/SimpleSAML/Metadata/MetaDataStorageHandlerXML.php#L49

I also added the missing namespace for the Exception case (also not applicable for >= `2.5`).